### PR TITLE
Do only show toplevel outdated npms

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -182,7 +182,7 @@ node.js
 ```````
 ::
 
-    bin/npm --prefix node_modules outdated
+    bin/npm --prefix node_modules --depth 0 outdated
 
 bower
 `````


### PR DESCRIPTION
I updated the docs so that the command for outdated gems now only shows
one level. This way we do not see the outdated dependencies of the gems
we depend on.