### PR TITLE
Hide password in log file

### DIFF
--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1476,6 +1476,21 @@ class TestShowRequestBody:
         assert len(result) < len(cornice_request.body)
         assert result.endswith('...')
 
+    def test_password_is_hidden(self, cornice_request):
+        import json
+        from adhocracy_core.rest.views import _show_request_body
+        cornice_request.body = json.dumps({'name': 'foo', 'password': 'bar'})
+        result = _show_request_body(cornice_request)
+        assert '"<hidden>"' in result
+        assert 'bar' not in result
+
+    def test_other_content_type(self, cornice_request):
+        """Just the request body is returned in case of other content types."""
+        from adhocracy_core.rest.views import _show_request_body
+        cornice_request.content_type = 'text/plain'
+        cornice_request.body = 'password: foofoo'
+        result = _show_request_body(cornice_request)
+        assert result == cornice_request.body
 
 @fixture()
 def integration(config):

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -237,26 +237,27 @@ def _show_request_body(request: Request) -> str:
     """
     Show the request body.
 
-    In case of JSON requests with a "password" field at the top level,
-    the contents of the password field will be hidden.
-
     In case of multipart/form-data requests (file upload), only the 120
     first characters of the body are shown.
+
+    In case of JSON requests with a "password" field at the top level,
+    the contents of the password field will be hidden.
     """
     result = request.body
     if request.content_type == 'multipart/form-data' and len(result) > 120:
         result = '{}...'.format(result[:120])
     elif request.content_type == 'application/json':
-        # Hide password, if it occurs as a top-level field
+        json_data = ''
         try:
             json_data = request.json_body
         except ValueError:
-            pass  # Not even valid JSON, so we cannot repair it
-        else:
-            if isinstance(json_data, dict) and 'password' in json_data:
-                loggable_data = json_data.copy()
-                loggable_data['password'] = '<hidden>'
-                result = json.dumps(loggable_data)
+            pass  # Not even valid JSON, so we cannot hide anything
+        if not isinstance(json_data, dict):
+            pass
+        elif 'password' in json_data:
+            loggable_data = json_data.copy()
+            loggable_data['password'] = '<hidden>'
+            result = json.dumps(loggable_data)
     return result
 
 

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from datetime import datetime
 from datetime import timezone
 from logging import getLogger
+import json
 
 from colander import drop
 from colander import Invalid
@@ -236,12 +237,26 @@ def _show_request_body(request: Request) -> str:
     """
     Show the request body.
 
+    In case of JSON requests with a "password" field at the top level,
+    the contents of the password field will be hidden.
+
     In case of multipart/form-data requests (file upload), only the 120
     first characters of the body are shown.
     """
     result = request.body
     if request.content_type == 'multipart/form-data' and len(result) > 120:
         result = '{}...'.format(result[:120])
+    elif request.content_type == 'application/json':
+        # Hide password, if it occurs as a top-level field
+        try:
+            json_data = request.json_body
+        except ValueError:
+            pass  # Not even valid JSON, so we cannot repair it
+        else:
+            if isinstance(json_data, dict) and 'password' in json_data:
+                loggable_data = json_data.copy()
+                loggable_data['password'] = '<hidden>'
+                result = json.dumps(loggable_data)
     return result
 
 


### PR DESCRIPTION
Fixes #681.

A "password" field at the top level of invalid JSON requests will be rendered as  `<hidden>`.