### PR TITLE
Automatically redirect old versions to newest version

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -195,9 +195,9 @@ export class Service implements AdhTopLevelState.IAreaInput {
         ]).then((values : any[]) => {
             var resource : ResourcesBase.Resource = values[0];
             var processType : string = values[1];
-            var abort : boolean = values[2];
+            var hasRedirected : boolean = values[2];
 
-            if (abort) {
+            if (hasRedirected) {
                 return;
             }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -1,9 +1,14 @@
 import _ = require("lodash");
 
+import ResourcesBase = require("../../ResourcesBase");
+
+import SIVersionable = require("../../Resources_/adhocracy_core/sheets/versions/IVersionable");
+
 import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
 import AdhProcess = require("../Process/Process");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
+import AdhUtil = require("../Util/Util");
 
 var pkgLocation = "/ResourceArea";
 
@@ -22,8 +27,9 @@ export class Provider implements angular.IServiceProvider {
         var self = this;
         this.defaults = {};
         this.specifics = {};
-        this.$get = ["$q", "$injector", "adhHttp", "adhConfig",
-            ($q, $injector, adhHttp, adhConfig) => new Service(self, $q, $injector, adhHttp, adhConfig)];
+        this.$get = ["$q", "$injector", "$location", "adhHttp", "adhConfig", "adhResourceUrlFilter",
+            ($q, $injector, $location, adhHttp, adhConfig, adhResourceUrlFilter) => new Service(
+        self, $q, $injector, $location, adhHttp, adhConfig, adhResourceUrlFilter)];
     }
 
     public default(resourceType : string, view : string, processType : string, defaults : Dict) : Provider {
@@ -103,8 +109,10 @@ export class Service implements AdhTopLevelState.IAreaInput {
         private provider : Provider,
         private $q : angular.IQService,
         private $injector : angular.auto.IInjectorService,
+        private $location : angular.ILocationService,
         private adhHttp : AdhHttp.Service<any>,
-        private adhConfig : AdhConfig.IService
+        private adhConfig : AdhConfig.IService,
+        private adhResourceUrlFilter
     ) {
         this.templateUrl = adhConfig.pkg_path + pkgLocation + "/ResourceArea.html";
     }
@@ -142,6 +150,27 @@ export class Service implements AdhTopLevelState.IAreaInput {
         return this.$q.when("");
     }
 
+    private conditionallyRedirectVersionToLast(resourceUrl : string) : angular.IPromise<boolean> {
+        var self : Service = this;
+
+        return self.adhHttp.get(resourceUrl).then((resource : ResourcesBase.Resource) => {
+            if (resource.data.hasOwnProperty(SIVersionable.nick)) {
+                if (resource.data[SIVersionable.nick].followed_by.length === 0) {
+                    return false;
+                } else {
+                    var itemUrl = AdhUtil.parentPath(resourceUrl);
+                    return self.adhHttp.getNewestVersionPathNoFork(itemUrl).then((lastUrl) => {
+                        self.$location.path(self.adhResourceUrlFilter(lastUrl));
+                        return true;
+                    });
+
+                }
+            } else {
+                return false;
+            }
+        });
+    }
+
     public route(path : string, search : Dict) : angular.IPromise<Dict> {
         var self : Service = this;
         var segs : string[] = path.replace(/\/+$/, "").split("/");
@@ -161,10 +190,16 @@ export class Service implements AdhTopLevelState.IAreaInput {
 
         return self.$q.all([
             self.adhHttp.get(resourceUrl),
-            self.getProcessType(resourceUrl)
+            self.getProcessType(resourceUrl),
+            self.conditionallyRedirectVersionToLast(resourceUrl)
         ]).then((values : any[]) => {
-            var resource = values[0];
+            var resource : ResourcesBase.Resource = values[0];
             var processType : string = values[1];
+            var abort : boolean = values[2];
+
+            if (abort) {
+                return;
+            }
 
             return self.getSpecifics(resource, view, processType).then((specifics : Dict) => {
                 var defaults : Dict = self.getDefaults(resource.content_type, view, processType);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -157,7 +157,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
             view = segs.pop().replace(/^@/, "");
         }
 
-        var resourceUrl : string = this.adhConfig.rest_url + segs.join("/");
+        var resourceUrl : string = this.adhConfig.rest_url + segs.join("/") + "/";
 
         return self.$q.all([
             self.adhHttp.get(resourceUrl),

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
@@ -66,7 +66,7 @@ export var register = () => {
 
                 it("sets resourceUrl", (done) => {
                     service.route("/platform/wlog/@blarg", {}).then((data) => {
-                        expect(data["resourceUrl"]).toBe("rest_url/platform/wlog");
+                        expect(data["resourceUrl"]).toBe("rest_url/platform/wlog/");
                         done();
                     });
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
@@ -12,6 +12,8 @@ export var register = () => {
             var adhHttpMock;
             var adhConfigMock;
             var $injectorMock;
+            var $locationMock;
+            var adhResourceUrlFilterMock;
             var service;
 
             beforeEach(() => {
@@ -22,16 +24,22 @@ export var register = () => {
 
                 adhHttpMock = jasmine.createSpyObj("adhHttp", ["get"]);
                 adhHttpMock.get.and.returnValue(q.when({
-                    content_type: "content_type"
+                    content_type: "content_type",
+                    data: {}
                 }));
 
                 $injectorMock = jasmine.createSpyObj("$injector", ["invoke"]);
+
+                $locationMock = jasmine.createSpyObj("$location", ["path"]);
 
                 adhConfigMock = {
                     rest_url: "rest_url"
                 };
 
-                service = new AdhResourceArea.Service(providerMock, <any>q, $injectorMock, adhHttpMock, adhConfigMock);
+                adhResourceUrlFilterMock = (path) => path;
+
+                service = new AdhResourceArea.Service(providerMock, <any>q, $injectorMock, $locationMock, adhHttpMock, adhConfigMock,
+                    adhResourceUrlFilterMock);
             });
 
             describe("route", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -139,7 +139,6 @@ export class Service {
     private area : IArea;
     private currentSpace : string;
     private blockTemplate : boolean;
-    private locationHasChanged : boolean;
     private lock : boolean;
 
     // NOTE: data and on could be replaced by a scope and $watch, respectively.
@@ -163,12 +162,9 @@ export class Service {
         this.currentSpace = "";
         this.data = {"": <any>{}};
 
-        this.locationHasChanged = false;
         this.lock = false;
 
         this.$rootScope.$watch(() => self.$location.absUrl(), () => {
-            self.locationHasChanged = true;
-
             if (!self.lock) {
                 self.fromLocation();
             }
@@ -235,10 +231,9 @@ export class Service {
 
     private fromLocation() : angular.IPromise<void> {
         var area = this.getArea();
+        var absUrl = this.$location.absUrl();
         var path = this.$location.path().replace("/" + area.prefix, "");
         var search = this.$location.search();
-
-        this.locationHasChanged = false;
 
         if (area.skip) {
             return this.$q.when();
@@ -249,7 +244,7 @@ export class Service {
             return <any>area.route(path, search)
                 .catch((error) => this.handleRoutingError(error))
                 .then((data) => {
-                    if (this.locationHasChanged) {
+                    if (absUrl !== this.$location.absUrl()) {
                         return this.fromLocation();
                     }
 


### PR DESCRIPTION
As the versioning system isn't in full use yet, i.e. a linear history is
enforced, and this history isn't exposed to the UI yet, this commit
makes views on old versions of versionables automatically redirect to
the newest version.

This will be changed as soon as versioning will be exposed through the
UI.