### PR TITLE
Hide registration form after success

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -1,5 +1,5 @@
 <div class="register">
-    <form novalidate="novalidate" class="register-form" name="registerForm" data-ng-submit="register()">
+    <form novalidate="novalidate" class="register-form" name="registerForm" data-ng-if="!success" data-ng-submit="register()">
         <div class="form-error" ng-repeat="error in errors track by $index">
             <p>{{ error | translate }}</p>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -65,15 +65,16 @@
             <p>{{ "TR__REGISTRATION_LOGIN_INSTEAD" | translate }}
             <a href="/login">{{ "TR__LINK_HERE" | translate }}</a></p>
         </div>
-        <a class="register-cancel" href="" ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
-        <div class="register-support">
-            {{ "TR__REGISTRATION_SUPPORT" | translate }} <br />
-            <a href="mailto:{{supportEmail}}?subject=Trouble%20with%20registration">{{ supportEmail }}</a>
-        </div>
     </form>
 
     <div data-ng-if="success" class="register-success">
         <p>{{ "TR__REGISTER_SUCCESS" | translate }}</p>
         <p>{{ "TR__CALL_FOR_ACTIVATION" | translate:{siteName: siteName} }}</p>
+    </div>
+
+    <a class="register-cancel" href="" ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
+    <div class="register-support">
+        {{ "TR__REGISTRATION_SUPPORT" | translate }} <br />
+        <a href="mailto:{{supportEmail}}?subject=Trouble%20with%20registration">{{ supportEmail }}</a>
     </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_login.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_login.scss
@@ -145,7 +145,8 @@ Register Dialog.
 }
 
 .register-support,
-.login-support {
+.login-support,
+.register-cancel {
     font-size: $font-size-small;
     text-align: center;
 }


### PR DESCRIPTION
The previous behavior was very confusing. In particular, on small screens users didn't see the email hint at all.