### PR TITLE
Fix emails not being queued in the test config

### DIFF
--- a/etc/test.ini
+++ b/etc/test.ini
@@ -3,13 +3,17 @@ use = egg:adhocracy_mercator
 pyramid.prevent_http_cache = true
 pyramid.includes =
     pyramid_tm
-    pyramid_mailer.testing
+    pyramid_mailer
 zodbconn.uri = memory://
 adhocracy.add_test_users = true
 substanced.secret = seekri1
 substanced.autosync_catalogs = true
-adhocracy.ws_url = 
+adhocracy.ws_url =
+
+mail.queue_path = %(here)s/../var/mail
 mail.default_sender = support@unconfigured.domain
+# Set to false to use the SMTP server instead
+adhocracy.use_mail_queue = true
 # Email address receiving abuse complaints
 adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # Template for the subjects of messages sent to users (Python format string,


### PR DESCRIPTION
This works to send email/message in the test version (tested manually on port 9090). I'm not sure of the implication for the other tests  (unit tests using the pyramid_mailer.testing setup?)