### PR TITLE
Lock rate button during post

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -377,12 +377,11 @@ export var rateController = (
                         fetchAggregatedRates($scope, adhHttp, $scope.postPoolPath, $scope.refersTo)
                     ]);
                 })
-                .then(() => {
-                    $scope.locked = false;
-                }, () => {
+                .catch(() => {
                     console.log("Rate.postUpdate failed. Refetching.");
                     fetchMyRate($scope, adhHttp, $scope.postPoolPath, $scope.refersTo, adhUser.userPath);
                     fetchAggregatedRates($scope, adhHttp, $scope.postPoolPath, $scope.refersTo);
+                }).finally<void>(() => {
                     $scope.locked = false;
                 });
         }


### PR DESCRIPTION
This avoids errors on "double-click". Also, post errors should show error message and trigger a reload of the current rates.