### PR TITLE
2015 04 jk run all tests

### DIFF
--- a/buildout-core.cfg
+++ b/buildout-core.cfg
@@ -18,6 +18,7 @@ parts +=
 
 [adhocracy]
 frontend.static_dir = src/adhocracy_frontend/adhocracy_frontend/build
+eggs += mercator[debug]
 
 [test_run_unit]
 package_paths = src/adhocracy_*

--- a/buildout-meinberlin.cfg
+++ b/buildout-meinberlin.cfg
@@ -22,6 +22,7 @@ parts +=
 frontend.static_dir = src/meinberlin/meinberlin/build
 frontend_package_name = meinberlin
 backend_package_name = adhocracy_meinberlin
+eggs += mercator[debug]
 
 [test_run_unit]
 package_paths = src/adhocracy_*  src/adhocracy_frontend/adhocracy_frontend/tests/unit

--- a/buildout-mercator.cfg
+++ b/buildout-mercator.cfg
@@ -22,6 +22,7 @@ parts +=
 frontend.static_dir = src/mercator/mercator/build
 frontend_package_name = mercator
 backend_package_name = adhocracy_mercator
+eggs += mercator[debug]
 
 [test_run_unit]
 package_paths = src/adhocracy_* src/adhocracy_frontend/adhocracy_frontend/tests/unit

--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -182,7 +182,6 @@ class BatchView(RESTView):
             code = 500
             error_dict = internal_exception_to_dict(err)
             body = {'status': 'error', 'errors': [error_dict]}
-            logger.exception('Unexpected exception processing nested request')
         return BatchItemResponse(code, body)
 
     def _extend_path_map(self, path_map: dict, result_path: str,

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -31,6 +31,7 @@ if sys.version_info < (3, 4):
 
 test_requires = [
     'pytest',
+    'polytester',
     'selenium',
     'webtest',
     'pytest-splinter',

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,8 @@
+pyunit:
+    command: bin/coverage run bin/py.test -m"not functional and not jasmine" src/adhocracy_*  && bin/coverage report && bin/coverage html
+pyfunc:
+    command: bin/py.test -m"functional and not jasmine" src/adhocracy_*
+jsunit:
+    command: make -C ./parts/static/js/ compile_tests_node && bin/jasmine-node ./parts/static/js
+acceptance:
+    command: bin/protractor etc/protractorConf.js


### PR DESCRIPTION
Problem:

   * no script to run all tests
   * documentation how to run tests complicated/broken
   * broken tests because nobody runs them (happend twice in python test)

Proposal:
    
   * user polytester to run all python and available javascript/acceptance tests
   * simplify buildout config to create testscripts and add dependencies to python path
   * updated documentation

Example: 

    run:
    
        bin/polytester -c test.yml
    
    restrict tests:
    
        bin/polytester -c test.yml pyunit
    
    enable verbose output:

           bin/polytester -v -c test.yml pyunit


    
