### PR TITLE
meinberlin workbench

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Detail.html
@@ -8,4 +8,16 @@
             {{tab.content}}
         </tab>
     </tabset>
+
+    <a href="{{path | adhResourceUrl:'create_proposal'}}">{{ "TR__CREATE_PROPOSAL" | translate }}</a>
+
+    <adh-listing
+        data-path="/"
+        data-no-create-form="true"
+        data-empty-text="{{ 'TR__PROPOSAL_EMPTY_TEXT' | translate }}"
+        data-params="{tag: 'LAST'}"
+        data-content-type="adhocracy_meinberlin.resources.kiezkassen.IProposalVersion">
+        <adh-mein-berlin-kiezkassen-proposal-list-item data-path="{{element}}">
+        </adh-mein-berlin-kiezkassen-proposal-list-item>
+    </adh-listing>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
@@ -2,5 +2,7 @@
     <h1>{{ data.title }}</h1>
     <adh-rate data-refers-to="{{path}}"></adh-rate>
 
+    <a href="{{ path | adhResourceUrl:'comments' }}">{{"TR__SHOW_COMMENTS"}}</a>
+
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur.</p>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
@@ -1,3 +1,3 @@
 <div class="mein-berlin-kiezkassen-proposal-list-item">
-    <h1>{{ data.title }}</h1>
+    <h1><a href="{{ path | adhResourceUrl }}">{{ data.title }}</a></h1>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/MeinBerlin.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/MeinBerlin.ts
@@ -1,13 +1,16 @@
 import AdhMeinBerlinKiezkassen = require("./Kiezkassen/Kiezkassen");
+import AdhMeinBerlinWorkbench = require("./Workbench/Workbench");
 
 
 export var moduleName = "adhMeinBerlin";
 
 export var register = (angular) => {
     AdhMeinBerlinKiezkassen.register(angular);
+    AdhMeinBerlinWorkbench.register(angular);
 
     angular
         .module(moduleName, [
-            AdhMeinBerlinKiezkassen.moduleName
+            AdhMeinBerlinKiezkassen.moduleName,
+            AdhMeinBerlinWorkbench.moduleName
         ]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/CommentColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/CommentColumn.html
@@ -1,0 +1,22 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <i class="icon-speechbubble-unfilled moving-column-icon"></i>
+        <div class="moving-column-menu-nav">
+            <a data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+        </div>
+    </div>
+
+    <adh-comment-listing
+        data-ng-if="commentableUrl"
+        data-path="{{commentableUrl}}"
+        data-frontend-order-predicate="frontendOrderPredicate"
+        data-frontend-order-reverse="frontendOrderReverse"
+        data-ng-switch-when="body">
+    </adh-comment-listing>
+
+    <adh-report-abuse
+        data-ng-switch-when="overlays"
+        data-ng-if="overlay === 'abuse'"
+        data-url="{{ shared.abuseUrl | adhResourceUrl | adhCanonicalUrl }}">
+    </adh-report-abuse>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenDetailColumn.html
@@ -1,0 +1,13 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <i class="icon-process moving-column-icon"></i>
+    </div>
+
+    <a data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl }}"><i class="icon-process moving-column-icon"></i></a>
+
+    <adh-mein-berlin-kiezkassen-detail
+        data-ng-switch-when="body"
+        data-ng-if="processUrl"
+        data-path="{{processUrl}}">
+    </adh-mein-berlin-kiezkassen-detail>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalCreateColumn.html
@@ -1,0 +1,12 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <i class="icon-document moving-column-icon"></i>
+
+        <div class="moving-column-menu-nav">
+            <a data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+        </div>
+    </div>
+
+    <adh-mein-berlin-kiezkassen-proposal-create data-ng-switch-when="body">
+    </adh-mein-berlin-kiezkassen-proposal-create>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
@@ -1,0 +1,17 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <i class="icon-document moving-column-icon"></i>
+
+        <div class="moving-column-menu-nav">
+            <a data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+        </div>
+    </div>
+
+    <a data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhResourceUrl }}"><i class="icon-document moving-column-icon"></i></a>
+
+    <adh-mein-berlin-kiezkassen-proposal-detail
+        data-ng-switch-when="body"
+        data-ng-if="proposalUrl"
+        data-path="{{proposalUrl}}">
+    </adh-mein-berlin-kiezkassen-proposal-detail>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.html
@@ -1,0 +1,12 @@
+<div data-adh-moving-columns="" class="moving-columns">
+    <adh-moving-column>
+        <adh-mein-berlin-kiezkassen-detail-column></adh-mein-berlin-kiezkassen-detail-column>
+    </adh-moving-column>
+    <adh-moving-column>
+        <adh-mein-berlin-kiezkassen-proposal-create-column data-ng-if="view === 'create_proposal'"></adh-mein-berlin-kiezkassen-proposal-create-column>
+        <adh-mein-berlin-kiezkassen-proposal-detail-column data-ng-if="view !== 'create_proposal'"></adh-mein-berlin-kiezkassen-proposal-detail-column>
+    </adh-moving-column>
+    <adh-moving-column>
+        <adh-comment-column></adh-comment-column>
+    </adh-moving-column>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
 
 import AdhConfig = require("../../Config/Config");
