### PR TITLE
fix meinberlin build

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/__init__.py
@@ -7,7 +7,7 @@ from adhocracy_core import root_factory
 def includeme(config):
     """Setup adhocracy extension."""
     # include adhocracy_core
-    config.include('adhocracy_core')
+    config.include('adhocracy_sample')
 
 
 def main(global_config, **settings):

--- a/src/adhocracy_meinberlin/setup.py
+++ b/src/adhocracy_meinberlin/setup.py
@@ -8,10 +8,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
-requires = ['adhocracy_core',
+requires = ['adhocracy_sample',
             ]
 
-test_requires = ['adhocracy_core[test]',
+test_requires = ['adhocracy_sample[test]',
                  ]
 
 debug_requires = ['adhocracy_core[debug]',


### PR DESCRIPTION
adhocracy_core (and therefore meinberlin) depends on adhocracy_sample (although it arguably should not.  The only dependency AFAIK is in two JavaScript tests that are mostly unmaintained anyway)

This reflects that dependency in the code to fix the build. Buildout now executes without an error for me.