### PR TITLE
Fix: 'hasattr' might swallow exceptions

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -35,9 +35,11 @@ class TokenMangerAnnotationStorage:
 
     @property
     def token_to_user_id_timestamp(self):
-        if not hasattr(self.context, self.annotation_key):
-            setattr(self.context, self.annotation_key, PersistentDict())
-        return getattr(self.context, self.annotation_key)
+        tokens = getattr(self.context, self.annotation_key, None)
+        if tokens is None:
+            tokens = PersistentDict()
+            setattr(self.context, self.annotation_key, tokens)
+        return tokens
 
     def create_token(self, userid: str, secret='', hashalg='sha512') -> str:
         """Create authentication token for user_id.

--- a/src/adhocracy_core/adhocracy_core/graph/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/graph/__init__.py
@@ -174,9 +174,9 @@ class Graph(Persistent):
             if targets is None:
                 continue
             node = schema[field_name]
-            if not hasattr(node, 'reftype'):
+            reftype = getattr(node, 'reftype', None)
+            if reftype is None:
                 continue
-            reftype = schema[field_name].reftype
             if IResource.providedBy(targets):
                 targets = [targets]
             self.set_references(source, targets, reftype, registry)

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -88,11 +88,15 @@ class GenericResourceSheet(PropertySheet):
 
     @property
     def _data(self):
-        if not hasattr(self.context, '_sheets'):
-            self.context._sheets = PersistentMapping()
-        if self._data_key not in self.context._sheets:
-            self.context._sheets[self._data_key] = PersistentMapping()
-        return self.context._sheets[self._data_key]
+        sheets_data = getattr(self.context, '_sheets', None)
+        if sheets_data is None:
+            sheets_data = PersistentMapping()
+            setattr(self.context, '_sheets', sheets_data)
+        data = sheets_data.get(self._data_key, None)
+        if data is None:
+            data = PersistentMapping()
+            sheets_data[self._data_key] = data
+        return data
 
     def _get_reference_appstruct(self, params: dict={}) -> iter:
         references = self._get_references()

--- a/src/adhocracy_core/adhocracy_core/sheets/principal.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/principal.py
@@ -240,15 +240,16 @@ class PasswordAuthenticationSheet(GenericResourceSheet):
         password = appstruct.get('password', '')
         if not password:
             return
-        if not hasattr(self.context, 'password'):
-            self.context.password = ''
-        if not hasattr(self.context, 'pwd_manager'):
-            self.context.pwd_manager = BCRYPTPasswordManager()
-        self.context.password = self.context.pwd_manager.encode(password)
+        manager = getattr(self.context, 'pwd_manager', None)
+        if manager is None:
+            manager = BCRYPTPasswordManager()
+            self.context.pwd_manager = manager
+        password_encoded = self.context.pwd_manager.encode(password)
+        self.context.password = password_encoded
 
     def _get_data_appstruct(self, params: dict={}):
-        password = getattr(self.context, 'password', '')
-        return {'password': password}
+        password_encoded = getattr(self.context, 'password', '')
+        return {'password': password_encoded}
 
     def check_plaintext_password(self, password: str) -> bool:
         """ Check if `password` matches the stored encrypted password.

--- a/src/adhocracy_core/adhocracy_core/websockets/server.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/server.py
@@ -171,10 +171,10 @@ class ClientCommunicator(WebSocketServerProtocol):
                 connection.sync()
 
     def _get_zodb_connection(self) -> Connection:
-        if not hasattr(self, '_zodb_connection'):
+        connection = getattr(self, '_zodb_connection', None)
+        if connection is None:
             connection = self.zodb_database.open()
             self._zodb_connection = connection
-        connection = self._zodb_connection
         connection.sync()
         return connection
 


### PR DESCRIPTION
Python build in hasattr might hide Attribute and zodb exceptions:

http://stackoverflow.com/questions/24971061/python-hasattr-vs-getattr
https://dev.plone.org/ticket/3285
http://mail.dzug.org/mailman/archives/zope/2006-October/002010.html

To be on the safe side we should just not use it.