### PR TITLE
Drop support for IE9

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
@@ -9,7 +9,7 @@
         <base href="/" />
     </head>
     <body>
-        <!--[if lt IE 9]>
+        <!--[if lt IE 10]>
         <div class="unsupported-browser">
             <img src="/static/icons/png/attention.png"/>
             <div>
@@ -19,7 +19,7 @@
             </div>
         </div>
         <![endif]-->
-        <!--[if gt IE 8]><!-->
+        <!--[if gt IE 9]><!-->
         <adh-view></adh-view>
         % for url in js:
             <script type="text/javascript" src="${url}"></script>


### PR DESCRIPTION
IE9 has multiple open issues (see below, but also no support for websockets and more). It has already caused a lot of hassle in the past, and it will do so in the future.

We don't have hard support requirements for IE9, so let's drop it.

- closes #487 (won't fix)
- closes #592 (won't fix)
- closes #486 (won't fix)
- closes #607 (won't fix)