### PR TITLE
Upgrade angular (1.3.10 -> 1.3.13) (fixes #738)

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -196,13 +196,13 @@ update-command = ${:command}
 recipe = bowerrecipe
 packages =
     jquery#1.11.1
-    angular#1.3.10
-    angular-animate#1.3.10
-    angular-aria#1.3.10
-    angular-messages#1.3.10
+    angular#1.3.13
+    angular-animate#1.3.13
+    angular-aria#1.3.13
+    angular-messages#1.3.13
+    angular-route#1.3.13
     angular-cache#3.2.5
     angular-elastic#2.4.2
-    angular-route#1.3.10
     angular-scroll#0.6.4
     angular-translate#2.6.0
     angular-translate-loader-static-files#2.6.0


### PR DESCRIPTION
This was a bug in angular which caused `element.off("click.adh_href")`
remove too many click events.

This is fixed in angular/angular.js#10866 in version 1.3.11 .