### PR TITLE
Sort comments - newest first

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/de.json
@@ -19,6 +19,7 @@
     "TR__DESCRIPTION": "Beschreibung",
     "TR__DISCLAIMER": "Hinweis",
     "TR__EDIT": "bearbeiten",
+    "TR__EDITED": "bearbeitet",
     "TR__EMAIL": "E-Mail",
     "TR__EMAIL_OR_USERNAME": "E-Mail oder Benutzername",
     "TR__ERROR_FORMAT_EMAIL": "E-Mail-Format ist ungültig.",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/en.json
@@ -19,6 +19,7 @@
     "TR__DESCRIPTION": "description",
     "TR__DISCLAIMER": "disclaimer",
     "TR__EDIT": "edit",
+    "TR__EDITED": "edited",
     "TR__EMAIL": "email",
     "TR__EMAIL_OR_USERNAME": "email or username",
     "TR__ERROR_FORMAT_EMAIL": "Email format is incorrect.",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
@@ -1,3 +1,7 @@
+/// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
+
+import _ = require("lodash");
+
 import AdhComment = require("./Comment");
 import AdhListing = require("../Listing/Listing");
 import AdhUtil = require("../Util/Util");
@@ -87,5 +91,9 @@ export class CommentAdapter extends ListingCommentableAdapter implements AdhComm
 
     commentCount(resource : RICommentVersion) : number {
         return AdhUtil.eachItemOnce(resource.data[SICommentable.nick].comments).length;
+    }
+
+    edited(resource : RICommentVersion) : boolean {
+        return !(<any>_).endsWith(resource.path, "/VERSION_0000001/");
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -89,6 +89,8 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
 
         directive.scope.refersTo = "@";
         directive.scope.poolPath = "@";
+        directive.scope.frontendOrderPredicate = "=?";
+        directive.scope.frontendOrderReverse = "=?";
 
         directive.controller = ["adhTopLevelState", "$scope", (
             adhTopLevelState : AdhTopLevelState.Service,
@@ -231,7 +233,9 @@ export var adhCommentListing = (adhConfig : AdhConfig.IService) => {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/CommentListing.html",
         scope: {
-            path: "@"
+            path: "@",
+            frontendOrderReverse: "=?",
+            frontendOrderPredicate: "=?"
         },
         controller: ["adhTopLevelState", "$location", (
             adhTopLevelState : AdhTopLevelState.Service,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -38,6 +38,7 @@ export interface ICommentAdapter<T extends ResourcesBase.Resource> extends AdhLi
     creationDate(resource : T) : string;
     modificationDate(resource : T) : string;
     commentCount(resource : T) : number;
+    edited(resource : T) : boolean;
 }
 
 
@@ -163,7 +164,8 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
                     modificationDate: this.adapter.modificationDate(resource),
                     commentCount: this.adapter.commentCount(resource),
                     comments: this.adapter.elemRefs(resource),
-                    replyPoolPath: this.adapter.poolPath(resource)
+                    replyPoolPath: this.adapter.poolPath(resource),
+                    edited: this.adapter.edited(resource)
                 };
                 this.adhPermissions.bindScope(scope, scope.data.replyPoolPath, "poolOptions");
                 this.adhPermissions.bindScope(scope, AdhUtil.parentPath(scope.data.path), "commentItemOptions");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -6,7 +6,10 @@
                     <adh-user-meta data-path="{{data.creator}}"></adh-user-meta>
                 </span>
                 <span class="comment-header-date">
-                    <adh-time data-datetime="data.modificationDate"></adh-time>
+                    <adh-time data-datetime="data.creationDate"></adh-time>
+                </span>
+                <span class="comment-header-edited" data-ng-if="data.edited">
+                    ({{ "TR__EDITED" | translate }})
                 </span>
             </div>
             <div class="comment-header-column2">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -61,10 +61,12 @@
     </div>
     <div class="comment-children">
         <adh-resource-wrapper
-            data-ng-repeat="comment in data.comments">
+            data-ng-repeat="comment in data.comments | orderBy:frontendOrderPredicate:frontendOrderReverse">
             <adh-comment-resource
                 data-path="{{comment}}"
-                data-mode="display">
+                data-mode="display"
+                data-frontend-order-predicate="frontendOrderPredicate"
+                data-frontend-order-reverse="frontendOrderReverse">
             </adh-comment-resource>
         </adh-resource-wrapper>
     </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentListing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentListing.html
@@ -1,6 +1,8 @@
 <adh-comment-listing-partial
     data-path="{{path}}"
-    data-empty-text="{{ 'TR__COMMENT_EMPTY_TEXT' | translate }}">
+    data-empty-text="{{ 'TR__COMMENT_EMPTY_TEXT' | translate }}"
+    data-frontend-order-predicate="frontendOrderPredicate"
+    data-frontend-order-reverse="frontendOrderReverse">
     <div data-ng-switch="transclusionId">
         <adh-resource-wrapper
             data-on-submit="onCreate()"
@@ -18,7 +20,9 @@
             data-ng-switch-when="element-id">
             <adh-comment-resource
                 data-path="{{element}}"
-                data-mode="display">
+                data-mode="display"
+                data-frontend-order-predicate="frontendOrderPredicate"
+                data-frontend-order-reverse="frontendOrderReverse">
             </adh-comment-resource>
         </adh-resource-wrapper>
     </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentSpec.ts
@@ -25,7 +25,7 @@ export var register = () => {
                 pkg_path: "mock"
             };
 
-            adapterMock = <any>jasmine.createSpyObj("adapterMock", ["create", "createItem", "content", "refersTo", "creator",
+            adapterMock = <any>jasmine.createSpyObj("adapterMock", ["create", "createItem", "content", "edited", "refersTo", "creator",
                 "creationDate", "modificationDate", "commentCount", "elemRefs", "poolPath"]);
             adapterMock.create.and.returnValue(RESOURCE);
             adapterMock.createItem.and.returnValue(RESOURCE);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
@@ -3,7 +3,7 @@
         <adh-inject data-transclusion-id="create-form-id"></adh-inject>
     </div>
     <ol class="listing-elements">
-        <li class="listing-element" data-ng-repeat="element in elements | orderBy:frontendOrderPredicate:frontendOrderReverse">
+        <li class="listing-element" data-ng-repeat="element in elements">
             <adh-inject data-transclusion-id="element-id"></adh-inject>
         </li>
     </ol>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
@@ -3,7 +3,7 @@
         <adh-inject data-transclusion-id="create-form-id"></adh-inject>
     </div>
     <ol class="listing-elements">
-        <li class="listing-element" data-ng-repeat="element in elements">
+        <li class="listing-element" data-ng-repeat="element in elements | orderBy:frontendOrderPredicate:frontendOrderReverse">
             <adh-inject data-transclusion-id="element-id"></adh-inject>
         </li>
     </ol>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -53,6 +53,9 @@ export interface IFacet {
     items : IFacetItem[];
 }
 
+export type IPredicateItem = string | ((string) => string);
+export type IPredicate = IPredicateItem | IPredicateItem[];
+
 export interface ListingScope<Container> extends ng.IScope {
     path : string;
     contentType? : string;
@@ -65,6 +68,8 @@ export interface ListingScope<Container> extends ng.IScope {
     poolOptions : AdhHttp.IOptions;
     createPath? : string;
     elements : string[];
+    frontendOrderPredicate : IPredicate;
+    frontendOrderReverse : boolean;
     update : (boolean?) => ng.IPromise<void>;
     wshandle : number;
     clear : () => void;
@@ -106,6 +111,8 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 contentType: "@",
                 facets: "=?",
                 sort: "=?",
+                frontendOrderPredicate: "=?",
+                frontendOrderReverse: "=?",
                 params: "=?",
                 update: "=?",
                 noCreateForm: "=?",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -151,9 +151,6 @@ export class Listing<Container extends ResourcesBase.Resource> {
                             });
                         });
                     }
-                    if ($scope.sort) {
-                        params["sort"] = $scope.sort.replace(/^-/, "");
-                    }
                     return adhHttp.get($scope.path, params, warmup).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);
@@ -162,10 +159,6 @@ export class Listing<Container extends ResourcesBase.Resource> {
                         // because otherwise sometimes the already reversed sorted list (from cache) would be
                         // reversed again
                         var elements = _.clone(_self.containerAdapter.elemRefs($scope.container));
-
-                        if ($scope.sort && $scope.sort[0] === "-") {
-                            elements.reverse();
-                        }
 
                         // trying to maintain compatible with builtin orderBy functionality, but
                         // allow to not specify predicate or reverse.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -102,6 +102,7 @@ export var register = () => {
                 });
 
                 describe("controller", () => {
+                    var filterMock = () => { ; };
                     var adhHttpMock;
                     var adhPreliminaryNamesMock;
                     var adhPermissionsMock;
@@ -122,8 +123,8 @@ export var register = () => {
                             $watch: jasmine.createSpy("$watch")
                         };
 
-                        var controller = directive.controller[4];
-                        controller(scope, adhHttpMock, adhPreliminaryNamesMock, adhPermissionsMock);
+                        var controller = directive.controller[5];
+                        controller(filterMock, scope, adhHttpMock, adhPreliminaryNamesMock, adhPermissionsMock);
                     });
 
                     it("watches scope.path", () => {

--- a/src/mercator/static/js/Packages/MercatorProposal/Listing.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Listing.html
@@ -3,6 +3,8 @@
     data-content-type="{{contentType}}"
     data-facets="facets"
     data-sort="sort"
+    data-frontend-order-predicate="frontendOrderPredicate"
+    data-frontend-order-reverse="frontendOrderReverse"
     data-params="params"
     data-update="update"
     data-no-create-form="true"

--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -836,6 +836,8 @@ export var listing = (adhConfig : AdhConfig.IService) => {
             update: "=?",
             facets: "=?",
             sort: "=?",
+            frontendOrderPredicate: "=?",
+            frontendOrderReverse: "=?",
             params: "=?"
         }
     };

--- a/src/mercator/static/js/Packages/MercatorWorkbench/CommentColumn.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/CommentColumn.html
@@ -6,6 +6,8 @@
     <adh-comment-listing
         data-ng-if="commentableUrl"
         data-path="{{commentableUrl}}"
+        data-frontend-order-predicate="frontendOrderPredicate"
+        data-frontend-order-reverse="frontendOrderReverse"
         data-ng-switch-when="body">
     </adh-comment-listing>
 

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalListingColumn.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalListingColumn.html
@@ -23,6 +23,8 @@
         data-update="shared.update"
         data-facets="shared.facets"
         data-sort="shared.sort"
+        data-frontend-order-predicate="frontendOrderPredicate"
+        data-frontend-order-reverse="frontendOrderReverse"
     >
     </adh-mercator-proposal-listing>
 </div>

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -167,7 +167,8 @@ export var mercatorProposalListingColumnDirective = (adhTopLevelState : AdhTopLe
                     {key: "above_50000", name: "50000 € +"}
                 ]
             }];
-            scope.shared.sort = "-rates";
+            scope.shared.sort = "rates";
+            scope.frontendOrderReverse = true;
         }
     };
 };

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -82,6 +82,8 @@ export var commentColumnDirective = (adhTopLevelState : AdhTopLevelState.Service
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             bindVariablesAndClear(scope, column, adhTopLevelState, ["proposalUrl", "commentableUrl"]);
+            scope.frontendOrderPredicate = (id) => id;
+            scope.frontendOrderReverse = true;
         }
     };
 };


### PR DESCRIPTION
Above all, this orders comments in *any* useful way instead of leaving them unsorted.

Furthermore, it changes the comment metadata that way that it always shows the creation time, not the modification time. If a comment has been modified, a `(edited)` label is added.

This is all subject to change, but shall make the comment thread as it is a bit more coherent and make the sorting understandable to the users.