### PR TITLE
Create new ITitle sheet and attach it to the main MercatorProposal

### DIFF
--- a/etc/development.ini
+++ b/etc/development.ini
@@ -20,7 +20,7 @@ substanced.secret = seekri1
 substanced.initial_email = admin@example.com
 substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
 substanced.autosync_catalogs = true
-substanced.autoevolve = true
+substanced.autoevolve = false
 adhocracy.ws_url = ws://localhost:8080
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy

--- a/etc/noserver.ini
+++ b/etc/noserver.ini
@@ -25,7 +25,7 @@ substanced.initial_password = admin
 substanced.initial_email = admin@example.com
 substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
 substanced.autosync_catalogs = true
-substanced.autoevolve = true
+substanced.autoevolve = false
 adhocracy.ws_url =
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy

--- a/etc/noserver.ini
+++ b/etc/noserver.ini
@@ -24,7 +24,7 @@ substanced.initial_login = admin
 substanced.initial_password = admin
 substanced.initial_email = admin@example.com
 substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
-substanced.autosync_catalogs = true
+substanced.autosync_catalogs = false
 substanced.autoevolve = false
 adhocracy.ws_url =
 # The id for the root level adhocracy resource

--- a/src/adhocracy_mercator/adhocracy_mercator/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/__init__.py
@@ -18,6 +18,7 @@ def includeme(config):
     config.include('.catalog')
     config.include('.sheets.mercator')
     config.include('.resources.mercator')
+    config.include('.evolution')
 
 
 def main(global_config, **settings):

