### PR TITLE
Handle 410 Gone responses

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -131,7 +131,15 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
     }
 
     public _handleDelete(instance : AdhResourceWidgets.IResourceWidgetInstance<R, ICommentResourceScope>, path : string) {
-        return this.$q.when();
+        // FIXME: use resource abstractions here
+        return this.adhHttp.put(path, {
+            content_type: "adhocracy_core.resources.comment.IComment",
+            data: {
+                "adhocracy_core.sheets.metadata.IMetadata": {
+                    hidden: true
+                }
+            }
+        });
     }
 
     public _update(

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -71,7 +71,7 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
         private adapter : ICommentAdapter<R>,
         adhConfig : AdhConfig.IService,
         adhHttp : AdhHttp.Service<any>,
-        public adhPermissions : AdhPermissions.Service,
+        protected adhPermissions : AdhPermissions.Service,
         adhPreliminaryNames : AdhPreliminaryNames.Service,
         $q : ng.IQService
     ) {
@@ -195,7 +195,7 @@ export class CommentCreate<R extends ResourcesBase.Resource> extends CommentReso
         adapter : ICommentAdapter<R>,
         adhConfig : AdhConfig.IService,
         adhHttp : AdhHttp.Service<any>,
-        public adhPermissions : AdhPermissions.Service,
+        adhPermissions : AdhPermissions.Service,
         adhPreliminaryNames : AdhPreliminaryNames.Service,
         $q : ng.IQService
     ) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -23,6 +23,7 @@
                     <!-- #FIXME: Dummy -->
                     <a href="#"><i class="icon-ban-circle"></i>
                         {{ "Report" | translate }}</a>
+                    <a href="#" data-ng-click="delete()">{{ "Delete" | translate }}</a>
                 </span>
                 <adh-rate data-refers-to="{{data.path}}"
                           data-post-pool-sheet="adhocracy.sheets.rate.IRateable"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
@@ -59,7 +59,7 @@ export var register = () => {
                 adhPermissionsMock = jasmine.createSpyObj("adhPermissions", ["bindScope"]);
                 adhPathFilterMock = jasmine.createSpy("adhPathFilter").and.callFake((p) => q.when(p));
                 widget = new AdhComment.CommentResource(
-                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, adhPreliminaryNamesMock, <any>q);
+                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, adhPathFilterMock, <any>q);
 
                 wrapperMock = {
                     eventHandler: jasmine.createSpyObj("eventHandler", ["on", "off", "trigger"])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
@@ -52,12 +52,14 @@ export var register = () => {
             var instanceMock;
             var adhPermissionsMock;
             var adhPreliminaryNamesMock;
+            var adhPathFilterMock;
 
             beforeEach(() => {
                 adhPreliminaryNamesMock = jasmine.createSpyObj("adhPreliminaryNames", ["isPreliminary", "nextPreliminary"]);
                 adhPermissionsMock = jasmine.createSpyObj("adhPermissions", ["bindScope"]);
+                adhPathFilterMock = jasmine.createSpy("adhPathFilter").and.callFake((p) => q.when(p));
                 widget = new AdhComment.CommentResource(
-                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, <any>q);
+                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, adhPreliminaryNamesMock, <any>q);
 
                 wrapperMock = {
                     eventHandler: jasmine.createSpyObj("eventHandler", ["on", "off", "trigger"])
@@ -259,7 +261,7 @@ export var register = () => {
                 var adhPreliminaryNamesMock = jasmine.createSpyObj("adhPreliminaryNames", ["isPreliminary", "nextPreliminary"]);
                 var adhPermissionsMock = jasmine.createSpyObj("adhPermissions", ["bindScope"]);
                 widget = new AdhComment.CommentCreate(
-                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, <any>q);
+                    adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, null, <any>q);
             });
 
             it("sets 'templateUrl' on construction", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
@@ -23,6 +23,10 @@ var renderBackendError = (response : ng.IHttpPromiseCallbackArg<any>) : void => 
         }
     };
 
+    if (response.status === 410) {
+        return;
+    }
+
     console.log("http response with error status: " + response.status);
     console.log("request (.config):", sanitize(response.config));
     if (typeof <any>response.headers !== "undefined") {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -391,6 +391,17 @@ export class Service<Content extends ResourcesBase.Resource> {
 }
 
 
+/**
+ * Filter out all paths that can not successfully be fetched.
+ */
+export var pathFilterService = ($q : ng.IQService, adhHttp : Service<any>) => {
+    return (paths : string[]) : ng.IPromise<string[]> => {
+        return AdhUtil.qFilter(paths.map((path) => adhHttp.get(path)), $q)
+            .then((resources) => resources.map((r) => r.path));
+    };
+};
+
+
 export var moduleName = "adhHttp";
 
 export var register = (angular, metaApi) => {
@@ -398,6 +409,7 @@ export var register = (angular, metaApi) => {
         .module(moduleName, [
             AdhPreliminaryNames.moduleName
         ])
+        .service("adhPathFilter", ["$q", "adhHttp", pathFilterService])
         .service("adhHttp", ["$http", "$q", "$timeout", "adhMetaApi", "adhPreliminaryNames", "adhConfig", Service])
         .factory("adhMetaApi", () => new AdhMetaApi.MetaApiQuery(metaApi))
         .filter("adhFormatError", () => AdhError.formatError);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -116,8 +116,8 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 });
             },
             controller: ["$scope", "adhHttp", "adhPreliminaryNames", "adhPermissions", (
-                $scope: ListingScope<Container>,
-                adhHttp: AdhHttp.Service<Container>,
+                $scope : ListingScope<Container>,
+                adhHttp : AdhHttp.Service<Container>,
                 adhPreliminaryNames : AdhPreliminaryNames.Service,
                 adhPermissions : AdhPermissions.Service
             ) : void => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -125,7 +125,7 @@ export var register = () => {
                         };
 
                         var controller = directive.controller[5];
-                        controller(scope, adhHttpMock, adhPreliminaryNamesMock, adhPermissionsMock);
+                        controller(scope, adhHttpMock, adhPreliminaryNamesMock, adhPermissionsMock, adhPathFilterMock);
                     });
 
                     it("watches scope.path", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -105,6 +105,7 @@ export var register = () => {
                     var adhHttpMock;
                     var adhPreliminaryNamesMock;
                     var adhPermissionsMock;
+                    var adhPathFilterMock;
                     var scope;
 
                     beforeEach(() => {
@@ -113,6 +114,7 @@ export var register = () => {
                         adhPreliminaryNamesMock = jasmine.createSpyObj("adhPreliminaryNames", ["isPreliminary", "nextPreliminary"]);
                         adhPermissionsMock = jasmine.createSpyObj("adhPermissionsMock", ["bindScope"]);
                         adhPermissionsMock.bindScope.and.returnValue(q.when());
+                        adhPathFilterMock = jasmine.createSpy("adhPathFilterMock").and.callFake((a) => q.when(a));
 
                         scope = {
                             // arbitrary values
@@ -122,7 +124,7 @@ export var register = () => {
                             $watch: jasmine.createSpy("$watch")
                         };
 
-                        var controller = directive.controller[4];
+                        var controller = directive.controller[5];
                         controller(scope, adhHttpMock, adhPreliminaryNamesMock, adhPermissionsMock);
                     });
 
@@ -168,7 +170,7 @@ export var register = () => {
 
                         it("updates scope.elements using adapter from container", () => {
                             expect(adapter.elemRefs).toHaveBeenCalledWith(container);
-                            expect(scope.elements).toBe(elements);
+                            expect(scope.elements.length).toBe(elements.length);
                         });
                     });
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
@@ -278,8 +278,7 @@ export class ResourceWidget<R extends ResourcesBase.Resource, S extends IResourc
             }
         });
 
