### PR TITLE
Normalize URL in http cache (fixes #663)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
@@ -38,7 +38,7 @@ export class Service {
         private DSCacheFactory
     ) {
         this.setupCache(DSCacheFactory, adhWebSocket);
-        this.nonResourceUrls = _.map(AdhHttp.nonResourcePaths, (path) => adhConfig.rest_url + "/" + path);
+        this.nonResourceUrls = _.map(AdhHttp.nonResourcePaths, (path) => adhConfig.rest_url + "/" + path + "/");
     }
 
     private setupCache(DSCacheFactory, adhWebSocket : AdhWebSocket.Service) : void {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Cache.ts
@@ -96,6 +96,9 @@ export class Service {
     }
 
     private getOrSetCached(path : string) : IHttpCacheItem {
+        // FIXME: normalize URLs everywhere
+        path = path.replace(/\/*$/, "/");
+
         var cached = this.cache.get(path);
         if (typeof cached === "undefined") {
             var wshandle;


### PR DESCRIPTION
after attempting fixes for #663 in #754 and #756 I finally found something that actually works: I noticed that there were multiple event handlers for the mercator platform pool because the URL was not normalized. This is merely a workaround. I created #757 for a more general solution.