### PR TITLE
Allow to build adhocracy_core without mercator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,8 @@ src/pyramid_cachebust/
 /package.json
 /node_modules
 /Gruntfile.js
-src/mercator/mercator/build
+src/adhocracy_frontend/adhocracy_frontend/build/
+src/mercator/mercator/build/
 /tmp
 /wheelhouse
 /share

--- a/buildout-core.cfg
+++ b/buildout-core.cfg
@@ -1,0 +1,45 @@
+[buildout]
+extends =
+    src/adhocracy_core/sources.cfg
+    src/adhocracy_core/base.cfg
+    src/adhocracy_core/checkcode.cfg
+    src/adhocracy_core/sphinx.cfg
+    src/adhocracy_core/wheels.cfg
+#    src/adhocracy_core/varnish.cfg
+    src/adhocracy_frontend/sources.cfg
+    src/adhocracy_frontend/base.cfg
+    src/adhocracy_frontend/checkcode_and_compile.cfg
+develop =
+    src/adhocracy_core
+    src/adhocracy_sample
+    src/adhocracy_frontend
+parts +=
+    make_wheels
+
+[adhocracy]
+frontend.static_dir = src/adhocracy_frontend/adhocracy_frontend/build
+
+[test_run_unit]
+package_paths = src/adhocracy_core src/adhocracy_sample
+
+[test_run_all]
+package_paths = src/adhocracy_frontend/adhocracy_frontend/tests/unit ${test_run_unit:package_paths}
+
+[merge_static_directories]
+static_directories = ${adhocracy:frontend.core.static_dir}
+
+[supervisor]
+groups =
+    10 adhocracy zeo,autobahn,backend,frontend
+#    10 adhocracy zeo,autobahn,backend,varnish,frontend
+    20 adhocracy_test test_zeo,test_autobahn,test_backend,test_frontend
+
+[varnish]
+port = 8088
+vcl = ${buildout:directory}/etc/varnish.vcl
+
+[make_wheels]
+wheels +=
+       src/adhocracy_frontend
+
+[eggs]

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
@@ -16,7 +16,7 @@ import RIUsersService = require("../../Resources_/adhocracy_core/resources/princ
 
 var pkgLocation = "/DocumentWorkbench";
 
-interface IDocumentWorkbenchScope extends angular.IScope {
+export interface IDocumentWorkbenchScope extends angular.IScope {
     path : string;
     user : AdhUser.Service;
     websocketTestPaths : string;
@@ -24,8 +24,8 @@ interface IDocumentWorkbenchScope extends angular.IScope {
 }
 
 export var documentWorkbench = (
-    adhConfig : AdhConfig.IService
-    adhUser : AdhUser.Service,
+    adhConfig : AdhConfig.IService,
+    adhUser : AdhUser.Service
 ) => {
     return {
         restrict: "E",
@@ -35,7 +35,7 @@ export var documentWorkbench = (
             scope.contentType = RIProposal.content_type;
             scope.user = adhUser;
             scope.websocketTestPaths = JSON.stringify([scope.path]);
-        }]
+        }
     };
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -168,16 +168,6 @@ parent: comment
     margin-bottom: 10px / $font-size-small * 1em;
     padding-top: 3px / $font-size-small * 1em;
 
-    .comment-header-icon {
-        @include border-radius(50%);
-        float: left;
-        font-size: 150%;
-        line-height: 1.333;
-        width: 1.333em;
-        text-align: center;
-        background: white;
-    }
-
     .comment-header-creator,
     .comment-header-date,
     .comment-header-links {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -50,7 +50,6 @@ is selected, no state is applied.
     border-left: 1px solid $color-brand-one-normal;
 
     .comment {
-        @include triangle-tl;
         padding-right: 0;
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -45,6 +45,7 @@ $font-weight-introvert: 400;
 $font-weight-normal: normal;
 $font-weight-introvert: 400;
 $font-weight-extrovert: 900;
+$font-size-smaller: 10px;
 $font-size-small: 12px;
 $font-size-normal: 14px;
 $font-size-plus: 16px;

--- a/src/mercator/mercator/static/stylesheets/scss/components/_comment_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_comment_theme.scss
@@ -1,0 +1,3 @@
+.comment-children .comment {
+    @include triangle-tl;
+}


### PR DESCRIPTION
This adds a `buildout-core.cfg` besides `buildout.cfg`. Note that the frontend doesn't work yet, but at least it builds.

This is relevant, because we're going to base the senat code on core, not on mercator.