### PR TITLE
Handle uploaded assets represented as BytesIO correctly

### DIFF
--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -3,6 +3,7 @@ from collections import Sequence
 from collections import OrderedDict
 from datetime import datetime
 import decimal
+import io
 import os
 import re
 
@@ -795,7 +796,10 @@ class FileStoreType(colander.SchemaType):
                           title=value.filename)
             # We add the size as an extra attribute since get_size() doesn't
             # work before the transaction has been committed
-            result.size = os.fstat(value.file.fileno()).st_size
+            if isinstance(value.file, io.BytesIO):
+                result.size = len(value.file.getvalue())
+            else:
+                result.size = os.fstat(value.file.fileno()).st_size
         except Exception as err:
             raise colander.Invalid(node, msg=str(err), value=value)
         if result.size > self.SIZE_LIMIT:

--- a/src/adhocracy_core/adhocracy_core/schema/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/schema/test_init.py
@@ -1115,6 +1115,18 @@ class TestFileStoreType:
         assert inst.deserialize(None, value) == mock_response
         assert mock_response.size == mock_fstat_result.st_size
 
+    def test_deserialize_bytesio(self, inst, monkeypatch):
+        from adhocracy_core import schema
+        from io import BytesIO
+        mock_response = Mock()
+        mock_file_constructor = Mock(spec=schema.File,
+                                     return_value=mock_response)
+        monkeypatch.setattr(schema, 'File', mock_file_constructor)
+        value = Mock()
+        value.file = BytesIO(b'abcdef')
+        assert inst.deserialize(None, value) == mock_response
+        assert mock_response.size == 6
+
     def test_deserialize_exception(self, inst, monkeypatch):
         from adhocracy_core import schema
         mock_file_constructor = Mock(spec=schema.File, side_effect=IOError)


### PR DESCRIPTION
Fixes #687.