### PR TITLE
2015 02 cs email verification optional

### DIFF
--- a/etc/development.ini
+++ b/etc/development.ini
@@ -31,6 +31,8 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,
 # {} is the user-supplied title)
 adhocracy.message_user_subject = Adhocracy Info: {}
+# If true, new user accounts are activated immediately without email verification
+adhocracy.skip_registration_mail = false
 
 # Name of the entire site. Used in account registration information etc.
 adhocracy.site_name = Adhocracy Test Site

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -5,6 +5,7 @@ from os import urandom
 from smtplib import SMTPException
 
 from pyramid.registry import Registry
+from pyramid.settings import asbool
 from pyramid.traversal import find_resource
 from pyramid.request import Request
 from substanced.util import find_service
@@ -123,7 +124,17 @@ class User(Pool):
 def send_registration_mail(context: IUser,
                            registry: Registry,
                            options: dict={}):
-    """Send a registration mail to validate the email of a user account."""
+    """
+    Send a registration mail to validate the email of a user account.
+
+    But if the "adhocracy.skip_registration_mail" parameter is true, no mail
+    is sent and the account is instead activated immediately. This can be
+    useful for testing.
+    """
+    if asbool(registry.settings.get('adhocracy.skip_registration_mail',
+                                    'false')):
+        context.activate()
+        return
     # FIXME subject should be configurable
     name = context.name
     email = context.email

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -408,18 +408,14 @@ class TestGroupsAndRolesFinder:
 class TestIntegrationSendRegistrationMail:
 
     @fixture
-    def integration(self, config):
-        config.include('pyramid_mailer.testing')
-        config.include('pyramid_mako')
-        config.include('adhocracy_core.registry')
-        config.include('adhocracy_core.messaging')
-
-    @fixture
     def sample_user(self):
+        from zope.interface import directlyProvides
         from adhocracy_core.resources.principal import User
+        from adhocracy_core.sheets.metadata import IMetadata
         user = User()
         user.name = 'Anna Müller'
         user.email = 'anna@example.org'
+        directlyProvides(user, IMetadata)
         return user
 
     @mark.usefixtures('integration')
@@ -451,3 +447,11 @@ class TestIntegrationSendRegistrationMail:
             send_registration_mail(context=sample_user, registry=registry)
         assert 'Cannot send' in err_info.exconly()
         assert 'bad luck' in err_info.exconly()
+
+    @mark.usefixtures('integration')
+    def test_send_registration_mail_skip(self, registry, sample_user):
+        from adhocracy_core.resources.principal import send_registration_mail
+        registry.settings['adhocracy.skip_registration_mail'] = 'true'
+        send_registration_mail(context=sample_user, registry=registry)
+        assert sample_user.active is True
+        assert sample_user.activation_path is None

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -42,6 +42,8 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,
 # {} is the user-supplied title)
 adhocracy.message_user_subject = Adhocracy Info: {}
+# If true, new user accounts are activated immediately without email verification
+adhocracy.skip_registration_mail = false
 # Mode to set http cache headers for resources, valid entries: no-cache, without-proxy-cache, with-proxy-cache
 adhocracy_core.caching.http.mode = no-cache
 


### PR DESCRIPTION
Fixes #528. There is now a "adhocracy.skip_registration_mail" parameter that can be set to "true" to allow registering users without email verification.