### PR TITLE
Fix session token check on load

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
@@ -4,6 +4,8 @@
 
 import modernizr = require("modernizr");
 
+import AdhConfig = require("../Config/Config");
+
 import AdhHttp = require("../Http/Http");
 import AdhMetaApi = require("../Http/MetaApi");
 import AdhPreliminaryNames = require("../PreliminaryNames/PreliminaryNames");
@@ -35,6 +37,7 @@ export var register = (angular, config, meta_api) => {
     describe("[]", () => {
         var adhMetaApi : AdhMetaApi.MetaApiQuery;
         var adhPreliminaryNames : AdhPreliminaryNames.Service;
+        var adhConfig : AdhConfig.IService;
         var adhHttp : AdhHttp.Service<any>;
         var adhCache;
         var adhUser : AdhUser.Service;
@@ -70,6 +73,7 @@ export var register = (angular, config, meta_api) => {
                     $window
                 ) => {
                     return (new AdhUser.Service(
+                        adhConfig,
                         adhHttp,
                         adhCache,
                         $q,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -12,6 +12,7 @@ export var register = () => {
     describe("User", () => {
         describe("Service", () => {
             var adhUser;
+            var adhConfigMock;
             var adhHttpMock;
             var adhCacheMock;
             var httpMock;
@@ -20,6 +21,10 @@ export var register = () => {
             var elementMock;
             var angularMock;
             var modernizrMock;
+
+            adhConfigMock = {
+                rest_url: "mock"
+            };
 
             beforeEach(() => {
                 adhHttpMock = <any>jasmine.createSpyObj("adhHttpMock", ["get", "post", "postRaw"]);
@@ -36,12 +41,13 @@ export var register = () => {
                     memoize: (path, subkey, closure) => closure()
                 };
 
-                httpMock = <any>jasmine.createSpyObj("httpMock", ["post"]);
+                httpMock = <any>jasmine.createSpyObj("httpMock", ["head", "post"]);
                 httpMock.defaults = {
                     headers: {
                         common: {}
                     }
                 };
+                httpMock.head.and.returnValue(q.when({data: {}}));
                 httpMock.post.and.returnValue(q.when({data: {}}));
 
                 rootScopeMock = jasmine.createSpyObj("rootScope", ["$apply"]);
@@ -60,7 +66,7 @@ export var register = () => {
                 };
 
                 adhUser = new AdhUser.Service(
-                    adhHttpMock, adhCacheMock, <any>q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock);
+                    adhConfigMock, adhHttpMock, adhCacheMock, <any>q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock);
             });
 
             it("registers a handler on 'storage' DOM events", () => {
@@ -82,7 +88,9 @@ export var register = () => {
                 it("calls 'enableToken' if 'user-token' and 'user-path' exist in storage", () => {
                     windowMock.localStorage.getItem.and.returnValue("huhu");
                     fn();
-                    expect(adhUser.enableToken).toHaveBeenCalledWith("huhu", "huhu", true);
+                    _.defer(() => {
+                        expect(adhUser.enableToken).toHaveBeenCalledWith("huhu", "huhu");
+                    });
                 });
 
                 it("calls 'deleteToken' if neither 'user-token' nor 'user-path' exist in storage", (done) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -85,11 +85,12 @@ export var register = () => {
                     fn = <any>args[1];
                 });
 
-                it("calls 'enableToken' if 'user-token' and 'user-path' exist in storage", () => {
+                it("calls 'enableToken' if 'user-token' and 'user-path' exist in storage", (done) => {
                     windowMock.localStorage.getItem.and.returnValue("huhu");
                     fn();
                     _.defer(() => {
                         expect(adhUser.enableToken).toHaveBeenCalledWith("huhu", "huhu");
+                        done();
                     });
                 });
 


### PR DESCRIPTION
This does two things:

- It only enables the token *after* the validity check. Previously there
was a race condition due to the temporary token activation.
- It uses a better validity check: it calls HEAD on rest_url:/ instead
of calling POST on the user path. This is possible due to #713.