### PR TITLE
Add custom MercatorProposal listitem widget

### DIFF
--- a/src/mercator/static/js/Packages/MercatorProposal/Listing.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Listing.html
@@ -8,13 +8,8 @@
     data-no-create-form="true"
     data-empty-text="{{ 'TR__PROPOSAL_EMPTY_TEXT' | translate }}">
     <div data-ng-switch="transclusionId">
-        <adh-resource-wrapper
-            data-ng-switch-when="element-id">
-            <adh-mercator-proposal
-                 data-ng-if="element"
-                 data-path="{{element}}"
-                 data-mode="display">
-            </adh-mercator-proposal>
-        </adh-resource-wrapper>
+        <adh-mercator-proposal-list-item
+            data-path="{{element}}">
+        </adh-mercator-proposal-list-item>
     </div>
 </adh-listing>

--- a/src/mercator/static/js/Packages/MercatorProposal/Listing.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Listing.html
@@ -8,8 +8,8 @@
     data-no-create-form="true"
     data-empty-text="{{ 'TR__PROPOSAL_EMPTY_TEXT' | translate }}">
     <div data-ng-switch="transclusionId">
-        <adh-mercator-proposal-list-item
+        <adh-mercator-proposal
             data-path="{{element}}">
-        </adh-mercator-proposal-list-item>
+        </adh-mercator-proposal>
     </div>
 </adh-listing>

--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -842,6 +842,63 @@ export var userListing = (adhConfig : AdhConfig.IService) => {
 };
 
 
+export var listItem = (adhConfig : AdhConfig.IService, adhHttp) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/ListItem.html",
+        scope: {
+            path: "@"
+        },
+        link: (scope) => {
+            scope.data  = {};
+            adhHttp.get(scope.path).then((proposal) => {
+                scope.data.user_info = {
+                    first_name: proposal.data[SIMercatorUserInfo.nick].personal_name,
+                    last_name: proposal.data[SIMercatorUserInfo.nick].personal_name,
+                    country: proposal.data[SIMetaData.nick].item_creation_date,
+                    path: proposal.data[SIMetaData.nick].creator
+                };
+                adhHttp.get(proposal.data[SIMercatorSubResources.nick].introduction).then((introduction) => {
+                    scope.data.introduction = {
+                        picture: introduction.data[SIMercatorIntroduction.nick].picture,
+                        title: introduction.data[SIMercatorIntroduction.nick].title
+                    };
+                });
+                adhHttp.get(proposal.data[SIMercatorSubResources.nick].organization_info).then((organization_info) => {
+                    scope.data.organization_info = {
+                        name: organization_info.data[SIMercatorOrganizationInfo.nick].name
+                    };
+                });
+                adhHttp.get(proposal.data[SIMercatorSubResources.nick].finance).then((finance) => {
+                    scope.data.finance = {
+                        budget: finance.data[SIMercatorFinance.nick].budget
+                    };
+                });
+            });
+            adhHttp.get(AdhUtil.parentPath(scope.path), {
+                content_type: "adhocracy_core.resources.rate.IRateVersion",
+                tag: "LAST",
+                rate: 1,
+                depth: 3,
+                count: "true",
+                elements: "omit"
+            }).then((result) => {
+                scope.data.supporterCount = parseInt(result.data[SIPool.nick].count, 10);
+            });
+            adhHttp.get(AdhUtil.parentPath(scope.path), {
+                content_type: "adhocracy_core.resources.comment.ICommentVersion",
+                tag: "LAST",
+                depth: 4,
+                count: "true",
+                elements: "omit"
+            }).then((result) => {
+                scope.data.commentCountTotal = parseInt(result.data[SIPool.nick].count, 10);
+            });
+        }
+    };
+};
+
+
 export var imageUriFilter = () => {
     return (path? : string, format : string = "detail") : string => {
         if (path) {
@@ -966,6 +1023,7 @@ export var register = (angular) => {
             }])
         .directive("adhMercatorProposalListing", ["adhConfig", listing])
         .directive("adhMercatorUserProposalListing", ["adhConfig", userListing])
+        .directive("adhMercatorProposalListItem", ["adhConfig", "adhHttp", listItem])
         .filter("adhImageUri", imageUriFilter)
         .controller("mercatorProposalFormController", ["$scope", "$element", "$window", ($scope : IControllerScope, $element, $window) => {
             var heardFromCheckboxes = [

--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -1004,11 +1004,8 @@ export var register = (angular) => {
                 ]  // correspond to exact mime types EG image/png
             };
         }])
-        .directive("adhMercatorProposal", ["adhConfig", "adhHttp", "adhPreliminaryNames", "adhTopLevelState", "flowFactory", "moment", "$q",
-            (adhConfig, adhHttp, adhPreliminaryNames, adhTopLevelState, flowFactory, moment, $q) => {
-                var widget = new Widget(adhConfig, adhHttp, adhPreliminaryNames, adhTopLevelState, flowFactory, moment, $q);
-                return widget.createDirective();
-            }])
+        // NOTE: we do not use a Widget based directive here for performance reasons
+        .directive("adhMercatorProposal", ["adhConfig", "adhHttp", listItem])
         .directive("adhMercatorProposalDetailView",
             ["adhConfig", "adhHttp", "adhPreliminaryNames", "adhTopLevelState", "flowFactory", "moment", "$q",
             (adhConfig, adhHttp, adhPreliminaryNames, adhTopLevelState, flowFactory, moment, $q) => {
@@ -1023,7 +1020,6 @@ export var register = (angular) => {
             }])
         .directive("adhMercatorProposalListing", ["adhConfig", listing])
         .directive("adhMercatorUserProposalListing", ["adhConfig", userListing])
-        .directive("adhMercatorProposalListItem", ["adhConfig", "adhHttp", listItem])
         .filter("adhImageUri", imageUriFilter)
         .controller("mercatorProposalFormController", ["$scope", "$element", "$window", ($scope : IControllerScope, $element, $window) => {
             var heardFromCheckboxes = [


### PR DESCRIPTION
This improves initial load significantly (from 38s to 11s with 66 proposals and a couple of comments on my development setup).

We still do 7 HTTP requests per item:

- 3 can be loaded immediately (main resource, comments & rate queries)
- 3 subresources can be loaded once the main resource is there
- the image even needs to wait for the introduction subresource, i.e. requires 3 roundtrips after the proposal version path is known.

This doesn't reuse code from the main `MercatorProposal` resource widget as this would create effort.

Possible further improvements:

- Move `title` from `introduction` subresource to the main resource in order to display title earlier. The current modeling is an error anyway IMO.
- Loading all proposals in one query instead of separately could be done with the query API, but wouldn't help too much.
- A big improvement would be an extension of the GET API, which allows to specify which referenced resources shall also be retrieved. This would make the first suggestion obsolete.
