### PR TITLE
avoid multiple calls to adhPermissions.bindScope()

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -149,6 +149,10 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
             return this.update(instance);
         };
 
+        this.adhPermissions.bindScope(scope, () => scope.data && scope.data.replyPoolPath, "poolOptions");
+        this.adhPermissions.bindScope(scope, () => scope.data && AdhUtil.parentPath(scope.data.path), "commentItemOptions");
+        this.adhPermissions.bindScope(scope, () => scope.data && scope.data.path, "versionOptions");
+
         return instance;
     }
 
@@ -185,9 +189,6 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
                     replyPoolPath: this.adapter.poolPath(resource),
                     edited: this.adapter.edited(resource)
                 };
-                this.adhPermissions.bindScope(scope, scope.data.replyPoolPath, "poolOptions");
-                this.adhPermissions.bindScope(scope, AdhUtil.parentPath(scope.data.path), "commentItemOptions");
-                this.adhPermissions.bindScope(scope, scope.data.path, "versionOptions");
             });
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -150,7 +150,11 @@ export class CommentResource<R extends ResourcesBase.Resource> extends AdhResour
         };
 
         this.adhPermissions.bindScope(scope, () => scope.data && scope.data.replyPoolPath, "poolOptions");
-        this.adhPermissions.bindScope(scope, () => scope.data && AdhUtil.parentPath(scope.data.path), "commentItemOptions");
+        this.adhPermissions.bindScope(scope, () => {
+            if (scope.data && scope.data.path) {
+                return AdhUtil.parentPath(scope.data.path);
+            }
+        }, "commentItemOptions");
         this.adhPermissions.bindScope(scope, () => scope.data && scope.data.path, "versionOptions");
 
         return instance;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -131,6 +131,8 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 adhPreliminaryNames : AdhPreliminaryNames.Service,
                 adhPermissions : AdhPermissions.Service
             ) : void => {
+                adhPermissions.bindScope($scope, () => $scope.poolPath, "poolOptions");
+
                 $scope.createPath = adhPreliminaryNames.nextPreliminary();
 
                 $scope.update = (warmup? : boolean) : ng.IPromise<void> => {
@@ -176,8 +178,6 @@ export class Listing<Container extends ResourcesBase.Resource> {
                         } else {
                             $scope.elements = elements;
                         }
-
-                        return adhPermissions.bindScope($scope, $scope.poolPath, "poolOptions");
                     });
                 };
 


### PR DESCRIPTION
this is similar to #800. `bindScope()` does not expose the unregister function returned by `$watch`.

The solution here is different though: Instead of exposing the unregister function, we pass a function to `$watch`. This way, we do not need to keep track of the unregister function in the calling scope. The watch will automatically update and unregister when the scope is destroyed.