### PR TITLE
Basic print styling

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/_layout.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/_layout.scss
@@ -54,3 +54,15 @@
     margin: 5em auto 10em;
     padding: 0.5em;
 }
+
+
+@media print {
+    .l-header-center,
+    .l-content {
+        position: static;
+    }
+
+    .main-header {
+        display: none;
+    }
+}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -409,3 +409,26 @@ A list of alert messages to notify users in the moving column
         @include opacity(1);
     }
 }
+
+
+@media print {
+    .moving-column,
+    .moving-column-body {
+        position: static;
+    }
+
+    .moving-column {
+        // scss-lint:disable ImportantRule
+
+        width: auto !important;
+        border: 0;
+    }
+
+    .moving-column-menu,
+    .moving-column-sidebar,
+    .moving-column-overlay,
+    .moving-column-mask,
+    .moving-column-alerts {
+        display: none;
+    }
+}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
@@ -462,3 +462,14 @@ parent: inline
 <time datetime="2013-04-18T13:50:47+02:00">18. April 2013 13:50</time>
 ```
 */
+
+
+@media print {
+    // scss-lint:disable ImportantRule, ColorVariable
+
+    * {
+        background: white !important;
+        color: black !important;
+        border-color: black !important;
+    }
+}


### PR DESCRIPTION
this implements very basic print CSS rules for layout, moving columns
and type.  The following concepts are used:

-   do not show widgets that are only useful in an interactive context,
    e.g. navigation
-   use black on white to save ink
-   do not use position/float for layout
-   use the full available width

more adjustments are needed. This is only a start.