### PR TITLE
Cache eggs and node_modules in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "3.4"
@@ -13,3 +14,7 @@ notifications:
   email: false
 after_success:
   - "./bin/coveralls"
+cache:
+  directories:
+    - eggs
+    - node_modules


### PR DESCRIPTION
This is possible by using container-based builds (without sudo). We
might be able to cache even more, but this already speeds up the travis
setup time significantly (from 8 to 2 minutes until the first test
runs).

See:

- http://docs.travis-ci.com/user/workers/container-based-infrastructure/
- http://docs.travis-ci.com/user/caching/