### PR TITLE
2015 02 cs messaging templates

### DIFF
--- a/etc/development.ini
+++ b/etc/development.ini
@@ -29,8 +29,8 @@ adhocracy.use_mail_queue = true
 # Email address receiving abuse complaints
 adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,
-# {} is the user-supplied title)
-adhocracy.message_user_subject = Adhocracy Info: {}
+# usable variables: {site_name}, {sender_name}, {title})
+adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 # If true, new user accounts are activated immediately without email verification
 adhocracy.skip_registration_mail = false
 # URL of the Varnish cache

--- a/etc/test.ini
+++ b/etc/test.ini
@@ -13,8 +13,8 @@ mail.default_sender = support@unconfigured.domain
 # Email address receiving abuse complaints
 adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,
-# {} is the user-supplied title)
-adhocracy.message_user_subject = Adhocracy Info: {}
+# usable variables: {site_name}, {sender_name}, {title})
+adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 adhocracy.skip_registration_mail = true
 
 [server:main]

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -40,8 +40,8 @@ adhocracy.use_mail_queue = true
 # Email address receiving abuse complaints
 adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,
-# {} is the user-supplied title)
-adhocracy.message_user_subject = Adhocracy Info: {}
+# usable variables: {site_name}, {sender_name}, {title})
+adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 # If true, new user accounts are activated immediately without email verification
 adhocracy.skip_registration_mail = false
 # Mode to set http cache headers for resources, valid entries: no_cache, without_proxy_cache, with_proxy_cache

--- a/src/adhocracy_core/adhocracy_core/templates/abuse_complaint.txt.mako
+++ b/src/adhocracy_core/adhocracy_core/templates/abuse_complaint.txt.mako
@@ -5,8 +5,11 @@ URL: ${url}
 Reason given for complaint:
 ${remark}
 
-% if user_path is None:
+% if user_name is None:
 The complaint was sent by an anonymous user.
 % else:
-The complaint was sent by user ${user_path}.
+The complaint was sent by user ${user_name}.
+
+Click here to visit ${user_name}’s profile:
+${user_url}
 % endif

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -443,7 +443,8 @@ def app_settings(request) -> dict:
     settings['mail.default_sender'] = 'substanced_demo@example.com'
     settings['adhocracy.abuse_handler_mail'] \
         = 'abuse_handler@unconfigured.domain'
-    settings['adhocracy.message_user_subject'] = 'Adhocracy Info: {}'
+    settings['adhocracy.message_user_subject'] =\
+        '[{site_name}] Message from {sender_name}: {title}'
     return settings
 
 


### PR DESCRIPTION
Fixes #779 and fixes #745. Two bugs with one stone!

I changed

    adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}

in various places, e.g. `development.ini`, but it must still be changed in the config used in the Mercator staging and live system (don't know how to do that).

Several of the splinter tests failed for me (timeout problems), but I suppose that's unrelated (at least I don't see a connection).