### PR TITLE
Close overlays on navigation

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -119,12 +119,22 @@ export var movingColumns = (
                 }, 1);
             };
 
+            var triggerClearEvents = (newCls : string, oldCls : string) : void => {
+                var columns = element.find(".moving-column");
+                for (var i = 0; i < columns.length; i++) {
+                    if (newCls.split("-")[i + 1] === "hide" && oldCls.split("-")[i + 1] !== "hide") {
+                        columns.eq(i).trigger("adhMovingColumn.clear");
+                    }
+                }
+            };
+
             $($window).resize(resizeNoTransition);
 
             var move = (newCls) => {
                 if (newCls !== cls) {
                     element.removeClass(cls);
                     element.addClass(newCls);
+                    triggerClearEvents(newCls, cls);
                     cls = newCls;
                     resize();
                 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -263,6 +263,18 @@ export var movingColumnDirective = (adhConfig : AdhConfig.IService) => {
 };
 
 
+export var clearMovingColumnDirective = () => {
+    return {
+        restrict: "A",
+        link: (scope, element) => {
+            element.click(() => {
+                scope.$emit("adhMovingColumn.clear");
+            });
+        }
+    };
+};
+
+
 export var moduleName = "adhMovingColumns";
 
 export var register = (angular) => {
@@ -271,6 +283,7 @@ export var register = (angular) => {
             AdhTopLevelState.moduleName,
             AdhShareSocial.moduleName
         ])
+        .directive("adhClearMovingColumn", clearMovingColumnDirective)
         .directive("adhMovingColumn", ["adhConfig", movingColumnDirective])
         .directive("adhMovingColumns", ["adhTopLevelState", "$timeout", "$window", movingColumns]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -132,17 +132,17 @@ export var movingColumns = (
 
             var move = (newCls) => {
                 if (newCls !== cls) {
+                    if (typeof cls !== "undefined" && typeof newCls !== "undefined") {
+                        triggerClearEvents(newCls, cls);
+                    }
                     if (typeof cls !== "undefined") {
                         element.removeClass(cls);
                     }
                     if (typeof newCls !== "undefined") {
                         element.addClass(newCls);
+                        cls = newCls;
+                        resize();
                     }
-                    if (typeof cls !== "undefined" && typeof newCls !== "undefined") {
-                        triggerClearEvents(newCls, cls);
-                    }
-                    cls = newCls;
-                    resize();
                 }
             };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -176,11 +176,12 @@ export interface IMovingColumnScope extends ng.IScope {
 export class MovingColumnController {
     private lastId : number;
 
-    constructor(protected $timeout : ng.ITimeoutService, public $scope : IMovingColumnScope) {
+    constructor(protected $timeout : ng.ITimeoutService, public $scope : IMovingColumnScope, private $element) {
         $scope.ctrl = this;
         $scope._alerts = {};
         $scope.shared = {};
 
+        $element.on("adhMovingColumn.clear", () => this.clear());
         $scope.$on("adhMovingColumn.clear", () => this.clear());
 
         this.lastId = 0;
@@ -247,7 +248,7 @@ export var movingColumnDirective = (adhConfig : AdhConfig.IService) => {
         scope: true,
         transclude: true,
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MovingColumn.html",
-        controller: ["$timeout", "$scope", MovingColumnController]
+        controller: ["$timeout", "$scope", "$element", MovingColumnController]
     };
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -132,9 +132,15 @@ export var movingColumns = (
 
             var move = (newCls) => {
                 if (newCls !== cls) {
-                    element.removeClass(cls);
-                    element.addClass(newCls);
-                    triggerClearEvents(newCls, cls);
+                    if (typeof cls !== "undefined") {
+                        element.removeClass(cls);
+                    }
+                    if (typeof newCls !== "undefined") {
+                        element.addClass(newCls);
+                    }
+                    if (typeof cls !== "undefined" && typeof newCls !== "undefined") {
+                        triggerClearEvents(newCls, cls);
+                    }
                     cls = newCls;
                     resize();
                 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -181,6 +181,8 @@ export class MovingColumnController {
         $scope._alerts = {};
         $scope.shared = {};
 
+        $scope.$on("adhMovingColumn.clear", () => this.clear());
+
         this.lastId = 0;
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -119,30 +119,14 @@ export var movingColumns = (
                 }, 1);
             };
 
-            var triggerClearEvents = (newCls : string, oldCls : string) : void => {
-                var columns = element.find(".moving-column");
-                for (var i = 0; i < columns.length; i++) {
-                    if (newCls.split("-")[i + 1] === "hide" && oldCls.split("-")[i + 1] !== "hide") {
-                        columns.eq(i).trigger("adhMovingColumn.clear");
-                    }
-                }
-            };
-
             $($window).resize(resizeNoTransition);
 
             var move = (newCls) => {
                 if (newCls !== cls) {
-                    if (typeof cls !== "undefined" && typeof newCls !== "undefined") {
-                        triggerClearEvents(newCls, cls);
-                    }
-                    if (typeof cls !== "undefined") {
-                        element.removeClass(cls);
-                    }
-                    if (typeof newCls !== "undefined") {
-                        element.addClass(newCls);
-                        cls = newCls;
-                        resize();
-                    }
+                    element.removeClass(cls);
+                    element.addClass(newCls);
+                    cls = newCls;
+                    resize();
                 }
             };
 
@@ -192,13 +176,10 @@ export interface IMovingColumnScope extends ng.IScope {
 export class MovingColumnController {
     private lastId : number;
 
-    constructor(protected $timeout : ng.ITimeoutService, public $scope : IMovingColumnScope, private $element) {
+    constructor(protected $timeout : ng.ITimeoutService, public $scope : IMovingColumnScope) {
         $scope.ctrl = this;
         $scope._alerts = {};
         $scope.shared = {};
-
-        $element.on("adhMovingColumn.clear", () => this.clear());
-        $scope.$on("adhMovingColumn.clear", () => this.clear());
 
         this.lastId = 0;
     }
@@ -264,19 +245,7 @@ export var movingColumnDirective = (adhConfig : AdhConfig.IService) => {
         scope: true,
         transclude: true,
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MovingColumn.html",
-        controller: ["$timeout", "$scope", "$element", MovingColumnController]
-    };
-};
-
-
-export var clearMovingColumnDirective = () => {
-    return {
-        restrict: "A",
-        link: (scope, element) => {
-            element.click(() => {
-                scope.$emit("adhMovingColumn.clear");
-            });
-        }
+        controller: ["$timeout", "$scope", MovingColumnController]
     };
 };
 
@@ -289,7 +258,6 @@ export var register = (angular) => {
             AdhTopLevelState.moduleName,
             AdhShareSocial.moduleName
         ])
-        .directive("adhClearMovingColumn", clearMovingColumnDirective)
         .directive("adhMovingColumn", ["adhConfig", movingColumnDirective])
         .directive("adhMovingColumns", ["adhTopLevelState", "$timeout", "$window", movingColumns]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -184,6 +184,12 @@ export class MovingColumnController {
         this.lastId = 0;
     }
 
+    public clear() : void {
+        this.$scope._alerts = {};
+        this.$scope.overlay = undefined;
+        this.$scope._showSidebar = false;
+    }
+
     public alert(message : string, mode : string = "info", duration : number = 3000) : void {
         var id = this.lastId++;
         this.$timeout(() => this.removeAlert(id), duration);

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
@@ -1,11 +1,7 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-document moving-column-icon"></i>
-        <a
-            data-ng-if="proposalItemOptions.POST"
-            data-adh-clear-moving-column=""
-            href="{{ proposalUrl | adhResourceUrl:'edit' }}"
-        >{{ 'edit' | translate }}</a>
+        <a data-ng-if="proposalItemOptions.POST" href="{{ proposalUrl | adhResourceUrl:'edit' }}">{{ 'edit' | translate }}</a>
         <a href="" data-ng-click="ctrl.toggleOverlay('abuse')">{{ 'report' | translate }}</a>
         <a href="" data-ng-click="ctrl.toggleOverlay('share')">{{ 'share' | translate }}</a>
 

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
@@ -1,7 +1,11 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-document moving-column-icon"></i>
-        <a data-ng-if="proposalItemOptions.POST" href="{{ proposalUrl | adhResourceUrl:'edit' }}">{{ 'edit' | translate }}</a>
+        <a
+            data-ng-if="proposalItemOptions.POST"
+            data-adh-clear-moving-column=""
+            href="{{ proposalUrl | adhResourceUrl:'edit' }}"
+        >{{ 'edit' | translate }}</a>
         <a href="" data-ng-click="ctrl.toggleOverlay('abuse')">{{ 'report' | translate }}</a>
         <a href="" data-ng-click="ctrl.toggleOverlay('share')">{{ 'share' | translate }}</a>
 

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -47,14 +47,41 @@ var bindRedirectsToScope = (scope, adhConfig, $location) => {
 };
 
 
+/**
+ * Bind variables from topLevelState and clear the column whenever one of them changes.
+ */
+var bindVariablesAndClear = (
+    scope,
+    column : AdhMovingColumns.MovingColumnController,
+    adhTopLevelState : AdhTopLevelState.Service,
+    keys : string[]
+) : void => {
+    // NOTE: column directives are typically injected mutliple times
+    // with different transcludionIds. But we to trigger clear() only once.
+    var clear = () => {
+        if (scope.transclusionId === "body") {
+            column.clear();
+        }
+    };
+
+    clear();
+
+    keys.forEach((key : string) => {
+        adhTopLevelState.on(key, (value) => {
+            scope[key] = value;
+            clear();
+        });
+    });
+};
+
+
 export var commentColumnDirective = (adhTopLevelState : AdhTopLevelState.Service, adhConfig : AdhConfig.IService) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/CommentColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("proposalUrl", scope);
-            adhTopLevelState.bind("commentableUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["proposalUrl", "commentableUrl"]);
         }
     };
 };
@@ -70,7 +97,7 @@ export var mercatorProposalCreateColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MercatorProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("platformUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["platformUrl"]);
             bindRedirectsToScope(scope, adhConfig, $location);
         }
     };
@@ -87,8 +114,7 @@ export var mercatorProposalDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MercatorProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("platformUrl", scope);
-            adhTopLevelState.bind("proposalUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["platformUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
         }
     };
@@ -105,8 +131,7 @@ export var mercatorProposalEditColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MercatorProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("platformUrl", scope);
-            adhTopLevelState.bind("proposalUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["platformUrl", "proposalUrl"]);
             bindRedirectsToScope(scope, adhConfig, $location);
         }
     };
@@ -119,8 +144,7 @@ export var mercatorProposalListingColumnDirective = (adhTopLevelState : AdhTopLe
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MercatorProposalListingColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("platformUrl", scope);
-            adhTopLevelState.bind("proposalUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["platformUrl", "proposalUrl"]);
             scope.contentType = RIMercatorProposalVersion.content_type;
             scope.shared.facets = [{
                 key: "mercator_location",
@@ -156,7 +180,7 @@ export var userDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("userUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["userUrl"]);
             adhPermissions.bindScope(scope, adhConfig.rest_url + "/message_user", "messageOptions");
         }
     };
@@ -172,7 +196,7 @@ export var userListingColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserListingColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            adhTopLevelState.bind("userUrl", scope);
+            bindVariablesAndClear(scope, column, adhTopLevelState, ["userUrl"]);
         }
     };
 };


### PR DESCRIPTION
this is my attempt on fixing #577. I added ways to `clear()` a moving column, i.e. hide all overlays and alerts as well as the sidebar.

I am not too happy with the interface because it exposes this functionality 3 times: As a function on the controller, via DOM event and via angular event.

What is worse, it does not even work in all cases. While I tried to cover most of what we currently use, there are still exceptions. E.g. show the sidebar on the first column and then click "add proposal". The sidebar will still be visible on the form.

The first question that I had to think about was *when exactly* we want the moving columns to be cleared. I found that this is when they are hidden, but not when they are collapsed. We do know if column got closed via the `movingColumn` key in `adhTopLevelState` and we also know which directive represents which column in `adhMovingColumns`. So this case is covered.

Unfortunately, there is a second, much harder case. We also want to clear a column when we exchange its contents. This happends for example when switching from listing to create form (first column) or from detail to edit (second column). We keep the same column element in order to get smooth transitions.

In the case of the second column, I mitigated the problem by registering a `click` handler on the "edit" button. This is not possible in the case of the first column because the "add proposal" button does not have any relation to the column where it triggers a change.

I think this pull request covers many cases and is a big improvement. So I propose merging it. But it is not sufficient to call #577 "fixed".