+import AdhHttp = require("../../Http/Http");
 import AdhMovingColumns = require("../../MovingColumns/MovingColumns");
 import AdhProcess = require("../../Process/Process");
 import AdhResourceArea = require("../../ResourceArea/ResourceArea");
@@ -8,6 +9,7 @@ import AdhResourceArea = require("../../ResourceArea/ResourceArea");
 import RICommentVersion = require("../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
 import RIKiezkassenProcess = require("../../../Resources_/adhocracy_core/resources/pool/IBasicPool");  // FIXME
 import RIProposalVersion = require("../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
+import SIComment = require("../../../Resources_/adhocracy_core/sheets/comment/IComment");
 
 var pkgLocation = "/MeinBerlin/Workbench";
 
@@ -81,6 +83,7 @@ export var moduleName = "adhMeinBerlinWorkbench";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhHttp.moduleName,
             AdhMovingColumns.moduleName,
             AdhProcess.moduleName,
             AdhResourceArea.moduleName
@@ -92,22 +95,68 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
+                .specific(RIKiezkassenProcess.content_type, "", "", [() => (resource : RIKiezkassenProcess) => {
+                    return {
+                        processUrl: resource.path
+                    };
+                }])
                 .default(RIKiezkassenProcess.content_type, "create_proposal", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", "", [() => (resource : RIKiezkassenProcess) => {
+                    return {
+                        processUrl: resource.path
+                    };
+                }])
                 .default(RIProposalVersion.content_type, "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
+                .specific(RIProposalVersion.content_type, "", "", [() => (resource : RIProposalVersion) => {
+                    return {
+                        proposalUrl: resource.path,
+                        processUrl: "/adhocracy"  // FIXME
+                    };
+                }])
                 .default(RIProposalVersion.content_type, "comments", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
+                .specific(RIProposalVersion.content_type, "comments", "", [() => (resource : RIProposalVersion) => {
+                    return {
+                        commentableUrl: resource.path,
+                        proposalUrl: resource.path,
+                        processUrl: "/adhocracy"  // FIXME
+                    };
+                }])
                 .default(RICommentVersion.content_type, "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
-                });
+                })
+                .specific(RIProposalVersion.content_type, "", "", ["adhHttp", "$q", (
+                    adhHttp : AdhHttp.Service<any>,
+                    $q : angular.IQService
+                ) => {
+                    var getCommentableUrl = (resource) : angular.IPromise<any> => {
+                        if (resource.content_type !== RICommentVersion.content_type) {
+                            return $q.when(resource);
+                        } else {
+                            var url = resource.data[SIComment.nick].refers_to;
+                            return adhHttp.get(url).then(getCommentableUrl);
+                        }
+                    };
+
+                    return (resource : RICommentVersion) => {
+                        return getCommentableUrl(resource).then((commentable) => {
+                            return {
+                                commentableUrl: commentable.path,
+                                proposalUrl: commentable.path,
+                                processUrl: "/adhocracy"  // FIXME
+                            };
+                        });
+                    };
+                }]);
         }])
         .config(["adhProcessProvider", (adhProcessProvider : AdhProcess.Provider) => {
             adhProcessProvider.templateFactories[""] = ["$q", ($q : angular.IQService) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
@@ -1,0 +1,91 @@
+import AdhConfig = require("../../Config/Config");
+import AdhMovingColumns = require("../../MovingColumns/MovingColumns");
+import AdhResourceArea = require("../../ResourceArea/ResourceArea");
+
+var pkgLocation = "/MeinBerlin/Workbench";
+
+
+export var meinBerlinWorkbenchDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Workbench.html"
+    };
+};
+
+export var commentColumnDirective = (
+    bindVariablesAndClear : AdhMovingColumns.IBindVariablesAndClear,
+    adhConfig : AdhConfig.IService
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/CommentColumn.html",
+        require: "^adhMovingColumn",
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+            bindVariablesAndClear(scope, column, ["proposalUrl", "commentableUrl"]);
+        }
+    };
+};
+
+export var kiezkassenProposalDetailColumnDirective = (
+    bindVariablesAndClear : AdhMovingColumns.IBindVariablesAndClear,
+    adhConfig : AdhConfig.IService
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/KiezkassenProposalDetailColumn.html",
+        require: "^adhMovingColumn",
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+            bindVariablesAndClear(scope, column, ["processUrl", "proposalUrl"]);
+        }
+    };
+};
+
+export var kiezkassenProposalCreateColumnDirective = (
+    bindVariablesAndClear : AdhMovingColumns.IBindVariablesAndClear,
+    adhConfig : AdhConfig.IService
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/KiezkassenProposalCreateColumn.html",
+        require: "^adhMovingColumn",
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+            bindVariablesAndClear(scope, column, ["processUrl"]);
+        }
+    };
+};
+
+export var kiezkassenDetailColumnDirective = (
+    bindVariablesAndClear : AdhMovingColumns.IBindVariablesAndClear,
+    adhConfig : AdhConfig.IService
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/KiezkassenDetailColumn.html",
+        require: "^adhMovingColumn",
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+            bindVariablesAndClear(scope, column, ["processUrl"]);
+        }
+    };
+};
+
+
+export var moduleName = "adhMeinBerlinWorkbench";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhMovingColumns.moduleName,
+            AdhResourceArea.moduleName
+        ])
+        .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
+            // FIXME
+        }])
+        .directive("adhMeinBerlinWorkbench", ["adhConfig", meinBerlinWorkbenchDirective])
+        .directive("adhCommentColumn", ["adhBindVariablesAndClear", "adhConfig", commentColumnDirective])
+        .directive("adhMeinBerlinKiezkassenProposalDetailColumn", [
+            "adhBindVariablesAndClear", "adhConfig", kiezkassenProposalDetailColumnDirective])
+        .directive("adhMeinBerlinKiezkassenProposalCreateColumn", [
+            "adhBindVariablesAndClear", "adhConfig", kiezkassenProposalCreateColumnDirective])
+        .directive("adhMeinBerlinKiezkassenDetailColumn", [
+            "adhBindVariablesAndClear", "adhConfig", kiezkassenDetailColumnDirective]);
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
@@ -1,6 +1,13 @@
+/// <reference path="../../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
 import AdhConfig = require("../../Config/Config");
 import AdhMovingColumns = require("../../MovingColumns/MovingColumns");
