### PR TITLE
Rafactor rate adapter

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Adapter.ts
@@ -50,10 +50,7 @@ export class RateAdapter implements AdhRate.IRateAdapter<RIRateVersion> {
     }
 
     isRateable(resource : ResourcesBase.Resource) : boolean {
-        return (
-            resource.data.hasOwnProperty(SIRateable.nick) ||
-            resource.data.hasOwnProperty(SILikeable.nick)
-        );
+        return resource.data.hasOwnProperty(SIRateable.nick);
     }
 
     rateablePostPoolPath(resource : ResourcesBase.Resource) : string {
@@ -109,6 +106,10 @@ export class RateAdapter implements AdhRate.IRateAdapter<RIRateVersion> {
 
 
 export class LikeAdapter extends RateAdapter {
+    isRateable(resource : ResourcesBase.Resource) : boolean {
+        return resource.data.hasOwnProperty(SILikeable.nick);
+    }
+
     rateablePostPoolPath(resource : ResourcesBase.Resource) : string {
         return resource.data[SILikeable.nick].post_pool;
     }


### PR DESCRIPTION
In #644 I noticed that there was only a single adapter for rate and like. I split it into one adapter for each. This is a fixup which splits a second function I did not notice before.