### PR TITLE
Properly setup subrequest in case script_name env is set

### DIFF
--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -160,6 +160,12 @@ class BatchView(RESTView):
         self.copy_attr_if_exists('__cached_principals__', request)
         self.copy_header_if_exists('X-User-Path', request)
         self.copy_header_if_exists('X-User-Token', request)
+
+        # properly setup subrequest in case script_name env is set,
+        # see https://github.com/Pylons/pyramid/issues/1434
+        request.script_name = self.request.script_name
+        request.path_info = request.path_info[len(self.request.script_name):]
+
         return request
 
     def _invoke_subrequest_and_handle_errors(

--- a/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
@@ -103,6 +103,7 @@ class TestBatchView:
         # present
         request.authenticated_userid = resource_path(context)
         request.root = context
+        request.script_name = '/virtual'
         inst = self._make_one(context, request)
         paths = {'path': '/pool/item',
                  'first_version_path': '/pool/item/v1'}
@@ -114,6 +115,9 @@ class TestBatchView:
         assert subrequest.__cached_principals__ == [1]
         assert subrequest.headers.get('X-User-Path') == 2
         assert subrequest.headers.get('X-User-Token') == 3
+        assert subrequest.script_name == '/virtual'
+        assert subrequest.path_info == 'cy/blah'
+
 
     def test_post_successful_subrequest_with_updated_resources(
             self, context, request, mock_invoke_subrequest):


### PR DESCRIPTION
This allows to deploy the backend under a different path than / and
therefore allows to deploy backend and frontend on the same domain -
this fixes #707.