--- a/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
@@ -1,0 +1,45 @@
+"""Scripts to migrate legacy objects in existing databases."""
+import logging  # pragma: no cover
+from substanced.util import find_catalog  # pragma: no cover
+
+logger = logging.getLogger(__name__)  # pragma: no cover
+
+
+def evolve1_add_ititle_sheet_to_proposals(root):  # pragma: no cover
+    """Migrate title value from ole IIntroduction sheet to ITitle sheet."""
+    from pyramid.threadlocal import get_current_registry
+    from adhocracy_mercator.resources.mercator import IMercatorProposalVersion
+    from adhocracy_mercator.sheets.mercator import ITitle
+    from adhocracy_mercator.sheets.mercator import IMercatorSubResources
+    from adhocracy_mercator.sheets.mercator import IIntroduction
+    from zope.interface import alsoProvides
+    from adhocracy_core.utils import get_sheet_field
+    logger.info('Running substanced evolve step 1: add new ITitle sheet')
+    registry = get_current_registry()
+    catalog = find_catalog(root, 'system')
+    path = catalog['path']
+    interfaces = catalog['interfaces']
+    query = path.eq('/mercator') \
+        & interfaces.eq(IMercatorProposalVersion) \
+        & interfaces.noteq(ITitle)
+    proposals = query.execute()
+    for proposal in proposals:
+        logger.info('updating {0}'.format(proposal))
+        introduction = get_sheet_field(proposal, IMercatorSubResources,
+                                       'introduction')
+        if introduction == '' or introduction is None:
+            # FIXME: the default value for references should be None
+            continue
+        alsoProvides(proposal, ITitle)
+        if 'title' not in introduction._sheets[IIntroduction.__identifier__]:
+            continue
+        value = introduction._sheets[IIntroduction.__identifier__]['title']
+        title = registry.content.get_sheet(proposal, ITitle)
+        title.set({'title': value})
+        del introduction._sheets[IIntroduction.__identifier__]['title']
+    logger.info('Finished substanced evolve step 1: add new ITitle sheet')
+
+
+def includeme(config):  # pragma: no cover
+    """Register evolution utilities and add evolution steps."""
+    config.add_evolution_step(evolve1_add_ititle_sheet_to_proposals)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
@@ -401,7 +401,8 @@ class IMercatorProposalVersion(IItemVersion):
 mercator_proposal_version_meta = itemversion_metadata._replace(
     content_name='MercatorProposalVersion',
     iresource=IMercatorProposalVersion,
-    extended_sheets=[adhocracy_mercator.sheets.mercator.IUserInfo,
+    extended_sheets=[adhocracy_mercator.sheets.mercator.ITitle,
+                     adhocracy_mercator.sheets.mercator.IUserInfo,
                      adhocracy_mercator.sheets.mercator.IHeardFrom,
                      adhocracy_mercator.sheets.mercator.IMercatorSubResources,
                      ICommentable,

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
@@ -27,6 +27,11 @@ class IMercatorSubResources(ISheet, ISheetReferenceAutoUpdateMarker):
     """Marker interface for commentable subresources of MercatorProposal."""
 
 
+class ITitle(ISheet, ISheetReferenceAutoUpdateMarker):
+
+    """Marker interface for the proposal title."""
+
+
 class IUserInfo(ISheet, ISheetReferenceAutoUpdateMarker):
 
     """Marker interface for information about the proposal submitter."""
@@ -90,6 +95,17 @@ class IExperience(ISheet, ISheetReferenceAutoUpdateMarker):
 class IHeardFrom(ISheet, ISheetReferenceAutoUpdateMarker):
 
     """Marker interface for heard from fields."""
+
+
+class TitleSchema(colander.MappingSchema):
+
+    """Data structure for the proposal title."""
+
+    title = SingleLine(validator=colander.Length(min=1, max=100))
+
+
+title_meta = sheet_metadata_defaults._replace(isheet=ITitle,
+                                              schema_class=TitleSchema)
 
 
 class UserInfoSchema(colander.MappingSchema):
@@ -285,7 +301,6 @@ class IntroductionSchema(colander.MappingSchema):
 
     """Data structure for the proposal introduction."""
 
-    title = SingleLine(validator=colander.Length(min=1, max=100))
     teaser = Text(validator=colander.Length(min=1, max=300))
     picture = Reference(reftype=IntroImageReference)
 
@@ -466,6 +481,7 @@ heardfrom_meta = sheet_metadata_defaults._replace(
 def includeme(config):
     """Register sheets."""
     add_sheet_to_registry(mercator_sub_resources_meta, config.registry)
+    add_sheet_to_registry(title_meta, config.registry)
     add_sheet_to_registry(userinfo_meta, config.registry)
     add_sheet_to_registry(organizationinfo_meta, config.registry)
     add_sheet_to_registry(introduction_meta, config.registry)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator.py
@@ -16,6 +16,12 @@ def integration(config):
 @mark.usefixtures('integration')
 class TestIncludeme:
 
+    def test_includeme_register_title_sheet(self, config):
+        from adhocracy_mercator.sheets.mercator import ITitle
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=ITitle)
+        assert get_sheet(context, ITitle)
+
     def test_includeme_register_userinfo_sheet(self, config):
         from adhocracy_mercator.sheets.mercator import IUserInfo
         from adhocracy_core.utils import get_sheet
@@ -87,6 +93,35 @@ class TestIncludeme:
         from adhocracy_core.utils import get_sheet
         context = testing.DummyResource(__provides__=IHeardFrom)
         assert get_sheet(context, IHeardFrom)
+
+
+class TestTitleSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator import title_meta
+        return title_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from zope.interface.verify import verifyObject
+        from adhocracy_core.interfaces import IResourceSheet
+        from adhocracy_mercator.sheets.mercator import ITitle
+        from adhocracy_mercator.sheets.mercator import TitleSchema
+        inst = meta.sheet_class(meta, context)
+        assert IResourceSheet.providedBy(inst)
+        assert verifyObject(IResourceSheet, inst)
+        assert inst.meta.isheet == ITitle
+        assert inst.meta.schema_class == TitleSchema
+
+    def test_get_empty(self, meta, context):
+        inst = meta.sheet_class(meta, context)
+        wanted = {'title': ''}
+        assert inst.get() == wanted
 
 
 class TestUserInfoSheet:
@@ -244,7 +279,7 @@ class TestIntroductionSheet:
 
     def test_get_empty(self, meta, context):
         inst = meta.sheet_class(meta, context)
-        wanted = {'picture': '', 'teaser': '', 'title': ''}
+        wanted = {'picture': '', 'teaser': ''}
         assert inst.get() == wanted
 
 

--- a/src/mercator/static/js/Packages/MercatorProposal/Create.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Create.html
@@ -314,7 +314,7 @@
                         <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_TITLE_LABEL" | translate }}:</span>
                         <input
                             type="text"
-                            data-ng-model="data.introduction.title"
+                            data-ng-model="data.title"
                             name="introduction-title"
                             maxlength="100"
                             placeholder="{{ 'TR__MAX_CHARS_100' | translate }}"

--- a/src/mercator/static/js/Packages/MercatorProposal/Detail.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Detail.html
@@ -18,7 +18,7 @@
                 <adh-like data-refers-to="{{path}}"></adh-like>
             </li>
         </ul>
-        <h1 class="mercator-proposal-cover-header">{{ data.introduction.title }}
+        <h1 class="mercator-proposal-cover-header">{{ data.title }}
             <a class="mercator-proposal-cover-show-comments" href="{{ path | adhResourceUrl:'comments' }}">
                 <i class="icon-speechbubble-document"></i> {{ data.commentCount }}
             </a>

--- a/src/mercator/static/js/Packages/MercatorProposal/ListItem.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/ListItem.html
@@ -7,7 +7,7 @@
                 {{data.organization_info.name}}
             </span>
         </p>
-        <h3 class="mercator-proposal-list-item-title">{{ data.introduction.title }}</h3>
+        <h3 class="mercator-proposal-list-item-title">{{ data.title.title }}</h3>
         <ul class="mercator-propsal-list-item-meta">
             <li class="mercator-propsal-list-item-meta-item mercator-propsal-list-item-meta-item-date">
                 <adh-time data-datetime="data.user_info.createtime" data-format="D/M/YYYY"></adh-time>

--- a/src/mercator/tests/acceptance/MercatorProposalFormPage.js
+++ b/src/mercator/tests/acceptance/MercatorProposalFormPage.js
@@ -19,7 +19,7 @@ var MercatorProposalFormPage = function() {
     this.organizationInfoName = this.form.element(by.model("data.organization_info.name"));
     this.organizationInfoCountry = this.form.element(by.model("data.organization_info.country"));
     this.organizationInfoWebsite = this.form.element(by.model("data.organization_info.website"));
-    this.introductionTitle = this.form.element(by.model("data.introduction.title"));
+    this.title = this.form.element(by.model("data.title"));
     this.introductionTeaser = this.form.element(by.model("data.introduction.teaser"));
     this.descriptionDescription = this.form.element(by.model("data.description.description"));
     this.locationLocationIsSpecific = this.form.element(by.model("data.location.location_is_specific"));
@@ -55,7 +55,7 @@ var MercatorProposalFormPage = function() {
         this.organizationInfoName.sendKeys("organization name");
         this.organizationInfoCountry.element(by.cssContainingText("option", "Chile")).click();
         this.organizationInfoWebsite.sendKeys("http://example.org");
-        this.introductionTitle.sendKeys("protitle");
+        this.title.sendKeys("protitle");
         this.introductionTeaser.sendKeys("proteaser");
         this.setImage("./proposalImageValid.png");
         this.descriptionDescription.sendKeys("prodescription");

--- a/src/mercator/tests/acceptance/test_mercator_filter.py
+++ b/src/mercator/tests/acceptance/test_mercator_filter.py
@@ -63,8 +63,8 @@ class TestMercatorFilter(object):
 
 def is_filtered(browser, proposals, location=None, budget=None):
     try:
-        introduction_sheet = 'adhocracy_mercator.sheets.mercator.IIntroduction'
-        title = lambda p: p[20]['body']['data'][introduction_sheet]['title']
+        title_sheet = 'adhocracy_mercator.sheets.mercator.ITitle'
+        title = lambda p: p[23]['body']['data'][title_sheet]['title']
         expected_titles = [title(p) for p in proposals
             if _verify_location(location, p) and
             _verify_budget(budget, p)]

--- a/src/mercator/tests/fixtures/fixturesMercatorProposals1.py
+++ b/src/mercator/tests/fixtures/fixturesMercatorProposals1.py
@@ -708,7 +708,6 @@ def _create_proposal():
                     "data": {
                         "adhocracy_mercator.sheets.mercator.IIntroduction": {
                             "teaser": get_random_string(300, whitespace=True),
-                            "title": name
                         },
                         "adhocracy_core.sheets.versions.IVersionable": {
                             "follows": [
@@ -770,6 +769,9 @@ def _create_proposal():
                 "body": {
                     "parent": "@pn31",
                     "data": {
+                        "adhocracy_mercator.sheets.mercator.ITitle": {
+                            "title": name
+                        },
                         "adhocracy_mercator.sheets.mercator.IHeardFrom": {
                             "heard_from_colleague": true,
                             "heard_elsewhere": "i'm not telling"


### PR DESCRIPTION
Backend part of a fix for #709. The main MercatorProposal resource now has a sheet `adhocracy_mercator.sheets.mercator.ITitle` with a "title" field. The IIntroduction doesn't have it any more.

Frontend still needs to be adapted before this can be merged.