### PR TITLE
Warmup cache for listings

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
@@ -32,6 +32,7 @@ export class Service {
     private nonResourceUrls;
 
     constructor(
+        private $q : ng.IQService,
         private adhConfig : AdhConfig.IService,
         private adhWebSocket : AdhWebSocket.Service,
         private DSCacheFactory
@@ -134,6 +135,16 @@ export class Service {
             return promise;
         } else {
             return closure();
+        }
+    }
+
+    /**
+     * Force value into cache.
+     */
+    public putCached(path, subkey, value) {
+        if (this.adhWebSocket.isConnected()) {
+            var cached = this.getOrSetCached(path);
+            cached.promises[subkey] = this.$q.when(value);
         }
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -129,12 +129,34 @@ export class Service<Content extends ResourcesBase.Resource> {
         return this.$http.get(path, { params : params });
     }
 
-    public get(path : string, params ?: { [key : string] : string }) : ng.IPromise<Content> {
+    /**
+     * Send HTTP request to path with params and returns a promise of the
+     * imported response.
+     *
+     * The optional parameter `warmupPoolCache` can be used on pool queries
+     * in order to requests the IPool sheet to contain a list of resources
+     * instead of only paths. The returned promise however has the same API
+     * as if `warmupPoolCache` would be skipped.
+     */
+    public get(
+        path : string,
+        params ?: { [key : string] : string },
+        warmupPoolCache ?: boolean
+    ) : ng.IPromise<Content> {
         var query = (typeof params === "undefined") ? "" : "?" + $.param(params);
+
+        if (warmupPoolCache) {
+            if (_.has(params, "elements")) {
+                throw "cannot use warmupPoolCache when elements is set";
+            } else {
+                params["elements"] = "content";
+            }
+        }
 
         return this.adhCache.memoize(path, query,
             () => this.getRaw(path, params).then(
-                (response) => AdhConvert.importContent(<any>response, this.adhMetaApi, this.adhPreliminaryNames),
+                (response) => AdhConvert.importContent(
+                    <any>response, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache, warmupPoolCache),
                 AdhError.logBackendError));
     }
 
@@ -155,7 +177,7 @@ export class Service<Content extends ResourcesBase.Resource> {
             .then(
                 (response) => {
                     _self.adhCache.invalidateUpdated(response.data.updated_resources);
-                    return AdhConvert.importContent(<any>response, _self.adhMetaApi, _self.adhPreliminaryNames);
+                    return AdhConvert.importContent(<any>response, _self.adhMetaApi, _self.adhPreliminaryNames, this.adhCache);
                 },
                 AdhError.logBackendError);
     }
@@ -189,7 +211,7 @@ export class Service<Content extends ResourcesBase.Resource> {
             .then(
                 (response) => {
                     this.adhCache.invalidateUpdated(response.data.updated_resources);
-                    return AdhConvert.importContent(<any>response, _self.adhMetaApi, _self.adhPreliminaryNames);
+                    return AdhConvert.importContent(<any>response, _self.adhMetaApi, _self.adhPreliminaryNames, this.adhCache);
                 },
                 AdhError.logBackendError);
     }
@@ -485,7 +507,7 @@ export var register = (angular, config, metaApi) => {
         .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", busyDirective])
         .service("adhHttp", [
             "$http", "$q", "$timeout", "adhMetaApi", "adhPreliminaryNames", "adhConfig", "adhCache", Service])
-        .service("adhCache", ["adhConfig", "adhWebSocket", "DSCacheFactory", AdhCache.Service])
+        .service("adhCache", ["$q", "adhConfig", "adhWebSocket", "DSCacheFactory", AdhCache.Service])
         .factory("adhMetaApi", () => new AdhMetaApi.MetaApiQuery(metaApi))
         .filter("adhFormatError", () => AdhError.formatError);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:variable-name */
 /// <reference path="../../../lib/DefinitelyTyped/requirejs/require.d.ts"/>
 /// <reference path="../../../lib/DefinitelyTyped/jquery/jquery.d.ts"/>
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -527,6 +527,17 @@ export var register = () => {
         });
 
         describe("importContent", () => {
+            var adhCacheMock;
+
+            beforeEach(() => {
+                adhCacheMock = {
+                    invalidate: (path) => undefined,
+                    invalidateAll: () => undefined,
+                    invalidateUpdated: (updated, posted) => undefined,
+                    memoize: (path, subkey, closure) => closure()
+                };
+            });
+
             it("returns response.data if it is an object", () => {
                 var obj : ResourcesBase.Resource = <any>{
                     content_type: "adhocracy_core.resources.pool.IBasicPool",
@@ -538,7 +549,7 @@ export var register = () => {
                 };
                 var adhMetaApiMock = mkAdhMetaApiMock();
                 var adhPreliminaryNames = new AdhPreliminaryNames.Service();
-                var imported = () => Convert.importContent(response, <any>adhMetaApiMock, adhPreliminaryNames);
+                var imported = () => Convert.importContent(response, <any>adhMetaApiMock, adhPreliminaryNames, adhCacheMock);
                 expect(imported().path).toBe(obj.path);
             });
             it("throws if response.data is not an object", () => {
@@ -548,7 +559,7 @@ export var register = () => {
                 };
                 var adhMetaApiMock = mkAdhMetaApiMock();
                 var adhPreliminaryNames = new AdhPreliminaryNames.Service();
-                var imported = () => Convert.importContent(response, <any>adhMetaApiMock, adhPreliminaryNames);
+                var imported = () => Convert.importContent(response, <any>adhMetaApiMock, adhPreliminaryNames, adhCacheMock);
                 expect(imported).toThrow();
             });
         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:variable-name */
 /// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 
 import _ = require("lodash");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
@@ -117,7 +117,8 @@ export class Transaction {
 
         return this.adhHttp.postRaw("/batch", this.requests.map(conv)).then(
             (response) => {
-                var imported = AdhConvert.importBatchContent(response.data.responses, this.adhMetaApi, this.adhPreliminaryNames);
+                var imported = AdhConvert.importBatchContent(
+                    response.data.responses, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache);
                 _self.adhCache.invalidateUpdated(response.data.updated_resources, _.pluck(imported, "path"));
                 return imported;
             },

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -144,7 +144,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                     if ($scope.sort) {
                         params["sort"] = $scope.sort.replace(/^-/, "");
                     }
-                    return adhHttp.get($scope.path, params).then((container) => {
+                    return adhHttp.get($scope.path, params, true).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);
                         $scope.elements = _self.containerAdapter.elemRefs($scope.container);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -63,7 +63,7 @@ export interface ListingScope<Container> extends ng.IScope {
     poolOptions : AdhHttp.IOptions;
     createPath? : string;
     elements : string[];
-    update : () => ng.IPromise<void>;
+    update : (boolean?) => ng.IPromise<void>;
     wshandle : number;
     clear : () => void;
     onCreate : () => void;
@@ -123,7 +123,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
             ) : void => {
                 $scope.createPath = adhPreliminaryNames.nextPreliminary();
 
-                $scope.update = () : ng.IPromise<void> => {
+                $scope.update = (warmup? : boolean) : ng.IPromise<void> => {
                     var params = <any>_.extend({}, $scope.params);
                     if (typeof $scope.contentType !== "undefined") {
                         params.content_type = $scope.contentType;
@@ -144,7 +144,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                     if ($scope.sort) {
                         params["sort"] = $scope.sort.replace(/^-/, "");
                     }
-                    return adhHttp.get($scope.path, params, true).then((container) => {
+                    return adhHttp.get($scope.path, params, warmup).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);
                         $scope.elements = _self.containerAdapter.elemRefs($scope.container);
@@ -177,7 +177,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                         // order to not miss any messages in between. But in
                         // order to subscribe we already need the resource. So
                         // that is not possible.
-                        $scope.update().then(() => {
+                        $scope.update(true).then(() => {
                             try {
                                 $scope.wshandle = adhWebSocket.register($scope.poolPath, $scope.update);
                             } catch (e) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -157,7 +157,7 @@ export var register = () => {
                         });
 
                         it("updates scope.container from server", () => {
-                            expect(adhHttpMock.get).toHaveBeenCalledWith(path, {});
+                            expect(adhHttpMock.get).toHaveBeenCalledWith(path, {}, true);
                             expect(scope.container).toBe(container);
                         });
 
@@ -184,7 +184,7 @@ export var register = () => {
                         it("updates scope.container from server", () => {
                             expect(adhHttpMock.get).toHaveBeenCalledWith(path, {
                                 content_type: "some_content_type"
-                            });
+                            }, true);
                             expect(scope.container).toBe(container);
                         });
                     });


### PR DESCRIPTION
This extends `adhHttp.get` by an optional `warmupCache` parameter.

The optional parameter `warmupPoolCache` can be used on pool queries
in order to requests the IPool sheet to contain a list of resources
instead of only paths. The returned promise however has the same API
as if `warmupPoolCache` would be skipped.

This is then used in the listing widget. It saves one request per listitem,
but more importantly reduces the number of roundtrips by one for all
subresources and images.

On my local development setup, there isn't a huge impact (4s load instead
of 5s, which is at least something). However the impact may be more
relevant if there is actual network latency. 