-        var clearID = wrapper.eventHandler.on("clear", () =>
-            self.clear(instance));
+        var clearID = wrapper.eventHandler.on("clear", () => self.clear(instance));
 
         scope.$on("triggerDelete", (ev, path : string) => self._handleDelete(instance, path));
         scope.$on("$delete", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
@@ -160,3 +160,39 @@ export function endsWith(str, suffix) {
 
     return str.indexOf(suffix, str.length - suffix.length) !== -1;
 }
+
+
+/**
+ * Very much like $q.all().
+ *
+ * The only real difference is that it skips rejected promises instead of rejecting the whole result.
+ */
+export var qFilter = (promises : ng.IPromise<any>[], $q : ng.IQService) : ng.IPromise<any[]> => {
+    // unique marker
+    var empty = new Object();
+
+    var count = promises.length;
+    var results = [];
+
+    var deferred = $q.defer();
+
+    if (count === 0) {
+        deferred.resolve(results);
+    } else {
+        _.forEach(promises, (promise : ng.IPromise<any>, i : number) => {
+            results.push(empty);
+
+            promise
+                .then((result) => results[i] = result)
+                .finally(() => {
+                    count -= 1;
+                    if (count === 0) {
+                        results = results.filter((e) => e !== empty);
+                        deferred.resolve(results);
+                    }
+                });
+        });
+    }
+
+    return deferred.promise;
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
@@ -2,6 +2,8 @@
 
 import JasmineHelpers = require("../../JasmineHelpers");
 
+import q = require("q");
+
 import AdhUtil = require("./Util");
 
 export var register = () => {
@@ -186,6 +188,32 @@ export var register = () => {
                 };
 
                 expect(() => AdhUtil.sortDagTopologically(dag, ["A"])).toThrow();
+            });
+        });
+
+        describe("qFilter", () => {
+            it("works mostly like $q.all", (done) => {
+                AdhUtil.qFilter([q.when("a"), q.when("b"), q.when("c")], q)
+                    .then((result) => {
+                        expect(result).toEqual(["a", "b", "c"]);
+                        done();
+                    });
+            });
+
+            it("filters out any rejected promises", (done) => {
+                AdhUtil.qFilter([q.when("a"), q.reject("b"), q.when("c")], q)
+                    .then((result) => {
+                        expect(result).toEqual(["a", "c"]);
+                        done();
+                    });
+            });
+
+            it("promises empty list if empty list was passed", (done) => {
+                AdhUtil.qFilter([], q)
+                    .then((result) => {
+                        expect(result).toEqual([]);
+                        done();
+                    });
             });
         });
     });


### PR DESCRIPTION
When we start to hide (delete) resources, we might get `410 Gone` responses. This happened for me when deleting comments.

In this pull request, I add UI for hiding comments as well as code that takes care of ignoring unavailable resources in listings and comment trees.

Notes:

-  the comment-hide UI is not finished. I only included it here to simplify testing.
-  the backend might get better at removing hidden resources from results automatically. But there may always be cases where the backend just can not do that.
-  there may be several unexpected issues with hidden resources. For example, I found #549 
-  the filter makes a get request on every single resource in the list. This is currently very expensive and will be very cheap once we have a cache.

While this is still very unfinished, it think there is enough valuable code in here to justify a pull request.