### PR TITLE
Extract TR__ strings

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/extract_messages.sh
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/extract_messages.sh
@@ -1,4 +1,8 @@
-git grep "{{[^{]*['\"]\s*|\s*translate" \
-| grep -o '{{[^{]*|\s*translate' \
-| sed "s/{{\s*[\"']//;s/[\"']\s*|\s*translate//" \
-| sort | uniq
+#!/bin/sh
+
+(
+    git grep "{{[^{]*['\"]\s*|\s*translate" \
+        | grep -o '{{[^{]*|\s*translate' \
+        | sed "s/{{\s*[\"']//;s/[\"']\s*|\s*translate//";
+    grep -o -h "TR__[^\"']*" $(git ls-files | grep '\.ts$');
+) | sort | uniq

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
@@ -39,6 +39,7 @@
     "Shorter than minimum length 6": "Kürzer als minimale Länge 6",
     "User doesn't exist or password is wrong": "Nutzer*in existiert nicht oder Passwort ist falsch",
     "CALL_FOR_ACTIVATION": "Nachdem Sie auf den Aktivierungslink geklickt haben, können Sie {{siteName}} verwenden.",
+    "TR__GUEST": "Gast",
     "TR__MESSAGE_STATUS_OK": "Nachricht wurde versendet",
     "TR__REPORT_ABUSE_STATUS_OK": "Die Moderator*innen wurden benachrichtigt"
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
@@ -41,6 +41,7 @@
   "username": "username",
   "CALL_FOR_ACTIVATION": "Once you have clicked on the activation link you can procede using {{siteName}}",
   "USERS_PROPOSALS": "{{name}}'s proposals",
+  "TR__GUEST": "guest",
   "TR__MESSAGE_STATUS_OK": "Message was sent",
   "TR__REPORT_ABUSE_STATUS_OK": "The moderators have been notified"
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -207,7 +207,7 @@ export var metaDirective = (adhConfig : AdhConfig.IService) => {
                         $scope.isAnonymous = false;
                     });
             } else {
-                $translate("guest").then((translated) => {
+                $translate("TR__GUEST").then((translated) => {
                     $scope.userBasic = {
                         name: translated
                     };


### PR DESCRIPTION
this continues #659 in that it uses technical "TR__"-strings everywhere we have translation in typescript code. It also adds these strings to the extract_messages script.