### PR TITLE
Upgrade protractor (1.7.0 -> 1.8.0)

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -155,7 +155,7 @@ input = inline:
             "tslint": "2.1.1",
             "bower": "1.3.12",
             "jasmine-node": "2.0.0",
-            "protractor": "1.7.0",
+            "protractor": "1.8.0",
             "sync-exec": "0.4.0",
             "q": "1.1.2",
             "lodash": "3.2.0",


### PR DESCRIPTION
This should allow to use firefox 35/36 instead of chromedriver.

Haven't tried it though.

This doesn't solve #858.