### PR TITLE
Allow different templates for different processes

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -36,6 +36,7 @@ import AdhLocalSocket = require("./Packages/LocalSocket/LocalSocket");
 import AdhMovingColumns = require("./Packages/MovingColumns/MovingColumns");
 import AdhPermissions = require("./Packages/Permissions/Permissions");
 import AdhPreliminaryNames = require("./Packages/PreliminaryNames/PreliminaryNames");
+import AdhProcess = require("./Packages/Process/Process");
 import AdhProposal = require("./Packages/Proposal/Proposal");
 import AdhRate = require("./Packages/Rate/Rate");
 import AdhAngularHelpers = require("./Packages/AngularHelpers/AngularHelpers");
@@ -159,6 +160,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhPermissions.register(angular);
     AdhPreliminaryNames.register(angular);
     AdhProposal.register(angular);
+    AdhProcess.register(angular);
     AdhRate.register(angular);
     AdhAngularHelpers.register(angular);
     AdhResourceArea.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
@@ -1,0 +1,59 @@
+/// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import AdhTopLevelState = require("../TopLevelState/TopLevelState");
+
+
+export class Provider implements angular.IServiceProvider {
+    public templateUrls : {[processType : string]: string};
+    public $get;
+
+    constructor () {
+        this.templateUrls = {};
+
+        this.$get = ["$templateRequest", ($templateRequest) => {
+            return new Service(this, $templateRequest);
+        }];
+    }
+}
+
+export class Service {
+    constructor(
+        private provider : Provider,
+        private $templateRequest : angular.ITemplateRequestService
+    ) {}
+
+    public getTemplate(processType : string) : angular.IPromise<string> {
+        var templateUrl = this.provider.templateUrls[processType];
+        return this.$templateRequest(templateUrl);
+    }
+}
+
+export var processViewDirective = (
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhProcess : Service,
+    $compile : angular.ICompileService
+) => {
+    return {
+        restrict: "E",
+        link: (scope, element) => {
+            adhTopLevelState.on("processType", (processType) => {
+                adhProcess.getTemplate(processType).then((template) => {
+                    element.html(template);
+                    $compile(element.contents())(scope);
+                });
+            });
+        }
+    };
+};
+
+
+export var moduleName = "adhProcess";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhTopLevelState.moduleName
+        ])
+        .provider("adhProcess", Provider)
+        .directive("adhProcessView", ["adhTopLevelState", "adhProcess", "$compile", processViewDirective]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
@@ -4,14 +4,14 @@ import AdhTopLevelState = require("../TopLevelState/TopLevelState");
 
 
 export class Provider implements angular.IServiceProvider {
-    public templateUrls : {[processType : string]: string};
+    public templateFactories : {[processType : string]: Function};
     public $get;
 
     constructor () {
-        this.templateUrls = {};
+        this.templateFactories = {};
 
-        this.$get = ["$templateRequest", ($templateRequest) => {
-            return new Service(this, $templateRequest);
+        this.$get = ["$injector", ($injector) => {
+            return new Service(this, $injector);
         }];
     }
 }
@@ -19,12 +19,12 @@ export class Provider implements angular.IServiceProvider {
 export class Service {
     constructor(
         private provider : Provider,
-        private $templateRequest : angular.ITemplateRequestService
+        private $injector : angular.auto.IInjectorService
     ) {}
 
     public getTemplate(processType : string) : angular.IPromise<string> {
-        var templateUrl = this.provider.templateUrls[processType];
-        return this.$templateRequest(templateUrl);
+        var fn = this.provider.templateFactories[processType];
+        return this.$injector.invoke(fn);
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/ProcessSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/ProcessSpec.ts
@@ -1,0 +1,11 @@
+/// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
+
+import AdhProcess = require("./Process");
+
+export var register = () => {
+    describe("Tracking", () => {
+        xit("is defined", () => {
+            expect(AdhProcess).toBeDefined();
+        });
+    });
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/ProcessSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/ProcessSpec.ts
@@ -3,7 +3,7 @@
 import AdhProcess = require("./Process");
 
 export var register = () => {
-    describe("Tracking", () => {
+    describe("Process", () => {
         xit("is defined", () => {
             expect(AdhProcess).toBeDefined();
         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -2,6 +2,7 @@ import _ = require("lodash");
 
 import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
+import AdhProcess = require("../Process/Process");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
 
 
@@ -88,7 +89,7 @@ export class Provider implements angular.IServiceProvider {
  * possible. In those cases, search overwrites specifics overwrites meta overwrites defaults.
  */
 export class Service implements AdhTopLevelState.IAreaInput {
-    public template : string = "<adh-page-wrapper><adh-mercator-workbench></adh-mercator-workbench></adh-page-wrapper>";
+    public template : string = "<adh-page-wrapper><adh-process-view></adh-process-view></adh-page-wrapper>";
 
     constructor(
         private provider : Provider,
@@ -223,6 +224,7 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhHttp.moduleName,
+            AdhProcess.moduleName,
             AdhTopLevelState.moduleName
         ])
         .config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -39,6 +39,7 @@ import AdhMercatorWorkbench = require("./Packages/MercatorWorkbench/MercatorWork
 import AdhMovingColumns = require("./Packages/MovingColumns/MovingColumns");
 import AdhPermissions = require("./Packages/Permissions/Permissions");
 import AdhPreliminaryNames = require("./Packages/PreliminaryNames/PreliminaryNames");
+import AdhProcess = require("./Packages/Process/Process");
 import AdhProposal = require("./Packages/Proposal/Proposal");
 import AdhRate = require("./Packages/Rate/Rate");
 import AdhAngularHelpers = require("./Packages/AngularHelpers/AngularHelpers");
@@ -179,6 +180,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhPermissions.register(angular);
     AdhPreliminaryNames.register(angular);
     AdhProposal.register(angular);
+    AdhProcess.register(angular);
     AdhRate.register(angular);
     AdhAngularHelpers.register(angular);
     AdhResourceArea.register(angular);

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -302,6 +302,11 @@ export var register = (angular) => {
                     }]
                 );
         }])
+        .config(["adhProcessProvider", (adhProcessProvider) => {
+            adhProcessProvider.templateFactories[""] = ["$q", ($q : angular.IQService) => {
+                return $q.when("<adh-mercator-workbench></adh-mercator-workbench>");
+            }];
+        }])
         .directive("adhMercatorWorkbench", ["adhConfig", mercatorWorkbenchDirective])
         .directive("adhCommentColumn", ["adhTopLevelState", "adhConfig", commentColumnDirective])
         .directive("adhMercatorProposalCreateColumn", ["adhTopLevelState", "adhConfig", "$location", mercatorProposalCreateColumnDirective])


### PR DESCRIPTION
This allows to define different templates for different process types.

It does not yet include a system to conigure topLevelState differently for different processes. That will be done in a separate pull request.