### PR TITLE
Disable varnish by default in development setup

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,11 +1,11 @@
 [buildout]
 extends =
-    src/adhocracy_core/varnish.cfg
     src/adhocracy_core/sources.cfg
     src/adhocracy_core/base.cfg
     src/adhocracy_core/checkcode.cfg
     src/adhocracy_core/sphinx.cfg
     src/adhocracy_core/wheels.cfg
+#    src/adhocracy_core/varnish.cfg
     src/adhocracy_frontend/sources.cfg
     src/adhocracy_frontend/base.cfg
     src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -32,7 +32,8 @@ static_directories = src/mercator/static ${adhocracy:frontend.core.static_dir}
 
 [supervisor]
 groups =
-    10 adhocracy zeo,autobahn,backend,varnish,frontend
+    10 adhocracy zeo,autobahn,backend,frontend
+#    10 adhocracy zeo,autobahn,backend,varnish,frontend
     20 adhocracy_test test_zeo,test_autobahn,test_backend,test_frontend
 
 [sphinx_documentation]

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -67,11 +67,10 @@ programs =
     10 zeo (autostart=false stdout_logfile=var/log/zeo.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/runzeo [-C etc/zeo.conf] ${buildout:directory} true
     20 autobahn (autostart=false stdout_logfile=var/log/autobahn.log stderr_logfile=NONE) ${buildout:bin-directory}/start_ws_server [etc/development.ini] ${buildout:directory} true
     30 backend (autostart=false stdout_logfile=var/log/adhocracy_backend.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/gunicorn [--paste etc/development.ini --forwarded-allow-ips="${servers:proxy_ip}"] ${buildout:directory} true
-    50 varnish (autostart=false stdout_logfile=var/log/varnish.log stderr_logfile=NONE) ${buildout:bin-directory}/varnishd ${buildout:directory} true
     100 test_zeo (autostart=false stdout_logfile=var/log/test_zeo.log stderr_logfile=NONE startsecs=2 stopwaitsecs=10) ${buildout:bin-directory}/runzeo [-C etc/test_zeo.conf] ${buildout:directory} true
     200 test_autobahn (autostart=false stdout_logfile=var/log/test_autobahn.log stderr_logfile=NONE) ${buildout:bin-directory}/start_ws_server [etc/test_with_ws.ini] ${buildout:directory} true
     300 test_backend (autostart=false stdout_logfile=var/log/test_adhocracy_backend.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/gunicorn [--paste etc/test.ini --forwarded-allow-ips="${servers:proxy_ip}"] ${buildout:directory} true
     300 test_backend_with_ws (autostart=false stdout_logfile=var/log/test_adhocracy_backend_with_ws.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/gunicorn [--paste etc/test_with_ws.ini --forwarded-allow-ips="${servers:proxy_ip}"] ${buildout:directory} true
 groups =
-    10 adhocracy zeo,autobahn,backend,varnish
+    10 adhocracy zeo,autobahn,backend
     20 adhocracy_test test_zeo,test_autobahn,test_backend

--- a/src/adhocracy_core/varnish.cfg
+++ b/src/adhocracy_core/varnish.cfg
@@ -27,4 +27,8 @@ input = inline:
 output = ${buildout:bin-directory}/varnishd
 mode = 755
 
-
+[supervisor]
+programs +=
+    50 varnish (autostart=false stdout_logfile=var/log/varnish.log stderr_logfile=NONE) ${buildout:bin-directory}/varnishd ${buildout:directory} true
+groups =
+    10 adhocracy zeo,autobahn,backend,varnish


### PR DESCRIPTION
#747 added varnish and builds it by default. However, most developers don't need varnish during development. Also, it slows down travis considerably.