### PR TITLE
Fix: template mail variable missing with tests

### DIFF
--- a/etc/test.ini
+++ b/etc/test.ini
@@ -12,7 +12,9 @@ adhocracy.ws_url =
 mail.default_sender = support@unconfigured.domain
 # Email address receiving abuse complaints
 adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
-
+# Template for the subjects of messages sent to users (Python format string,
+# {} is the user-supplied title)
+adhocracy.message_user_subject = Adhocracy Info: {}
 adhocracy.skip_registration_mail = true
 
 [server:main]


### PR DESCRIPTION
- Add adhocracy.message_user_subject variable to test.ini