### PR TITLE
Fix backend-based list sorting

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -151,6 +151,9 @@ export class Listing<Container extends ResourcesBase.Resource> {
                             });
                         });
                     }
+                    if ($scope.sort) {
+                        params["sort"] = $scope.sort;
+                    }
                     return adhHttp.get($scope.path, params, warmup).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = _self.containerAdapter.poolPath($scope.container);


### PR DESCRIPTION
This got accidently removed completely in
e4c72fb170ee6a23f70572140e8108fe521b54b9, instead of just removing the
minus-sign.