### PR TITLE
http busy draft

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -147,7 +147,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhDone.register(angular);
     AdhEmbed.register(angular);
     AdhEventManager.register(angular);
-    AdhHttp.register(angular, meta_api);
+    AdhHttp.register(angular, config, meta_api);
     AdhInject.register(angular);
     AdhListing.register(angular);
     AdhLocale.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -449,10 +449,10 @@ export class Busy {
 }
 
 
-export var busyDirective = (adhBusy : Busy) => {
+export var busyDirective = (adhConfig : AdhConfig.IService, adhBusy : Busy) => {
     return {
         restrict: "E",
-        template: "{{busy.count}}",
+        template: adhConfig.debug ? "{{busy.count}}" : "",
         link: (scope) => {
             scope.busy = adhBusy;
         }
@@ -462,7 +462,7 @@ export var busyDirective = (adhBusy : Busy) => {
 
 export var moduleName = "adhHttp";
 
-export var register = (angular, metaApi) => {
+export var register = (angular, config, metaApi) => {
     angular
         .module(moduleName, [
             AdhPreliminaryNames.moduleName,
@@ -470,10 +470,12 @@ export var register = (angular, metaApi) => {
             "angular-data.DSCacheFactory",
         ])
         .config(["$httpProvider", ($httpProvider) => {
-            $httpProvider.interceptors.push(["adhHttpBusy", (adhHttpBusy : Busy) => adhHttpBusy.createInterceptor()]);
+            if (config.debug) {
+                $httpProvider.interceptors.push(["adhHttpBusy", (adhHttpBusy : Busy) => adhHttpBusy.createInterceptor()]);
+            }
         }])
         .service("adhHttpBusy", Busy)
-        .directive("adhHttpBusy", ["adhHttpBusy", busyDirective])
+        .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", busyDirective])
         .service("adhHttp", [
             "$http", "$q", "$timeout", "adhMetaApi", "adhPreliminaryNames", "adhConfig", "adhCache", Service])
         .service("adhCache", ["adhWebSocket", "DSCacheFactory", AdhCache.Service])

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -159,7 +159,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhDone.register(angular);
     AdhEmbed.register(angular);
     AdhEventManager.register(angular);
-    AdhHttp.register(angular, meta_api);
+    AdhHttp.register(angular, config, meta_api);
     AdhInject.register(angular);
     AdhListing.register(angular);
     AdhLocale.register(angular);

--- a/src/mercator/static/js/Packages/TopLevelState/templates/Wrapper.html
+++ b/src/mercator/static/js/Packages/TopLevelState/templates/Wrapper.html
@@ -3,6 +3,7 @@
         <div class="l-header-left">
             <a class="call-to-action m-add" href="/r/mercator/@create_proposal">{{ "TR__PROPOSAL_ADD" | translate }}</a>
         </div>
+        <adh-http-busy></adh-http-busy>
         <div class="l-header-center">
             <adh-space-switch></adh-space-switch>
         </div>


### PR DESCRIPTION
This implements an idea @nidico and me had: A service that hooks into `$http` and counts how many requests are currently in progress. It might be useful for debugging. This is a request for comments: Do you think this might be useful, and if so, how should I procede?