### PR TITLE
separate sheet parse method

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
@@ -87,7 +87,7 @@ export var importContent = <Content extends ResourcesBase.Resource>(
         }
 
         var _sclass = Resources_.sheetRegistry[sheetName];
-        _obj.data[sheetName] = new _sclass(jsonSheet);
+        _obj.data[sheetName] = _sclass.parse(jsonSheet);
 
         // the above four lines compile because we leave
         // typescript in the dark about the actual type of _class.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -360,9 +360,7 @@ renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IM
                     var fieldParser : string = mkFieldType(sheet.fields[x]).parser;
 
                     if (fieldParser) {
-                        codeLine = "this.{0} = (typeof args.{0} === \"string\") ? ({1})(args.{0}) : args.{0};"
-                            .replace(/\{0\}/g, fieldName)
-                            .replace(/\{1\}/g, fieldParser);
+                        codeLine = "this." + fieldName + " = (" + fieldParser + ")(args." + fieldName + ");";
                     } else {
                         codeLine = "this." + fieldName + " = args." + fieldName + ";";
                     }
@@ -442,7 +440,7 @@ mkFieldSignatures = (fields : MetaApi.ISheetField[], tab : string, separator : s
 mkFieldSignaturesSheetCons = (fields : MetaApi.ISheetField[], tab : string, separator : string) : string =>
     UtilR.mkThingList(
         fields,
-        (field) => field.name + (isWriteableField(field) ? "" : "?"),
+        (field) => field.name + (isWriteableField(field) ? "" : "?") + " : " + mkFieldType(field).constructorType,
         tab, separator
     );
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -116,7 +116,7 @@ var config : IConfig = {
 
 interface FieldType {
     resultType : string;
-    constructorType : string;
+    jsonType : string;
     parser? : string;
 }
 
@@ -440,7 +440,7 @@ mkFieldSignatures = (fields : MetaApi.ISheetField[], tab : string, separator : s
 mkFieldSignaturesSheetCons = (fields : MetaApi.ISheetField[], tab : string, separator : string) : string =>
     UtilR.mkThingList(
         fields,
-        (field) => field.name + (isWriteableField(field) ? "" : "?") + " : " + mkFieldType(field).constructorType,
+        (field) => field.name + (isWriteableField(field) ? "" : "?") + " : " + mkFieldType(field).jsonType,
         tab, separator
     );
 
@@ -705,7 +705,7 @@ mkNick = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
 
 mkFieldType = (field : MetaApi.ISheetField) : FieldType => {
     var resultType : string;
-    var constructorType : string = "string";
+    var jsonType : string = "string";
     var parser : string;
 
     // parsers
@@ -808,7 +808,7 @@ mkFieldType = (field : MetaApi.ISheetField) : FieldType => {
         switch (field.containertype) {
         case "list":
             resultType += "[]";
-            constructorType += "[]";
+            jsonType += "[]";
             if (parser) {
                 throw "not implemented: parsers for list fields.  email mf@zerobuzz.net to fix this.";
 
@@ -827,7 +827,7 @@ mkFieldType = (field : MetaApi.ISheetField) : FieldType => {
 
     return {
         resultType: resultType,
-        constructorType: constructorType,
+        jsonType: jsonType,
         parser: parser
     };
 };


### PR DESCRIPTION
This fixes #962. See there for a more detailed description.

This pull request includes quite some code duplication. This will be considerably reduced once the workaround for #261 can be removed.

Note that #927 needs to be adapted once this has been merged because it uses the new renamed variable `constructorType`.