### PR TITLE
2015 02 cs purge varnish

### DIFF
--- a/etc/development.ini
+++ b/etc/development.ini
@@ -33,6 +33,8 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 adhocracy.message_user_subject = Adhocracy Info: {}
 # If true, new user accounts are activated immediately without email verification
 adhocracy.skip_registration_mail = false
+# URL of the Varnish cache
+#adhocracy.varnish_url =
 
 # Name of the entire site. Used in account registration information etc.
 adhocracy.site_name = Adhocracy Test Site

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -33,6 +33,7 @@ def root_factory(request):
 def add_after_commit_hooks(request):
     """Add after commit hooks."""
     # FIXME this is a quick hack
+    from adhocracy_core.caching import purge_varnish_after_commit_hook
     from adhocracy_core.websockets.client import \
         send_messages_after_commit_hook
     from adhocracy_core.resources.subscriber import\
@@ -40,10 +41,8 @@ def add_after_commit_hooks(request):
     current_transaction = transaction.get()
     registry = request.registry
     # Order matters here
-    if 'adhocracy.varnish_url' in registry.settings:
-        from adhocracy_core.caching import purge_varnish_after_commit_hook
-        current_transaction.addAfterCommitHook(purge_varnish_after_commit_hook,
-                                               args=(registry,))
+    current_transaction.addAfterCommitHook(purge_varnish_after_commit_hook,
+                                           args=(registry,))
     current_transaction.addAfterCommitHook(send_messages_after_commit_hook,
                                            args=(registry,))
     current_transaction.addAfterCommitHook(

--- a/src/adhocracy_core/adhocracy_core/caching/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/caching/__init__.py
@@ -278,14 +278,14 @@ def purge_varnish_after_commit_hook(success: bool, registry: Registry):
                     resp = requests.request('PURGE', varnish_url + path)
                     if resp.status_code != 200:
                         logger.warning(
-                            'Varnish responded %i to purge request for %s',
+                            'Varnish responded %s to purge request for %s',
                             resp.status_code, path)
                 except RequestException as err:
                     logger.error(
                         'Couldn\'t send purge request for %s to Varnish: %s',
                         path, exception_to_str(err))
                     errcount += 1
-                    if errcount >= 3:
+                    if errcount >= 3:  # pragma: no cover
                         logger.error('Giving up on purge requests')
                         return
 

--- a/src/adhocracy_core/adhocracy_core/caching/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/caching/test_init.py
@@ -484,6 +484,16 @@ class TestPurgeVarnishAfterCommitHook:
         purge_varnish_after_commit_hook(False, registry_for_varnish)
         assert not mock_requests.request.called
 
+    def test_no_varnish_url(self, monkeypatch, registry_with_changelog,
+                            changelog_meta, context):
+        """Nothing should happen if no varnish_url is configured."""
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch)
+        registry_with_changelog._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context, modified=True)
+        purge_varnish_after_commit_hook(True, registry_with_changelog)
+        assert not mock_requests.request.called
+
     def test_unexpected_status_code(self, monkeypatch, registry_for_varnish,
                                  changelog_meta, context):
         from adhocracy_core import caching

--- a/src/adhocracy_core/adhocracy_core/caching/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/caching/test_init.py
@@ -428,3 +428,87 @@ class TestIntegrationCaching:
         assert resp.status == '200 OK'
 
 
+class TestPurgeVarnishAfterCommitHook:
+
+    @fixture
+    def registry_for_varnish(self, registry_with_changelog):
+        registry_with_changelog.settings[
+            'adhocracy.varnish_url'] = 'http://localhost'
+        return registry_with_changelog
+
+    def _monkeypatch_requests(self, monkeypatch, status_code=200,
+                              side_effect=None):
+        from adhocracy_core import caching
+        from requests import Response
+        mock_requests = mock.Mock()
+        mock_response = mock.Mock(spec=Response)
+        mock_response.status_code = status_code
+        mock_requests.request = mock.Mock(return_value=mock_response,
+                                          side_effect=side_effect)
+        monkeypatch.setattr(caching, 'requests', mock_requests)
+        return mock_requests
+
+    def test_empty_changelog(self, monkeypatch, registry_for_varnish):
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch)
+        purge_varnish_after_commit_hook(True, registry_for_varnish)
+        assert not mock_requests.request.called
+
+    def test_non_empty_changelog(self, monkeypatch, registry_for_varnish,
+                                 changelog_meta, context):
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch)
+        registry_for_varnish._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context, modified=True)
+        purge_varnish_after_commit_hook(True, registry_for_varnish)
+        assert mock_requests.request.called
+        assert mock_requests.request.call_args[0] == ('PURGE',
+                                                      'http://localhost/')
+
+    def test_non_empty_changelog_but_unchanged_resource(
+            self, monkeypatch, registry_for_varnish, changelog_meta, context):
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch)
+        registry_for_varnish._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context)
+        purge_varnish_after_commit_hook(True, registry_for_varnish)
+        assert not mock_requests.request.called
+
+    def test_success_false(
+            self, monkeypatch, registry_for_varnish, changelog_meta, context):
+        """Nothing should happen if the transaction was unsuccessful."""
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch)
+        registry_for_varnish._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context, modified=True)
+        purge_varnish_after_commit_hook(False, registry_for_varnish)
+        assert not mock_requests.request.called
+
+    def test_unexpected_status_code(self, monkeypatch, registry_for_varnish,
+                                 changelog_meta, context):
+        from adhocracy_core import caching
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(monkeypatch,
+                                                   status_code=444)
+        mock_logger = mock.Mock()
+        monkeypatch.setattr(caching, 'logger', mock_logger)
+        registry_for_varnish._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context, modified=True)
+        purge_varnish_after_commit_hook(True, registry_for_varnish)
+        assert mock_requests.request.called
+        assert mock_logger.warning.called
+
+    def test_exception_raised(self, monkeypatch, registry_for_varnish,
+                              changelog_meta, context):
+        from requests.exceptions import RequestException
+        from adhocracy_core import caching
+        from adhocracy_core.caching import purge_varnish_after_commit_hook
+        mock_requests = self._monkeypatch_requests(
+            monkeypatch, side_effect=RequestException('Nope!'))
+        mock_logger = mock.Mock()
+        monkeypatch.setattr(caching, 'logger', mock_logger)
+        registry_for_varnish._transaction_changelog[
+            '/'] = changelog_meta._replace(resource=context, modified=True)
+        purge_varnish_after_commit_hook(True, registry_for_varnish)
+        assert mock_requests.request.called
+        assert mock_logger.error.called

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -46,6 +46,8 @@ adhocracy.message_user_subject = Adhocracy Info: {}
 adhocracy.skip_registration_mail = false
 # Mode to set http cache headers for resources, valid entries: no_cache, without_proxy_cache, with_proxy_cache
 adhocracy_core.caching.http.mode = no_cache
+# URL of the Varnish cache
+#adhocracy.varnish_url =
 
 mail.queue_path = %(here)s/../var/mail
 # Configure the following fields for sending mails via SMTP


### PR DESCRIPTION
Add after-commit hook to send PURGE requests to Varnish whenever resources have been changed by a transaction. The hook will only be added if an 'adhocracy.varnish_url' is configured in the ini-file.

I haven't tested this with a real Varnish yet so it's possible that further changes will be needed.

The Varnish config needs to be changed as documented at https://www.varnish-cache.org/docs/3.0/tutorial/purging.html#http-purges to allow PURGE requests.