### PR TITLE
Add mercator_budget index view

### DIFF
--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
@@ -414,6 +414,25 @@ def index_requested_funding(resource: IResource, default) -> str:
     return default
 
 
+def index_budget(resource: IResource, default) -> str:
+    """
+    Return search index keyword based on the "budget" field.
+
+    The returned values are the same values as per the "requested_funding"
+    field, or "above_50000" if the total budget value is more than 50,000 euro.
+    """
+    # FIXME: Why is finance '' in the first pass of that function
+    # during MercatorProposal create?
+    finance = get_sheet_field(resource, IMercatorSubResources, 'finance')
+    if finance is None or finance == '':
+            return default
+    funding = get_sheet_field(finance, IFinance, 'budget')
+    for limit in BUDGET_INDEX_LIMIT_KEYWORDS:
+        if funding <= limit:
+            return [str(limit)]
+    return 'above_50000'
+
+
 class ExperienceSchema(colander.MappingSchema):
 
     """Data structure for additional fields."""
@@ -468,4 +487,8 @@ def includeme(config):
     config.add_indexview(index_requested_funding,
                          catalog_name='adhocracy',
                          index_name='mercator_requested_funding',
+                         context=IMercatorSubResources)
+    config.add_indexview(index_budget,
+                         catalog_name='adhocracy',
+                         index_name='mercator_budget',
                          context=IMercatorSubResources)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator.py
@@ -388,7 +388,7 @@ class TestMercatorRequestedFundingIndex:
     def context(self, pool_graph):
         return pool_graph
 
-    def test_index_buget_default(self, context):
+    def test_index_requested_funding_default(self, context):
         from adhocracy_mercator.sheets.mercator import index_requested_funding
         resource = _make_mercator_resource(context)
         result = index_requested_funding(resource, 'default')
@@ -433,6 +433,60 @@ class TestMercatorRequestedFundingIndex:
             finance_appstruct={'requested_funding': 50001})
         result = index_requested_funding(resource, 'default')
         assert result == 'default'
+
+
+@mark.usefixtures('integration')
+class TestMercatorBudgetIndex:
+
+    @fixture
+    def context(self, pool_graph):
+        return pool_graph
+
+    def test_index_budget_default(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(context)
+        result = index_budget(resource, 'default')
+        assert result == 'default'
+
+    def test_index_budget_lte_5000(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(
+            context,
+            finance_appstruct={'budget': 5000})
+        result = index_budget(resource, 'default')
+        assert result == ['5000']
+
+    def test_index_budget_lte_10000(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(
+            context,
+            finance_appstruct={'budget': 10000})
+        result = index_budget(resource, 'default')
+        assert result == ['10000']
+
+    def test_index_budget_lte_20000(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(
+            context,
+            finance_appstruct={'budget': 20000})
+        result = index_budget(resource, 'default')
+        assert result == ['20000']
+
+    def test_index_budget_lte_50000(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(
+            context,
+            finance_appstruct={'budget': 50000})
+        result = index_budget(resource, 'default')
+        assert result == ['50000']
+
+    def test_index_budget_gt_50000(self, context):
+        from adhocracy_mercator.sheets.mercator import index_budget
+        resource = _make_mercator_resource(
+            context,
+            finance_appstruct={'budget': 50001})
+        result = index_budget(resource, 'default')
+        assert result == 'above_50000'
 
 
 class TestOutcomeSheet:


### PR DESCRIPTION
This adds a new mercator_budget index to the backend which allows filtering by the budget field. Values are same as with the mercator_requested_funding index, except that there is an additional value "above_50000" since this field has no upper limit.

CC @local-girl who wants to add the frontend part.