### PR TITLE
Check for session readiness before proposal routing

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -20,6 +20,7 @@ export interface IRegisterResponse {}
 
 export class Service {
     public loggedIn : boolean;
+    public ready : ng.IPromise<any>;
     public data : IUserBasic;
     public token : string;
     public userPath : string;
@@ -36,6 +37,15 @@ export class Service {
         private Modernizr
     ) {
         var _self : Service = this;
+
+        var deferred = $q.defer();
+        _self.ready = deferred.promise;
+        var unwatch = this.$rootScope.$watch(() => _self.loggedIn, ((loggedIn) => {
+            if (typeof loggedIn !== "undefined") {
+                deferred.resolve(null);
+                unwatch();
+            }
+        }));
 
         if (_self.Modernizr.localstorage) {
             var win = _self.angular.element(_self.$window);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -50,7 +50,7 @@ export var register = () => {
                 httpMock.head.and.returnValue(q.when({data: {}}));
                 httpMock.post.and.returnValue(q.when({data: {}}));
 
-                rootScopeMock = jasmine.createSpyObj("rootScope", ["$apply"]);
+                rootScopeMock = jasmine.createSpyObj("rootScope", ["$apply", "$watch"]);
 
                 windowMock = {
                     localStorage: <any>jasmine.createSpyObj("localStorage", ["getItem", "setItem", "removeItem"])

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -280,17 +280,21 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIPoolWithAssets.content_type, "create_proposal", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
-                    return (resource : RIPoolWithAssets) => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {};
-                            }
-                        });
-                    };
-                }]);
+                .specific(RIPoolWithAssets.content_type, "create_proposal",
+                    ["adhHttp", "adhUser", (adhHttp : AdhHttp.Service<any>, adhUser) => {
+                        return (resource : RIPoolWithAssets) => {
+                            return adhUser.ready.then(() => {
+                                return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                                    if (!options.POST) {
+                                        throw 401;
+                                    } else {
+                                        return {};
+                                    }
+                                });
+                            });
+                        };
+                    }]
+                );
         }])
         .directive("adhMercatorWorkbench", ["adhConfig", mercatorWorkbenchDirective])
         .directive("adhCommentColumn", ["adhTopLevelState", "adhConfig", commentColumnDirective])


### PR DESCRIPTION
This is a workaround for #762.

It's not very intrusive, as it only causes waiting for the session on protected resources. At the moment, this is only done for the MercatorProposal create resource manually. This should be done in a more generic way, e.g. in `TopLevelState`.