### PR TITLE
Fix: Don't change creator on autoupdate

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -158,10 +158,11 @@ def _create_new_version(event, appstruct) -> IResource:
     appstructs[event.isheet.__identifier__] = appstruct
     registry = event.registry
     iresource = get_iresource(event.object)
+    creator = get_sheet(event.object, IMetadata, registry).get()['creator']
     new_version = registry.content.create(iresource.__identifier__,
                                           parent=event.object.__parent__,
                                           appstructs=appstructs,
-                                          creator=event.creator,
+                                          creator=creator,
                                           registry=event.registry,
                                           root_versions=event.root_versions,
                                           is_batchmode=event.is_batchmode,


### PR DESCRIPTION
Otherwise this leads to setting the creator of the updated resource to
be the creator of the resource triggering the update.

Missing:

- [ ] adapt tests
- [ ] write migration for broken resources