+import AdhProcess = require("../../Process/Process");
 import AdhResourceArea = require("../../ResourceArea/ResourceArea");
+
+import RICommentVersion = require("../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
+import RIKiezkassenProcess = require("../../../Resources_/adhocracy_core/resources/pool/IBasicPool");  // FIXME
+import RIProposalVersion = require("../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
 
 var pkgLocation = "/MeinBerlin/Workbench";
 
@@ -75,10 +82,37 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhMovingColumns.moduleName,
+            AdhProcess.moduleName,
             AdhResourceArea.moduleName
         ])
+        // FIXME: the following should be specific to kiezkassen process
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
-            // FIXME
+            adhResourceAreaProvider
+                .default(RIKiezkassenProcess.content_type, "", "", {
+                    space: "content",
+                    movingColumns: "is-show-hide-hide"
+                })
+                .default(RIKiezkassenProcess.content_type, "create_proposal", "", {
+                    space: "content",
+                    movingColumns: "is-show-show-hide"
+                })
+                .default(RIProposalVersion.content_type, "", "", {
+                    space: "content",
+                    movingColumns: "is-show-show-hide"
+                })
+                .default(RIProposalVersion.content_type, "comments", "", {
+                    space: "content",
+                    movingColumns: "is-collapse-show-show"
+                })
+                .default(RICommentVersion.content_type, "", "", {
+                    space: "content",
+                    movingColumns: "is-collapse-show-show"
+                });
+        }])
+        .config(["adhProcessProvider", (adhProcessProvider : AdhProcess.Provider) => {
+            adhProcessProvider.templateFactories[""] = ["$q", ($q : angular.IQService) => {
+                return $q.when("<adh-mein-berlin-workbench></adh-mein-berlin-workbench>");
+            }];
         }])
         .directive("adhMeinBerlinWorkbench", ["adhConfig", meinBerlinWorkbenchDirective])
         .directive("adhCommentColumn", ["adhBindVariablesAndClear", "adhConfig", commentColumnDirective])


### PR DESCRIPTION
This integrates the new meinberlin widgets in a workbench. Basic navigation works, but not much more.

Note that there are still no kiezkassen processes in the backend. So for now basic pools are used instead.