### PR TITLE
Build adhocracy in debug mode

### DIFF
--- a/src/adhocracy_core/sphinx.cfg
+++ b/src/adhocracy_core/sphinx.cfg
@@ -32,7 +32,7 @@ dependent-scripts = true
 eggs = Sphinx
        repoze.sphinx.autointerface
        sphinx-autodoc-annotation
-       adhocracy_core[test]
+       adhocracy_core[debug]
        adhocracy_sample
-       adhocracy_frontend
-       mercator[test]
+       adhocracy_frontend[debug]
+       mercator[debug]


### PR DESCRIPTION
This allows use of ipdb and friends. Actually we intended it to be that way, it just accidently got overwritten by the sphinx part.