### PR TITLE
Make alert messages translateable

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
@@ -38,5 +38,7 @@
     "username": "Nutzername",
     "Shorter than minimum length 6": "Kürzer als minimale Länge 6",
     "User doesn't exist or password is wrong": "Nutzer*in existiert nicht oder Passwort ist falsch",
-    "CALL_FOR_ACTIVATION": "Nachdem Sie auf den Aktivierungslink geklickt haben, können Sie {{siteName}} verwenden."
+    "CALL_FOR_ACTIVATION": "Nachdem Sie auf den Aktivierungslink geklickt haben, können Sie {{siteName}} verwenden.",
+    "TR__MESSAGE_STATUS_OK": "Nachricht wurde versendet",
+    "TR__REPORT_ABUSE_STATUS_OK": "Die Moderator*innen wurden benachrichtigt"
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
@@ -40,5 +40,7 @@
   "title": "title",
   "username": "username",
   "CALL_FOR_ACTIVATION": "Once you have clicked on the activation link you can procede using {{siteName}}",
-  "USERS_PROPOSALS": "{{name}}'s proposals"
+  "USERS_PROPOSALS": "{{name}}'s proposals",
+  "TR__MESSAGE_STATUS_OK": "Message was sent",
+  "TR__REPORT_ABUSE_STATUS_OK": "The moderators have been notified"
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
@@ -20,7 +20,7 @@ export var reportAbuseDirective = (adhHttp : AdhHttp.Service<any>, adhConfig : A
                     remark: scope.remark
                 }).then(() => {
                     column.hideOverlay("abuse");
-                    column.alert("The moderators have been notified", "success");
+                    column.alert("TR__REPORT_ABUSE_STATUS_OK", "success");
                 }, () => {
                     // FIXME
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
@@ -28,7 +28,7 @@
     </div>
     <ul class="moving-column-alerts">
         <li data-ng-repeat="(id, alert) in _alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="ctrl.removeAlert(id)">
-            {{ alert.message }}
+            {{ alert.message | translate }}
         </li>
     </ul>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -315,7 +315,7 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
                     text: scope.message.text
                 }).then(() => {
                     column.hideOverlay();
-                    column.alert("Message was send", "success");
+                    column.alert("TR__MESSAGE_STATUS_OK", "success");
                 }, () => {
                     // FIXME
                 });


### PR DESCRIPTION
Introduce technical strings with a `TR__` prefix in order to be able to extract them automatically. Extraction isn't done in that PR though.