### PR TITLE
Allow to pass non-string arguments to sheet constructors

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -360,7 +360,9 @@ renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IM
                     var fieldParser : string = mkFieldType(sheet.fields[x]).parser;
 
                     if (fieldParser) {
-                        codeLine = "this." + fieldName + " = (" + fieldParser + ")(args." + fieldName + ");";
+                        codeLine = "this.{0} = (typeof args.{0} === \"string\") ? ({1})(args.{0}) : args.{0};"
+                            .replace(/\{0\}/g, fieldName)
+                            .replace(/\{1\}/g, fieldParser);
                     } else {
                         codeLine = "this." + fieldName + " = args." + fieldName + ";";
                     }
@@ -440,7 +442,7 @@ mkFieldSignatures = (fields : MetaApi.ISheetField[], tab : string, separator : s
 mkFieldSignaturesSheetCons = (fields : MetaApi.ISheetField[], tab : string, separator : string) : string =>
     UtilR.mkThingList(
         fields,
-        (field) => field.name + (isWriteableField(field) ? "" : "?") + " : " + mkFieldType(field).constructorType,
+        (field) => field.name + (isWriteableField(field) ? "" : "?"),
         tab, separator
     );
 


### PR DESCRIPTION
Before this, sheet constructors expected all arguments to be strings
because that is what we receive from the backend. The constructors would
then apply parsers to convert the incoming strings to native types.

When you want to create a sheet in the frontend, this is rather annoying.
So I changed the constructors to accept argumants of any type and only
convert them if they are strings.