### PR TITLE
Pin chrome to version 40 in protractor in sauce

### DIFF
--- a/etc/protractorConfSauce.js
+++ b/etc/protractorConfSauce.js
@@ -12,6 +12,7 @@ exports.config = {
 
     capabilities: {
         "browserName": "chrome",
+        "version": "40",
         "tunnel-identifier": process.env.TRAVIS_JOB_NUMBER,
         "build": process.env.TRAVIS_BUILD_NUMBER,
         "name": name


### PR DESCRIPTION
The pinning can be removed again after March 9th. Alternatively, this pull request can also be ignored and closed on March 9.

I just got an email from Saucelabs which stated that since a while Chrome was pinned to 35 (due to a temporary incompatibility with newer chromedriver). From March 9 on if the version is skipped, it is automatically the newest version again.

This is just in order to test whether the tests are more reliable. And, @pallix, as a note why things might have behaved differently on saucelabs than locally...