### PR TITLE
Upgrade python dependencies

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -51,7 +51,7 @@ compile python 3.4 and PIL ::
 
 install adhocracy ::
 
-    ./bin/python ./bootstrap.py -v 2.3.1 --setuptools-version=12.0.4
+    ./bin/python ./bootstrap.py -v 2.3.1 --setuptools-version=12.1
     ./bin/buildout
 
 update your shell environment::

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -7,7 +7,7 @@ MarkupSafe = 0.23
 PasteDeploy = 1.5.2
 Pygments = 2.0.2
 WebOb = 1.4
-WebTest = 2.0.17
+WebTest = 2.0.18
 astroid = 1.3.4
 bowerrecipe = 0.1.1
 collective.recipe.omelette = 0.16
@@ -26,7 +26,7 @@ gp.recipe.node = 0.10.28.0
 gp.recipe.phantomjs = 1.9.7.2
 hypatia = 0.3
 ipdb = 0.8
-ipython = 2.3.1
+ipython = 2.4.1
 logilab-common = 0.63.2
 mccabe = 0.3
 meld3 = 1.0.0
@@ -34,17 +34,17 @@ mr.developer = 1.31
 pep8 = 1.5.7
 pep8-naming = 0.2.2
 peppercorn = 0.5
-pip = 6.0.6
+pip = 6.0.8
 plone.recipe.command = 1.1
 profilehooks = 1.7.1
-pudb = 2014.1
+pudb = 2015.2
 py = 1.4.26
 pycallgraph = 1.0.1
 pyflakes = 0.8.1
 pylint = 1.4.1
 pyramid-zodbconn = 0.7
 pytest-pyramid = 0.1.1
-pytest-splinter = 1.2.9
+pytest-splinter = 1.2.10
 pytest-timeout = 0.4
 repoze.sendmail = 4.2
 requests = 2.5.1
@@ -69,7 +69,7 @@ BTrees = 4.1.1
 
 # Required by:
 # pyramid-chameleon==0.3
-Chameleon = 2.20
+Chameleon = 2.22
 
 # Required by:
 # adhocracy-core==0.0
@@ -95,10 +95,10 @@ ZODB = 4.1.0
 
 # Required by:
 # adhocracy-core==0.0
-autobahn = 0.9.5
+autobahn = 0.9.6
 
 # Required by:
-# WebTest==2.0.17
+# WebTest==2.0.18
 beautifulsoup4 = 4.3.2
 
 # Required by:
@@ -212,14 +212,14 @@ repoze.lru = 0.6
 # pytest-splinter==1.2.9
 # z3c.checkversions==0.5
 # zc.recipe.egg==2.0.1
-setuptools = 12.0.4
+setuptools = 12.1
 
 # Required by:
 # cornice==0.17
 simplejson = 3.6.5
 
 # Required by:
-# WebTest==2.0.17
+# WebTest==2.0.18
 # pylint==1.4.1
 # rubygemsrecipe==0.2.1
 # websocket-client==0.23.0

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -115,7 +115,7 @@ cryptacular = 1.4.1
 
 # Required by:
 # adhocracy-core==0.0
-gunicorn = 19.1.1
+gunicorn = 19.2.1
 
 # Required by:
 # gp.recipe.node==0.10.28.0


### PR DESCRIPTION
Nothing particularly interesting. I didn't update and fix pep8 in order to avoid conflicts with #685.

Changelogs: 

- autobahn (0.9.5 -> 0.9.6): https://github.com/tavendo/AutobahnPython/blob/master/doc/changelog.rst
- gunicorn (19.1.1 -> 19.2.2): http://docs.gunicorn.org/en/19.2.1/news.html#id1