### PR TITLE
switch to stable relatively-sticky

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
@@ -36,7 +36,7 @@ require.config({
         q: "../lib/q/q",
         modernizr: "../lib2/modernizr/modernizr-2.8.3.min",
         moment: "../lib/moment/min/moment-with-locales.min",
-        sticky: "../lib/sticky-kit/jquery.sticky-kit.min",
+        sticky: "../lib/relatively-sticky/jquery.relatively-sticky.min",
         socialSharePrivacy: "../lib/jquery.socialshareprivacy/jquery.socialshareprivacy.min",
         adhTemplates: "./templates",
         polyfiller: "../lib/webshim/js-webshim/minified/polyfiller"

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -214,7 +214,7 @@ packages =
     blanket#1.1.5
     q#1.1.2
     moment#2.9.0
-    xi/sticky-kit#refactor
+    relatively-sticky#2.0.0
     ng-flow#2.6.0
     dhepper/socialshareprivacy#protocol-relative-urls
     webshim#1.15.6


### PR DESCRIPTION
I did a proper release of my sticky-kit fork. So now we can point to version 2.0.0 instead of some branch.