### PR TITLE
Enable piwik-based frontend tracking

### DIFF
--- a/etc/frontend_development.ini
+++ b/etc/frontend_development.ini
@@ -36,6 +36,15 @@ adhocracy.frontend.site_name = Adhocracy Test Site
 # URL to terms and services
 adhocracy.frontend.terms_url =
 
+# Piwik tracking configuration
+#adhocracy.frontend.piwik_enabled = true
+#adhocracy.frontend.piwik_host =
+#adhocracy.frontend.piwik_site_id =
+# Tracking also works without cookie
+#adhocracy.frontend.piwik_use_cookies =
+# User id tracking (not recommended; should be used with care cause privacy)
+#adhocracy.frontend.piwik_track_user_id =
+
 # Canonical frontend base URL. If this is set, frontend links will always
 # prefix links with this URL. If this is an embedding URL, it should end with
 # #!.

--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -45,6 +45,14 @@ def config_view(request):
     config['cachebust'] = asbool(settings.get('cachebust.enabled', 'false'))
     config['cachebust_suffix'] = cachebust_query_params(request)
     config['terms_url'] = settings.get('adhocracy.frontend.terms_url')
+    config['piwik_enabled'] = asbool(settings.get(
+        'adhocracy.frontend.piwik_enabled', 'false'))
+    config['piwik_host'] = settings.get('adhocracy.frontend.piwik_host')
+    config['piwik_site_id'] = settings.get('adhocracy.frontend.piwik_site_id')
+    config['piwik_use_cookies'] = asbool(settings.get(
+        'adhocracy.frontend.piwik_use_cookies', 'false'))
+    config['piwik_track_user_id'] = asbool(settings.get(
+        'adhocracy.frontend.piwik_track_user_id', 'false'))
     return config
 
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -44,6 +44,7 @@ import AdhResourceWidgets = require("./Packages/ResourceWidgets/ResourceWidgets"
 import AdhShareSocial = require("./Packages/ShareSocial/ShareSocial");
 import AdhSticky = require("./Packages/Sticky/Sticky");
 import AdhTopLevelState = require("./Packages/TopLevelState/TopLevelState");
+import AdhTracking = require("./Packages/Tracking/Tracking");
 import AdhUser = require("./Packages/User/User");
 import AdhUserViews = require("./Packages/User/Views");
 import AdhWebSocket = require("./Packages/WebSocket/WebSocket");
@@ -84,7 +85,8 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhEmbed.moduleName,
         AdhResourceArea.moduleName,
         AdhProposal.moduleName,
-        AdhSticky.moduleName
+        AdhSticky.moduleName,
+        AdhTracking.moduleName
     ];
 
     if (config.cachebust) {
@@ -164,6 +166,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhShareSocial.register(angular);
     AdhSticky.register(angular);
     AdhTopLevelState.register(angular);
+    AdhTracking.register(angular);
     AdhUser.register(angular);
     AdhUserViews.register(angular);
     AdhWebSocket.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
@@ -24,4 +24,9 @@ export interface IService {
     cachebust_suffix : string;
     debug : boolean;
     terms_url : string;
+    piwik_enabled : string;
+    piwik_host : string;
+    piwik_site_id : string;
+    piwik_use_cookies : boolean;
+    piwik_track_user_id : boolean;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
@@ -76,6 +76,7 @@ export var register = (angular, config, meta_api) => {
                         adhConfig,
                         adhHttp,
                         adhCache,
+                        null,
                         $q,
                         $http,
                         $rootScope,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -27,6 +27,7 @@ import _ = require("lodash");
 
 import AdhConfig = require("../Config/Config");
 import AdhEventManager = require("../EventManager/EventManager");
+import AdhTracking = require("../Tracking/Tracking");
 import AdhUser = require("../User/User");
 
 var pkgLocation = "/TopLevelState";
@@ -94,11 +95,14 @@ export class Provider {
         };
         this.spaceDefaults = {};
 
-        this.$get = ["adhEventManagerClass", "adhUser", "$location", "$rootScope", "$http", "$q", "$injector", "$templateRequest",
-            (adhEventManagerClass, adhUser, $location, $rootScope, $http, $q, $injector, $templateRequest) => {
-                return new Service(self, adhEventManagerClass, adhUser, $location, $rootScope, $http, $q, $injector,
-                                   $templateRequest);
-            }];
+        this.$get = [
+            "adhEventManagerClass", "adhTracking", "adhUser",
+            "$location", "$rootScope", "$http", "$q", "$injector", "$templateRequest",
+            (adhEventManagerClass, adhTracking, adhUser, $location, $rootScope, $http, $q, $injector, $templateRequest) => {
+                return new Service(
+                    self, adhEventManagerClass, adhTracking, adhUser, $location, $rootScope, $http, $q, $injector, $templateRequest);
+            }
+        ];
     }
 
     public when(prefix : string, factory : (...args : any[]) => IAreaInput);
@@ -144,6 +148,7 @@ export class Service {
     constructor(
         private provider : Provider,
         adhEventManagerClass : typeof AdhEventManager.EventManager,
+        private adhTracking : AdhTracking.Service,
         private adhUser : AdhUser.Service,
         private $location : ng.ILocationService,
         private $rootScope : ng.IScope,
@@ -350,6 +355,7 @@ export class Service {
                 this.$location.search(key2, ret.search[key2]);
             }
         }
+        this.adhTracking.trackPageView(this.$location.absUrl());
     }
 
     private _set(key : string, value) : boolean {
@@ -542,6 +548,7 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhEventManager.moduleName,
+            AdhTracking.moduleName,
             AdhUser.moduleName
         ])
         .provider("adhTopLevelState", Provider)

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
@@ -15,6 +15,7 @@ export var register = () => {
             var rootScopeMock;
             var injectorMock;
             var providerMock;
+            var adhTrackingMock;
             var trigger;
             var off;
             var on;
@@ -25,12 +26,14 @@ export var register = () => {
                 on = jasmine.createSpy("on");
                 off = jasmine.createSpy("off");
                 trigger = jasmine.createSpy("trigger");
-                locationMock = jasmine.createSpyObj("locationMock", ["url", "search", "path", "replace"]);
+                locationMock = jasmine.createSpyObj("locationMock", ["absUrl", "url", "search", "path", "replace"]);
                 rootScopeMock = jasmine.createSpyObj("rootScopeMock", ["$watch"]);
 
                 providerMock = jasmine.createSpyObj("providerMock", ["getArea", "getSpaceDefaults"]);
                 providerMock.getArea.and.callThrough();
                 providerMock.getSpaceDefaults.and.callThrough();
+
+                adhTrackingMock = jasmine.createSpyObj("adhTrackingMock", ["trackPageView", "setUserId"]);
 
                 injectorMock = jasmine.createSpyObj("injectorMock", ["invoke"]);
                 injectorMock.invoke.and.returnValue(areaInput);
@@ -42,7 +45,8 @@ export var register = () => {
                 };
 
                 adhTopLevelState = <any>new AdhTopLevelState.Service(
-                    providerMock, eventManagerMockClass, null, locationMock, rootScopeMock, null, <any>q, injectorMock, null);
+                    providerMock, eventManagerMockClass, adhTrackingMock, null,
+                    locationMock, rootScopeMock, null, <any>q, injectorMock, null);
 
                 spyOn(adhTopLevelState, "toLocation");
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/Tracking.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/Tracking.ts
@@ -50,11 +50,24 @@ export class Service {
         }
     }
 
-    public setUser(userPath : string) {
-        if (this.trackUserId) {
+    public setLoginState(loggedIn : boolean) {
+        if (this.trackingEnabled) {
+            // NOTE: tracking login state on a page base
+            this.setCustomVariable(1, "user type", loggedIn ? "registered" : "anonymous", "page");
+        }
+    }
+
+    public setUserId(userPath : string) {
+        if (this.trackingEnabled && this.trackUserId) {
             this.$window._paq.push(["setUserId", userPath]);
         }
     }
+
+    /* TODO: nicer API without explicit index argument */
+    private setCustomVariable(index : number, name : string, value : string, scope : string) {
+        this.$window._paq.push(["setCustomVariable", index, name, value, scope]);
+    }
+
 }
 
 export var moduleName = "adhTracking";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/Tracking.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/Tracking.ts
@@ -1,0 +1,66 @@
+/// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import AdhConfig = require("../Config/Config");
+
+export interface PiwikWindow extends Window {
+    _paq : any[];
+}
+
+export class Service {
+    private trackingEnabled : boolean;
+    private trackUserId : boolean;
+    private _paq : any[];
+
+    constructor(
+        private $q : ng.IQService,
+        private $window : PiwikWindow,
+        private adhConfig : AdhConfig.IService
+    ) {
+        this.trackingEnabled = !!adhConfig.piwik_enabled;
+        this.trackUserId = !!adhConfig.piwik_track_user_id;
+
+        if (this.trackingEnabled) {
+            this._paq = [];
+            $window._paq = this._paq;
+
+            // Setup piwik
+            this.$window._paq.push(["setSiteId", adhConfig.piwik_site_id]);
+            this.$window._paq.push(["setTrackerUrl", adhConfig.piwik_host + "piwik.php"]);
+
+            if (!adhConfig.piwik_use_cookies) {
+                this.$window._paq.push(["disableCookies"]);
+            }
+
+            // Load piwik
+            $.ajax({
+                url: adhConfig.piwik_host + "piwik.js",
+                dataType: "script",
+                success: () => {
+                    console.log(
+                        "piwik loaded from " + adhConfig.piwik_host
+                        + " with cookies " + (!!adhConfig.piwik_use_cookies ? "enabled" : "disabled"));
+                }
+            });
+        }
+    }
+
+    public trackPageView(url : string, title? : string) {
+        if (this.trackingEnabled) {
+            this.$window._paq.push(["trackLink", url, "link"]);
+        }
+    }
+
+    public setUser(userPath : string) {
+        if (this.trackUserId) {
+            this.$window._paq.push(["setUserId", userPath]);
+        }
+    }
+}
+
+export var moduleName = "adhTracking";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [])
+        .service("adhTracking", ["$q", "$window", "adhConfig", Service]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/TrackingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tracking/TrackingSpec.ts
@@ -1,0 +1,9 @@
+/// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
+
+// import Tracking = require("./Tracking");
+
+export var register = () => {
+    describe("Tracking", () => {
+        // NYI
+    });
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -4,6 +4,7 @@ import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
 import AdhCache = require("../Http/Cache");
 import AdhLocale = require("../Locale/Locale");
+import AdhTracking = require("../Tracking/Tracking");
 
 import SIPasswordAuthentication = require("../../Resources_/adhocracy_core/sheets/principal/IPasswordAuthentication");
 import SIUserBasic = require("../../Resources_/adhocracy_core/sheets/principal/IUserBasic");
@@ -30,6 +31,7 @@ export class Service {
         private adhConfig : AdhConfig.IService,
         private adhHttp : AdhHttp.Service<any>,
         private adhCache : AdhCache.Service,
+        private adhTracking : AdhTracking.Service,
         private $q : ng.IQService,
         private $http : ng.IHttpService,
         private $rootScope : ng.IScope,
@@ -126,6 +128,7 @@ export class Service {
         _self.userPath = userPath;
         _self.$http.defaults.headers.common["X-User-Token"] = token;
         _self.$http.defaults.headers.common["X-User-Path"] = userPath;
+        _self.adhTracking.setUser(userPath);
 
         return _self.loadUser(userPath);
     }
@@ -157,6 +160,7 @@ export class Service {
         _self.userPath = undefined;
         _self.data = undefined;
         _self.loggedIn = false;
+        _self.adhTracking.setUser(null);
 
         _self.adhCache.invalidateAll();
     }
@@ -233,5 +237,7 @@ export var register = (angular) => {
             AdhHttp.moduleName,
             AdhLocale.moduleName,
         ])
-        .service("adhUser", ["adhConfig", "adhHttp", "adhCache", "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", Service]);
+        .service("adhUser", [
+            "adhConfig", "adhHttp", "adhCache", "adhTracking",
+            "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -128,7 +128,8 @@ export class Service {
         _self.userPath = userPath;
         _self.$http.defaults.headers.common["X-User-Token"] = token;
         _self.$http.defaults.headers.common["X-User-Path"] = userPath;
-        _self.adhTracking.setUser(userPath);
+        _self.adhTracking.setLoginState(true);
+        _self.adhTracking.setUserId(userPath);
 
         return _self.loadUser(userPath);
     }
@@ -160,7 +161,8 @@ export class Service {
         _self.userPath = undefined;
         _self.data = undefined;
         _self.loggedIn = false;
-        _self.adhTracking.setUser(null);
+        _self.adhTracking.setLoginState(false);
+        _self.adhTracking.setUserId(null);
 
         _self.adhCache.invalidateAll();
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -15,6 +15,7 @@ export var register = () => {
             var adhConfigMock;
             var adhHttpMock;
             var adhCacheMock;
+            var adhTrackingMock;
             var httpMock;
             var rootScopeMock;
             var windowMock;
@@ -41,6 +42,8 @@ export var register = () => {
                     memoize: (path, subkey, closure) => closure()
                 };
 
+                adhTrackingMock = jasmine.createSpyObj("adhTrackingMock", ["trackPageView", "setUser"]);
+
                 httpMock = <any>jasmine.createSpyObj("httpMock", ["head", "post"]);
                 httpMock.defaults = {
                     headers: {
@@ -66,7 +69,8 @@ export var register = () => {
                 };
 
                 adhUser = new AdhUser.Service(
-                    adhConfigMock, adhHttpMock, adhCacheMock, <any>q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock);
+                    adhConfigMock, adhHttpMock, adhCacheMock, adhTrackingMock,
+                    <any>q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock);
             });
 
             it("registers a handler on 'storage' DOM events", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -42,7 +42,7 @@ export var register = () => {
                     memoize: (path, subkey, closure) => closure()
                 };
 
-                adhTrackingMock = jasmine.createSpyObj("adhTrackingMock", ["trackPageView", "setUser"]);
+                adhTrackingMock = jasmine.createSpyObj("adhTrackingMock", ["trackPageView", "setLoginState", "setUserId"]);
 
                 httpMock = <any>jasmine.createSpyObj("httpMock", ["head", "post"]);
                 httpMock.defaults = {

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -47,6 +47,7 @@ import AdhResourceWidgets = require("./Packages/ResourceWidgets/ResourceWidgets"
 import AdhShareSocial = require("./Packages/ShareSocial/ShareSocial");
 import AdhSticky = require("./Packages/Sticky/Sticky");
 import AdhTopLevelState = require("./Packages/TopLevelState/TopLevelState");
+import AdhTracking = require("./Packages/Tracking/Tracking");
 import AdhUser = require("./Packages/User/User");
 import AdhUserViews = require("./Packages/User/Views");
 import AdhWebSocket = require("./Packages/WebSocket/WebSocket");
@@ -90,7 +91,8 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhMercatorWorkbench.moduleName,
         AdhResourceArea.moduleName,
         AdhProposal.moduleName,
-        AdhSticky.moduleName
+        AdhSticky.moduleName,
+        AdhTracking.moduleName
     ];
 
     if (config.cachebust) {
@@ -184,6 +186,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhShareSocial.register(angular);
     AdhSticky.register(angular);
     AdhTopLevelState.register(angular);
+    AdhTracking.register(angular);
     AdhUser.register(angular);
     AdhUserViews.register(angular);
     AdhWebSocket.register(angular);


### PR DESCRIPTION
This allows to 

- track users (browser settings; session click paths with login state)
- specify whether cookies shall be used
- specify whether user ids shall be tracked (I'm very much against that in non-research projects, but I'm in favor of leaving this feature in in order to learn more about tracking).

This is just a beginning. We should further evaluate what we actually want to track, communicate that properly to the users and allow more fine-grained opt-out (e.g. track browser settings and click paths, but independently).