### PR TITLE
Better check for comment edited state

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
@@ -90,7 +90,9 @@ export class CommentAdapter extends ListingCommentableAdapter implements AdhComm
     }
 
     edited(resource : RICommentVersion) : boolean {
+        // NOTE: this is lexicographic comparison. Might break if the datetime
+        // encoding changes.
         var meta = resource.data[SIMetadata.nick];
-        return (meta.modification_date > meta.item_creation_date);
+        return meta.modification_date > meta.item_creation_date;
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
@@ -1,7 +1,3 @@
-/// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
-
-import _ = require("lodash");
-
 import AdhComment = require("./Comment");
 import AdhListing = require("../Listing/Listing");
 import AdhUtil = require("../Util/Util");
@@ -94,6 +90,7 @@ export class CommentAdapter extends ListingCommentableAdapter implements AdhComm
     }
 
     edited(resource : RICommentVersion) : boolean {
-        return !(<any>_).endsWith(resource.path, "/VERSION_0000001/");
+        var meta = resource.data[SIMetadata.nick];
+        return (meta.modification_date > meta.item_creation_date);
     }
 }


### PR DESCRIPTION
This is possible due to the fix of #770.

Note that subcomments still show up as edited as soon as parent comments have been edited due to our updating model. This is not related to this though.