### PR TITLE
eventManager priority

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManager.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManager.ts
@@ -9,6 +9,10 @@ export class EventManager {
     private handlers : {[event : string]: {[id : number]: (arg : any) => void}} = {};
     private nextID : number = 0;
 
+    constructor(
+        private $q : ng.IQService
+    ) {}
+
     private getNextID() : number {
         return this.nextID++;
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManagerSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/EventManager/EventManagerSpec.ts
@@ -1,13 +1,16 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
+import q = require("q");
+
 import AdhEventManager = require("./EventManager");
+
 
 export var register = () => {
     describe("EventManager", () => {
         var eventManager : AdhEventManager.EventManager;
 
         beforeEach(() => {
-            eventManager = new AdhEventManager.EventManager();
+            eventManager = new AdhEventManager.EventManager(q);
         });
 
         it("allows to set handlers for events", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
@@ -102,7 +102,7 @@ export class Service {
             if (!_.contains(this.nonResourceUrls, path)) {
                 wshandle = this.adhWebSocket.register(path, (msg) => {
                     this.invalidate(path);
-                });
+                }, 1000);
             }
             cached = {
                 wshandle: wshandle,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
@@ -20,8 +20,11 @@ export class Service {
 
     private messageEventManager : AdhEventManager.EventManager;
 
-    constructor(adhEventManagerClass : typeof AdhEventManager.EventManager) {
-        this.messageEventManager = new adhEventManagerClass();
+    constructor(
+        $q : ng.IQService,
+        adhEventManagerClass : typeof AdhEventManager.EventManager
+    ) {
+        this.messageEventManager = new adhEventManagerClass($q);
     }
 
     public register(path : string, callback : (msg : ILocalEvent) => void) : number {
@@ -110,5 +113,5 @@ export var register = (angular) => {
         .module(moduleName, [
             AdhEventManager.moduleName
         ])
-        .service("adhLocalSocket", ["adhEventManagerClass", Service]);
+        .service("adhLocalSocket", ["$q", "adhEventManagerClass", Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
@@ -13,7 +13,7 @@ export interface ILocalEvent extends AdhWebSocket.IServerEvent {}
  * local client.  In many cases this is desired because we do not want the
  * UI to change all the time but we do want it to update on user interaction.
  *
- * FIXME: Currewntly, very few events are actually triggered.
+ * FIXME: Currently, very few events are actually triggered.
  */
 export class Service {
     "use strict";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/LocalSocket/LocalSocket.ts
@@ -27,8 +27,8 @@ export class Service {
         this.messageEventManager = new adhEventManagerClass($q);
     }
 
-    public register(path : string, callback : (msg : ILocalEvent) => void) : number {
-        return this.messageEventManager.on(path, callback);
+    public register(path : string, callback : (msg : ILocalEvent) => void, priority? : number) : number {
+        return this.messageEventManager.on(path, callback, priority);
     }
 
     public unregister(path : string, id : number) : void {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -360,7 +360,7 @@ export var register = (angular) => {
             AdhUser.moduleName,
             AdhWebSocket.moduleName
         ])
-        .service("adhRateEventManager", ["adhEventManagerClass", (cls) => new cls()])
+        .service("adhRateEventManager", ["$q", "adhEventManagerClass", ($q, cls) => new cls($q)])
         .directive("adhRate", [
             "$q",
             "adhRateEventManager",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
@@ -124,7 +124,7 @@ export var resourceWrapper = () => {
                 }
             };
 
-            self.eventManager = new adhEventManagerClass();
+            self.eventManager = new adhEventManagerClass($q);
 
             self.registerResourceDirective = (promise : ng.IPromise<ResourcesBase.Resource[]>) => {
                 resourcePromises.push(promise);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -154,7 +154,7 @@ export class Service {
     ) {
         var self : Service = this;
 
-        this.eventManager = new adhEventManagerClass();
+        this.eventManager = new adhEventManagerClass($q);
         this.currentSpace = "";
         this.data = {"": <any>{}};
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
@@ -196,3 +196,27 @@ export var qFilter = (promises : ng.IPromise<any>[], $q : ng.IQService) : ng.IPr
 
     return deferred.promise;
 };
+
+
+/**
+ * Execute a list of functions, one after the other.
+ */
+export var qSync = ($q : ng.IQService) => (list : Function[]) : ng.IPromise<any> => {
+    var deferred = $q.defer();
+    var i = 0;
+
+    var next = () => {
+        if (i < list.length) {
+            var fn = list[i];
+            $q.when(fn()).finally(() => {
+                i++;
+                next();
+            });
+        } else {
+            deferred.resolve();
+        }
+    };
+
+    next();
+    return deferred.promise;
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocket.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocket.ts
@@ -104,14 +104,14 @@ export class Service {
         return this.connected;
     }
 
-    public register(path : string, callback : (msg : IServerEvent) => void) : number {
+    public register(path : string, callback : (msg : IServerEvent) => void, priority? : number) : number {
         if (!this.registrations[path]) {
             this.registrations[path] = 1;
             this.send("subscribe", path);
         } else {
             this.registrations[path] += 1;
         }
-        return this.messageEventManager.on(path, callback);
+        return this.messageEventManager.on(path, callback, priority);
     }
 
     public unregister(path : string, id : number) : void {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocket.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocket.ts
@@ -69,15 +69,16 @@ export class Service {
     private domEventManager : AdhEventManager.EventManager;
 
     constructor(
+        $q : ng.IQService,
         private adhConfig : AdhConfig.IService,
         private adhEventManagerClass : typeof AdhEventManager.EventManager,
         rawWebSocketFactory : (uri : string) => IRawWebSocket
     ) {
         this.connected = false;
-        this.messageEventManager = new adhEventManagerClass();
+        this.messageEventManager = new adhEventManagerClass($q);
         this.registrations = {};
 
-        this.domEventManager = new adhEventManagerClass();
+        this.domEventManager = new adhEventManagerClass($q);
 
         this.ws = rawWebSocketFactory(adhConfig.ws_url);
         this.ws.onmessage = (ev) => {
@@ -209,5 +210,5 @@ export var register = (angular) => {
             AdhEventManager.moduleName
         ])
         .factory("adhRawWebSocketFactory", ["Modernizr", rawWebSocketFactoryFactory])
-        .service("adhWebSocket", ["adhConfig", "adhEventManagerClass", "adhRawWebSocketFactory", Service]);
+        .service("adhWebSocket", ["$q", "adhConfig", "adhEventManagerClass", "adhRawWebSocketFactory", Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocketSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/WebSocket/WebSocketSpec.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
+import q = require("q");
+
 import AdhConfig = require("../Config/Config");
 import AdhWebSocket = require("./WebSocket");
 
@@ -30,7 +32,7 @@ export var register = () => {
                 };
                 adhRawWebSocketMock = jasmine.createSpyObj("adhRawWebSocketFactory", ["send", "addEventListener"]);
                 adhEventManagerMocks = [];
-                service = new AdhWebSocket.Service(config, adhEventManagerClassMock, () => adhRawWebSocketMock);
+                service = new AdhWebSocket.Service(q, config, adhEventManagerClassMock, () => adhRawWebSocketMock);
             });
 
             it("calls the send method of web socket on every register to different resources", () => {


### PR DESCRIPTION
This adds an optional `priority` argument to `eventManager.on()`. Handlers with a higher priority are executed first.

This is meant to fix race conditions between HTTP cache invalidation and other webSocket message handlers. Unfortunately, it did not fix any visible issues.

I think this might be useful in some way, but does not fix anything yet. In addition, unittests are missing. So there might be significant bugs, e.g. the execution order might be reversed.

Another very relevant issue is that race conditions might still exist between different messages. For example, the server sends a `modified` message to a resource and a `modified_child` message to its parent. The order in which these are executed is not touched by this pull request.