### PR TITLE
Work on copy so that list does not get reversed twice (fixes #627)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -148,9 +148,9 @@ export class Listing<Container extends ResourcesBase.Resource> {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);
                         // FIXME: Sorting direction should be implemented in backend, working on a copy is used,
-                        // because otherwise sometimes the already reversed sorted list (from cache) would be 
+                        // because otherwise sometimes the already reversed sorted list (from cache) would be
                         // reversed again
-                        $scope.elements = angular.copy(_self.containerAdapter.elemRefs($scope.container));
+                        $scope.elements = _.clone(_self.containerAdapter.elemRefs($scope.container));
 
                         if ($scope.sort && $scope.sort[0] === "-") {
                             $scope.elements.reverse();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -3,6 +3,8 @@
 /// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 /// <reference path="../../_all.d.ts"/>
 
+import _ = require("lodash");
+
 import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
 import AdhInject = require("../Inject/Inject");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -147,7 +147,10 @@ export class Listing<Container extends ResourcesBase.Resource> {
                     return adhHttp.get($scope.path, params).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);
-                        $scope.elements = _self.containerAdapter.elemRefs($scope.container);
+                        // FIXME: Sorting direction should be implemented in backend, working on a copy is used,
+                        // because otherwise sometimes the already reversed sorted list (from cache) would be 
+                        // reversed again
+                        $scope.elements = angular.copy(_self.containerAdapter.elemRefs($scope.container));
 
                         if ($scope.sort && $scope.sort[0] === "-") {
                             $scope.elements.reverse();


### PR DESCRIPTION
Sometimes the list is loaded (for example if support button is clicked) from cache and should not reversed. So the final sorting is done on a copy. 