### PR TITLE
kiezkassen tabs

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
@@ -1,0 +1,105 @@
+/// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import _ = require("lodash");
+
+import AdhConfig = require("../Config/Config");
+
+var pkgLocation = "/Tabs";
+
+
+export interface ITabScope extends angular.IScope {
+    active : boolean;
+    heading : string;
+    select() : void;
+}
+
+export interface ITabsetScope extends angular.IScope {
+    tabs : ITabScope[];
+}
+
+export class TabSetController {
+    constructor(private $scope : ITabsetScope) {
+        this.$scope.tabs = [];
+    }
+
+    public select(selectedTab : ITabScope) {
+        _.forEach(this.$scope.tabs, (tab : ITabScope) => {
+            if (tab.active && tab !== selectedTab) {
+                tab.active = false;
+            }
+        });
+        selectedTab.active = true;
+    }
+
+    public addTab(tab : ITabScope) {
+        this.$scope.tabs.push(tab);
+
+        // we can"t run the select function on the first tab
+        // since that would select it twice
+        if (this.$scope.tabs.length === 1) {
+            tab.active = true;
+        } else if (tab.active) {
+            this.select(tab);
+        }
+    }
+
+    public removeTab(tab : ITabScope) {
+        var index = this.$scope.tabs.indexOf(tab);
+
+        // Select a new tab if the tab to be removed is selected and not destroyed
+        if (tab.active && this.$scope.tabs.length > 1) {
+            // If this is the last tab, select the previous tab. else, the next tab.
+            var newActiveIndex = (index === this.$scope.tabs.length - 1) ? index - 1 : index + 1;
+            this.select(this.$scope.tabs[newActiveIndex]);
+        }
+        this.$scope.tabs.splice(index, 1);
+    }
+}
+
+export var tabsetDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        scope: {},
+        transclude: true,
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/tabset.html",
+        controller: ["$scope", TabSetController]
+    };
+};
+
+export var tabDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        require: "^tabset",
+        restrict: "E",
+        transclude: true,
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/tab.html",
+        scope: {
+            active: "=?",
+            heading: "@"
+        },
+        link: (scope : ITabScope, element, attrs, tabsetCtrl : TabSetController) => {
+            scope.select = () => {
+                tabsetCtrl.select(scope);
+            };
+
+            tabsetCtrl.addTab(scope);
+
+            if (scope.active) {
+                tabsetCtrl.select(scope);
+            }
+
+            scope.$on("$destroy", () => {
+                tabsetCtrl.removeTab(scope);
+            });
+        }
+    };
+};
+
+
+export var moduleName = "adhTabs";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [])
+        .directive("tabset", ["adhConfig", tabsetDirective])
+        .directive("tab", ["adhConfig", tabDirective]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
@@ -22,13 +22,16 @@ export class TabSetController {
         this.$scope.tabs = [];
     }
 
-    public select(selectedTab : ITabScope) {
+    public select(selectedTab? : ITabScope) {
         _.forEach(this.$scope.tabs, (tab : ITabScope) => {
             if (tab.active && tab !== selectedTab) {
                 tab.active = false;
             }
         });
-        selectedTab.active = true;
+
+        if (typeof selectedTab !== "undefined") {
+            selectedTab.active = true;
+        }
     }
 
     public addTab(tab : ITabScope) {
@@ -78,7 +81,11 @@ export var tabDirective = (adhConfig : AdhConfig.IService) => {
         },
         link: (scope : ITabScope, element, attrs, tabsetCtrl : TabSetController) => {
             scope.select = () => {
-                tabsetCtrl.select(scope);
+                if (scope.active) {
+                    tabsetCtrl.select();
+                } else {
+                    tabsetCtrl.select(scope);
+                }
             };
 
             tabsetCtrl.addTab(scope);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tab.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tab.html
@@ -1,0 +1,6 @@
+<div
+    class="tab-pane"
+    data-ng-show="active"
+    data-ng-class="{'is-active': active}">
+    <ng-transclude></ng-transclude>
+</div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tabset.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tabset.html
@@ -1,0 +1,13 @@
+<div class="tabset">
+    <ul class="tabset-tabs">
+        <li
+            class="tab"
+            data-ng-repeat="tab in tabs"
+            data-ng-class="{'is-active': tab.active}">
+            <a href="" data-ng-click="tab.select()">{{tab.heading}}</a>
+        </li>
+    </ul>
+    <div class="tabset-panes">
+        <ng-transclude></ng-transclude>
+    </div>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -46,6 +46,7 @@ import AdhResourceArea = require("./Packages/ResourceArea/ResourceArea");
 import AdhResourceWidgets = require("./Packages/ResourceWidgets/ResourceWidgets");
 import AdhShareSocial = require("./Packages/ShareSocial/ShareSocial");
 import AdhSticky = require("./Packages/Sticky/Sticky");
+import AdhTabs = require("./Packages/Tabs/Tabs");
 import AdhTopLevelState = require("./Packages/TopLevelState/TopLevelState");
 import AdhTracking = require("./Packages/Tracking/Tracking");
 import AdhUser = require("./Packages/User/User");
@@ -181,6 +182,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhResourceWidgets.register(angular);
     AdhShareSocial.register(angular);
     AdhSticky.register(angular);
+    AdhTabs.register(angular);
     AdhTopLevelState.register(angular);
     AdhTracking.register(angular);
     AdhUser.register(angular);

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Detail.html
@@ -3,9 +3,9 @@
         {{ title }}
     </div>
 
-    <div class="mein-berlin-kiezkassen-detail-tabs tabs">
-        <div class="tab" data-ng-if="currentTab === 0">Tab1</div>
-        <div class="tab" data-ng-if="currentTab === 1">Tab2</div>
-        <div class="tab" data-ng-if="currentTab === 2">Tab3</div>
-    </div>
+    <tabset>
+        <tab data-ng-repeat="tab in tabs" data-heading="{{tab.heading}}">
+            {{tab.content}}
+        </tab>
+    </tabset>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Kiezkassen.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Kiezkassen.ts
@@ -1,5 +1,6 @@
 import AdhConfig = require("../../Config/Config");
 import AdhHttp = require("../../Http/Http");
+import AdhTabs = require("../../Tabs/Tabs");
 
 import AdhMeinBerlinKiezkassenProposal = require("./Proposal/Proposal");
 
@@ -15,6 +16,14 @@ export var detailDirective = (adhConfig : AdhConfig.IService, adhHttp : AdhHttp.
         },
         link: (scope) => {
             scope.currentTab = 0;
+
+            scope.tabs = [{
+                heading: "Tab1",
+                content: "foo1"
+            }, {
+                heading: "Tab2",
+                content: "foo2"
+            }];
 
             scope.$watch("path", (value : string) => {
                 if (value) {
@@ -39,6 +48,7 @@ export var register = (angular) => {
 
     angular
         .module(moduleName, [
+            AdhTabs.moduleName,
             AdhMeinBerlinKiezkassenProposal.moduleName
         ])
         .directive("adhMeinBerlinKiezkassenDetail", ["adhConfig", "adhHttp", detailDirective]);


### PR DESCRIPTION
This adds tabs for the kiezkassen process detail view.

At first I had tried to use the tabs from [angular-ui-bootstrap](https://angular-ui.github.io/bootstrap/) but that did not work (templates could not be loaded due to relative paths). So I ported them to TypeScript leaving out some details and added some features (deselect and height transition).