### PR TITLE
Use ng-submit instead of ng-click on submit button (fixes #503)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.html
@@ -1,11 +1,10 @@
-<form>
+<form data-ng-submit="submit()">
     <textarea data-ng-model="remark">
     </textarea>
     <footer class="form-footer">
         <input
             type="submit"
             value="{{ 'TR__SUBMIT' | translate }}"
-            data-ng-click="submit()"
             class="m-call-to-action form-footer-button-cta" />
         <a href="" class="button form-footer-button" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
     </footer>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentCreate.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentCreate.html
@@ -1,10 +1,10 @@
-<form class="comment-create-form">
+<form class="comment-create-form" data-ng-submit="submit()">
     <div class="form-error" data-ng-repeat="error in errors">
         <p>{{ error | translate }}</p>
     </div>
     <textarea class="comment-create-form-text" data-msd-elastic="" data-ng-model="data.content"></textarea>
     <footer class="form-footer">
-        <input class="comment-create-form-button-submit m-call-to-action form-footer-button-cta" type="submit" value="{{ 'TR__CREATE' | translate }}" data-ng-click="submit()" />
+        <input class="comment-create-form-button-submit m-call-to-action form-footer-button-cta" type="submit" value="{{ 'TR__CREATE' | translate }}" />
         <a href="" class="button form-footer-button" data-ng-click="cancel()" data-ng-if="!hideCancel">{{ "TR__CANCEL" | translate }}</a>
     </footer>
 </form>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -29,16 +29,16 @@
             </div>
         </div>
 
-        <div class="comment-children-edit-form" data-ng-switch-when="1">
+        <form class="comment-children-edit-form" data-ng-switch-when="1" data-ng-submit="submit()">
             <div class="form-error" data-ng-repeat="error in errors">
                 <p>{{ error | translate }}</p>
             </div>
             <textarea class="comment-edit-form-text" data-msd-elastic="" data-ng-model="data.content"></textarea>
             <footer class="form-footer">
-                <a href="" class="button m-call-to-action form-footer-button-cta" data-ng-click="submit()">{{ "TR__SAVE" | translate }}</a>
+                <input type="submit" class="m-call-to-action form-footer-button-cta" value="{{ 'TR__SAVE' | translate }}" />
                 <a href="" class="button form-footer-button" data-ng-click="cancel()" data-ng-if="!hideCancel">{{ "TR__CANCEL" | translate }}</a>
             </footer>
-        </div>
+        </form>
         <div class="comment-content" data-ng-switch-default="">
             {{data.content}}
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
@@ -1,5 +1,5 @@
 <div class="login">
-    <form novalidate="novalidate" class="login-form" name="loginForm">
+    <form novalidate="novalidate" class="login-form" name="loginForm" data-ng-submit="logIn()">
         <div class="form-error" data-ng-repeat="error in errors track by $index">
             <p>{{ error | translate }}</p>
         </div>
@@ -25,7 +25,6 @@
             type="submit"
             value="{{ 'TR__LOGIN' | translate }}"
             class="m-call-to-action"
-            data-ng-click="logIn()"
             data-ng-disabled="loginForm.$invalid" />
         <div class="login-info">
             <p>{{ "TR__OR_REGISTER" | translate }}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -1,5 +1,5 @@
 <div class="register">
-    <form novalidate="novalidate" class="register-form" name="registerForm">
+    <form novalidate="novalidate" class="register-form" name="registerForm" data-ng-submit="register()">
         <div class="form-error" ng-repeat="error in errors track by $index">
             <p>{{ error | translate }}</p>
         </div>
@@ -60,7 +60,6 @@
             name="register"
             value="{{ 'TR__REGISTER' | translate }}"
             class="m-call-to-action"
-            data-ng-click="register()"
             data-ng-disabled="registerForm.$invalid || input.password !== input.passwordRepeat" />
         <div data-ng-if="!success" class="register-info">
             <p>{{ "TR__REGISTRATION_LOGIN_INSTEAD" | translate }}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserMessage.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserMessage.html
@@ -1,6 +1,7 @@
 <div class="user-message">
     <form
         novalidate="novalidate"
+        data-ng-submit="messageSend()"
         name="messageForm">
         <!-- FIXME: replace "Username" -->
         <p>{{ "TR__MESSAGE_TO" | translate }} Username</p>
@@ -30,7 +31,6 @@
             <input
                 type="submit"
                 value="{{ 'TR__MESSAGE_SEND' | translate }}"
-                data-ng-click="messageSend()"
                 class="m-call-to-action form-footer-button-cta" />
             <a href="" class="button form-footer-button" data-ng-click="cancel()" >{{ "TR__CANCEL" | translate }}</a>
         </footer>

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -55,7 +55,7 @@ var EmbeddedCommentsPage = function(referer) {
         this.getEditLink(comment).click();
         var textarea = comment.element(by.model("data.content"));
         textarea.sendKeys.apply(textarea, keys);
-        comment.element(by.css("[data-ng-click='submit()']")).click();
+        comment.element(by.css("input[type=\"submit\"]")).click();
         return comment;
     };
 


### PR DESCRIPTION
According to https://docs.angularjs.org/api/ng/directive/form, both methods should work the same. For me, `ng-click` results in a double-post when using the return key to submit.