### PR TITLE
rename eventHandler to eventManager

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -27,7 +27,7 @@ import AdhDateTime = require("./Packages/DateTime/DateTime");
 import AdhDocumentWorkbench = require("./Packages/DocumentWorkbench/DocumentWorkbench");
 import AdhDone = require("./Packages/Done/Done");
 import AdhEmbed = require("./Packages/Embed/Embed");
-import AdhEventHandler = require("./Packages/EventHandler/EventHandler");
+import AdhEventManager = require("./Packages/EventManager/EventManager");
 import AdhHttp = require("./Packages/Http/Http");
 import AdhInject = require("./Packages/Inject/Inject");
 import AdhListing = require("./Packages/Listing/Listing");
@@ -146,7 +146,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhDocumentWorkbench.register(angular);
     AdhDone.register(angular);
     AdhEmbed.register(angular);
-    AdhEventHandler.register(angular);
+    AdhEventManager.register(angular);
     AdhHttp.register(angular, meta_api);
     AdhInject.register(angular);
     AdhListing.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
@@ -60,7 +60,7 @@ export var register = () => {
                     adapterMock, adhConfigMock, adhHttpMock, adhPermissionsMock, adhPreliminaryNamesMock, <any>q);
 
                 wrapperMock = {
-                    eventHandler: jasmine.createSpyObj("eventHandler", ["on", "off", "trigger"])
+                    eventManager: jasmine.createSpyObj("eventManager", ["on", "off", "trigger"])
                 };
                 instanceMock = {
                     scope: jasmine.createSpyObj("scope", ["$on"]),

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManager.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManager.ts
@@ -5,7 +5,7 @@
  * should rather inject the class itself and create an instance where
  * you need it.  This way you can avoid conflicting event names.
  */
-export class EventHandler {
+export class EventManager {
     private handlers : {[event : string]: {[id : number]: (arg : any) => void}} = {};
     private nextID : number = 0;
 
@@ -41,10 +41,10 @@ export class EventHandler {
 }
 
 
-export var moduleName = "adhEventHandler";
+export var moduleName = "adhEventManager";
 
 export var register = (angular) => {
     angular
         .module(moduleName, [])
-        .value("adhEventHandlerClass", EventHandler);
+        .value("adhEventManagerClass", EventManager);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManagerSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManagerSpec.ts
@@ -1,36 +1,36 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
-import AdhEventHandler = require("./EventHandler");
+import AdhEventManager = require("./EventManager");
 
 export var register = () => {
-    describe("EventHandler", () => {
-        var eventHandler : AdhEventHandler.EventHandler;
+    describe("EventManager", () => {
+        var eventManager : AdhEventManager.EventManager;
 
         beforeEach(() => {
-            eventHandler = new AdhEventHandler.EventHandler();
+            eventManager = new AdhEventManager.EventManager();
         });
 
         it("allows to set handlers for events", () => {
             var spy = jasmine.createSpy("spy");
-            eventHandler.on("test", spy);
-            eventHandler.trigger("test");
+            eventManager.on("test", spy);
+            eventManager.trigger("test");
             expect(spy).toHaveBeenCalled();
         });
 
         it("allow to pass a single argument on trigger", () => {
             var spy = jasmine.createSpy("spy");
-            eventHandler.on("test", spy);
-            eventHandler.trigger("test", "testArg");
+            eventManager.on("test", spy);
+            eventManager.trigger("test", "testArg");
             expect(spy).toHaveBeenCalledWith("testArg");
         });
 
         it("allows to unregister a single handler", () => {
             var spy1 = jasmine.createSpy("spy1");
             var spy2 = jasmine.createSpy("spy2");
-            var id1 = eventHandler.on("test", spy1);
-            eventHandler.on("test", spy2);
-            eventHandler.off("test", id1);
-            eventHandler.trigger("test");
+            var id1 = eventManager.on("test", spy1);
+            eventManager.on("test", spy2);
+            eventManager.off("test", id1);
+            eventManager.trigger("test");
             expect(spy1).not.toHaveBeenCalled();
             expect(spy2).toHaveBeenCalled();
         });
@@ -38,11 +38,11 @@ export var register = () => {
         it("allows to clear all handlers for a single event", () => {
             var spy1 = jasmine.createSpy("spy1");
             var spy2 = jasmine.createSpy("spy2");
-            eventHandler.on("test1", spy1);
-            eventHandler.on("test2", spy2);
-            eventHandler.off("test1");
-            eventHandler.trigger("test1");
-            eventHandler.trigger("test2");
+            eventManager.on("test1", spy1);
+            eventManager.on("test2", spy2);
+            eventManager.off("test1");
+            eventManager.trigger("test1");
+            eventManager.trigger("test2");
             expect(spy1).not.toHaveBeenCalled();
             expect(spy2).toHaveBeenCalled();
         });
@@ -50,11 +50,11 @@ export var register = () => {
         it("allows to clear all handlers for all events", () => {
             var spy1 = jasmine.createSpy("spy1");
             var spy2 = jasmine.createSpy("spy2");
-            eventHandler.on("test1", spy1);
-            eventHandler.on("test2", spy2);
-            eventHandler.off();
-            eventHandler.trigger("test1");
-            eventHandler.trigger("test2");
+            eventManager.on("test1", spy1);
+            eventManager.on("test2", spy2);
+            eventManager.off();
+            eventManager.trigger("test1");
+            eventManager.trigger("test2");
             expect(spy1).not.toHaveBeenCalled();
             expect(spy2).not.toHaveBeenCalled();
         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateSpec.ts
@@ -161,12 +161,12 @@ export var register = () => {
             var adhConfigMock;
             var adhPermissionsMock;
             var adhPreliminaryNamesMock;
-            var adhRateEventHandlerMock;
+            var adhRateEventManagerMock;
 
             beforeEach((done) => {
                 adapterMock = jasmine.createSpyObj("adapterMock", ["subject", "object", "rate", "rateablePostPoolPath"]);
                 adhPermissionsMock = jasmine.createSpyObj("adhPermissionsMock", ["bindScope"]);
-                adhRateEventHandlerMock = jasmine.createSpyObj("adhRateEventHandlerMock", ["on", "off", "trigger"]);
+                adhRateEventManagerMock = jasmine.createSpyObj("adhRateEventManagerMock", ["on", "off", "trigger"]);
 
                 adhConfigMock = <any>{};
 
@@ -175,7 +175,7 @@ export var register = () => {
 
                 directive = AdhRate.directiveFactory("", adapterMock)(
                     <any>q,
-                    adhRateEventHandlerMock,
+                    adhRateEventManagerMock,
                     adhConfigMock,
                     httpMock,
                     null,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgetsSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgetsSpec.ts
@@ -24,7 +24,7 @@ export var register = () => {
                 var attrsMock;
                 var parseMock;
                 var controller;
-                var eventHandlerClassMock = function() {
+                var eventManagerClassMock = function() {
                     this.on = jasmine.createSpy("on");
                     this.off = jasmine.createSpy("off");
                     this.trigger = jasmine.createSpy("trigger");
@@ -41,7 +41,7 @@ export var register = () => {
                     };
                     parseMock = jasmine.createSpy("$parse").and.returnValue(() => null);
                     adhHttpMock = jasmine.createSpyObj("adhHttpMock", ["deepPost"]);
-                    controller = new directive.controller[6](scopeMock, attrsMock, q, parseMock, eventHandlerClassMock, adhHttpMock);
+                    controller = new directive.controller[6](scopeMock, attrsMock, q, parseMock, eventManagerClassMock, adhHttpMock);
                 });
 
                 it("does not pollute the scope", () => {
@@ -61,8 +61,8 @@ export var register = () => {
                         controller.triggerSubmit().then(done);
                     });
 
-                    it("triggers a 'submit' event on eventHandler", () => {
-                        expect(controller.eventHandler.trigger).toHaveBeenCalledWith("submit");
+                    it("triggers a 'submit' event on eventManager", () => {
+                        expect(controller.eventManager.trigger).toHaveBeenCalledWith("submit");
                     });
 
                     it("calls onSubmit callback", () => {
@@ -77,8 +77,8 @@ export var register = () => {
                         controller.triggerCancel();
                     });
 
-                    it("triggers a 'cancel' event on eventHandler", () => {
-                        expect(controller.eventHandler.trigger).toHaveBeenCalledWith("cancel");
+                    it("triggers a 'cancel' event on eventManager", () => {
+                        expect(controller.eventManager.trigger).toHaveBeenCalledWith("cancel");
                     });
 
                     it("calls onCancel callback", () => {
@@ -87,9 +87,9 @@ export var register = () => {
                 });
 
                 describe("triggerSetMode", () => {
-                    it("triggers a 'setMode' event with mode as first parameter on eventHandler", () => {
+                    it("triggers a 'setMode' event with mode as first parameter on eventManager", () => {
                         controller.triggerSetMode("mode");
-                        expect(controller.eventHandler.trigger).toHaveBeenCalledWith("setMode", "mode");
+                        expect(controller.eventManager.trigger).toHaveBeenCalledWith("setMode", "mode");
                     });
                 });
             });
@@ -114,7 +114,7 @@ export var register = () => {
                         "triggerSetMode"]),
                     deferred: q.defer()
                 };
-                instanceMock.wrapper.eventHandler = jasmine.createSpyObj("eventHandler", ["on", "off", "trigger"]);
+                instanceMock.wrapper.eventManager = jasmine.createSpyObj("eventManager", ["on", "off", "trigger"]);
                 instanceMock.wrapper.triggerSubmit.and.returnValue(q.when());
 
                 resourceWidget = new AdhResourceWidgets.ResourceWidget(adhHttpMock, adhPreliminaryNamesMock, <any>q);
@@ -169,14 +169,14 @@ export var register = () => {
                             expect(instance.deferred.resolve).toHaveBeenCalledWith([]);
                         });
 
-                        it("unregisters all listeners on wrapper.eventHandler", () => {
-                            expect(instance.wrapper.eventHandler.off.calls.count()).toBe(4);
+                        it("unregisters all listeners on wrapper.eventManager", () => {
+                            expect(instance.wrapper.eventManager.off.calls.count()).toBe(4);
                         });
                     });
 
                     describe("on submit", () => {
                         it("calls provide and resolves the promise with the result", (done) => {
-                            var fn = getArgsByFirst(instance.wrapper.eventHandler.on, "submit")[0][1];
+                            var fn = getArgsByFirst(instance.wrapper.eventManager.on, "submit")[0][1];
                             resourceWidget.provide.and.returnValue(q.when("provided"));
 
                             fn().then(() => {
@@ -194,7 +194,7 @@ export var register = () => {
                         var fn;
 
                         beforeEach(() => {
-                            fn = getArgsByFirst(instance.wrapper.eventHandler.on, "cancel")[0][1];
+                            fn = getArgsByFirst(instance.wrapper.eventManager.on, "cancel")[0][1];
                         });
 
                         it("resets scope and sets mode to display if scope.mode is edit", (done) => {
@@ -219,7 +219,7 @@ export var register = () => {
 
                     describe("on setMode", () => {
                         it("calls setMode with first parameter", () => {
-                            var fn = getArgsByFirst(instance.wrapper.eventHandler.on, "setMode")[0][1];
+                            var fn = getArgsByFirst(instance.wrapper.eventManager.on, "setMode")[0][1];
                             fn("event", "mode");
                             expect(resourceWidget.setMode).toHaveBeenCalledWith(instance, "mode");
                         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
@@ -10,7 +10,7 @@ export var register = () => {
         describe("Service", () => {
             var adhTopLevelState : AdhTopLevelState.Service;
             var areaInput;
-            var eventHandlerMockClass;
+            var eventManagerMockClass;
             var locationMock;
             var rootScopeMock;
             var injectorMock;
@@ -35,14 +35,14 @@ export var register = () => {
                 injectorMock = jasmine.createSpyObj("injectorMock", ["invoke"]);
                 injectorMock.invoke.and.returnValue(areaInput);
 
-                eventHandlerMockClass = <any>function() {
+                eventManagerMockClass = <any>function() {
                     this.on = on;
                     this.off = off;
                     this.trigger = trigger;
                 };
 
                 adhTopLevelState = <any>new AdhTopLevelState.Service(
-                    providerMock, eventHandlerMockClass, null, locationMock, rootScopeMock, null, <any>q, injectorMock, null);
+                    providerMock, eventManagerMockClass, null, locationMock, rootScopeMock, null, <any>q, injectorMock, null);
 
                 spyOn(adhTopLevelState, "toLocation");
 
@@ -259,12 +259,12 @@ export var register = () => {
                 });
             });
 
-            it("dispatches calls to set() to eventHandler", () => {
+            it("dispatches calls to set() to eventManager", () => {
                 adhTopLevelState.set("content2Url", "some/path");
                 expect(trigger).toHaveBeenCalledWith(":content2Url", "some/path");
             });
 
-            it("dispatches calls to on() to eventHandler", () => {
+            it("dispatches calls to on() to eventManager", () => {
                 var callback = (url) => undefined;
                 adhTopLevelState.on("content2Url", callback);
                 expect(on).toHaveBeenCalledWith(":content2Url", callback);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocketSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocketSpec.ts
@@ -17,20 +17,20 @@ export var register = () => {
     describe("WebSocket", () => {
         describe("Service", () => {
             var service;
-            var adhEventHandlerClassMock;
-            var adhEventHandlerMocks;
+            var adhEventManagerClassMock;
+            var adhEventManagerMocks;
             var adhRawWebSocketMock;
 
             beforeEach(() => {
-                adhEventHandlerClassMock = function() {
-                    this.on = jasmine.createSpy("adhEventHandler.on");
-                    this.off = jasmine.createSpy("adhEventHandler.off");
-                    this.trigger = jasmine.createSpy("adhEventHandler.trigger");
-                    adhEventHandlerMocks.push(this);
+                adhEventManagerClassMock = function() {
+                    this.on = jasmine.createSpy("adhEventManager.on");
+                    this.off = jasmine.createSpy("adhEventManager.off");
+                    this.trigger = jasmine.createSpy("adhEventManager.trigger");
+                    adhEventManagerMocks.push(this);
                 };
                 adhRawWebSocketMock = jasmine.createSpyObj("adhRawWebSocketFactory", ["send", "addEventListener"]);
-                adhEventHandlerMocks = [];
-                service = new AdhWebSocket.Service(config, adhEventHandlerClassMock, () => adhRawWebSocketMock);
+                adhEventManagerMocks = [];
+                service = new AdhWebSocket.Service(config, adhEventManagerClassMock, () => adhRawWebSocketMock);
             });
 
             it("calls the send method of web socket on every register to different resources", () => {
@@ -68,7 +68,7 @@ export var register = () => {
                 expect(() => service.unregister("/adhocracy/somethingelse", 0)).toThrow();
             });
 
-            it("calls eventHandler.trigger on event", () => {
+            it("calls eventManager.trigger on event", () => {
                 var resource = "/adhocracy/sidty";
                 var msg = {
                     resource: resource,
@@ -79,7 +79,7 @@ export var register = () => {
                 adhRawWebSocketMock.onmessage({
                     data: JSON.stringify(msg)
                 });
-                expect(adhEventHandlerMocks[0].trigger).toHaveBeenCalledWith(resource, msg);
+                expect(adhEventManagerMocks[0].trigger).toHaveBeenCalledWith(resource, msg);
             });
 
             it("throws an exception on error", () => {
@@ -95,7 +95,7 @@ export var register = () => {
                     })
                 })).toThrow();
 
-                expect(adhEventHandlerMocks[0].trigger).not.toHaveBeenCalled();
+                expect(adhEventManagerMocks[0].trigger).not.toHaveBeenCalled();
             });
 
             it("resends all subscriptions on WebSocket open", () => {

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -28,7 +28,7 @@ import AdhCrossWindowMessaging = require("./Packages/CrossWindowMessaging/CrossW
 import AdhDateTime = require("./Packages/DateTime/DateTime");
 import AdhDone = require("./Packages/Done/Done");
 import AdhEmbed = require("./Packages/Embed/Embed");
-import AdhEventHandler = require("./Packages/EventHandler/EventHandler");
+import AdhEventManager = require("./Packages/EventManager/EventManager");
 import AdhHttp = require("./Packages/Http/Http");
 import AdhInject = require("./Packages/Inject/Inject");
 import AdhListing = require("./Packages/Listing/Listing");
@@ -158,7 +158,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhDateTime.register(angular);
     AdhDone.register(angular);
     AdhEmbed.register(angular);
-    AdhEventHandler.register(angular);
+    AdhEventManager.register(angular);
     AdhHttp.register(angular, meta_api);
     AdhInject.register(angular);
     AdhListing.register(angular);


### PR DESCRIPTION
The generic eventManager was introduced a long time ago to allow service to expose an interface similar to jquery's on/off/trigger.  For some reason, it was called "eventHandler". But this term is already used for callbacks that are registered fir an event. So I propose to rename it to "eventManager".