### PR TITLE
update javascript libraries

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -198,11 +198,11 @@ update-command = ${:command}
 recipe = bowerrecipe
 packages =
     jquery#1.11.2
-    angular#1.3.13
-    angular-animate#1.3.13
-    angular-aria#1.3.13
-    angular-messages#1.3.13
-    angular-route#1.3.13
+    angular#1.3.15
+    angular-animate#1.3.15
+    angular-aria#1.3.15
+    angular-messages#1.3.15
+    angular-route#1.3.15
     angular-cache#3.2.5
     angular-elastic#2.4.2
     angular-scroll#0.6.5

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -157,16 +157,16 @@ input = inline:
             "jasmine-node": "2.0.0",
             "protractor": "1.8.0",
             "sync-exec": "0.4.0",
-            "q": "1.1.2",
-            "lodash": "3.5.0",
+            "q": "1.2.0",
+            "lodash": "3.6.0",
             "node-fs": "0.1.7",
-            "underscore.string": "2.3.3",
+            "underscore.string": "3.0.3",
             "grunt": "0.4.5",
             "grunt-cli": "0.1.13",
             "grunt-angular-templates": "0.5.7",
-            "requirejs": "2.1.16",
+            "requirejs": "2.1.17",
             "grunt-contrib-requirejs": "0.4.4",
-            "htmlhint": "0.9.6",
+            "htmlhint": "0.9.7",
             "grunt-htmlhint": "0.4.0",
             "mailparser": "0.4.9",
             "ini": "1.3.3"
@@ -209,16 +209,16 @@ packages =
     angular-translate#2.6.1
     angular-translate-loader-static-files#2.6.1
     leaflet#0.7.3
-    lodash#3.5.0
-    requirejs#2.1.16
+    lodash#3.6.0
+    requirejs#2.1.17
     requirejs-text#2.0.14
     xi/DefinitelyTyped#angular-14-compat
     jasmine#2.2.1
     blanket#1.1.5
-    q#1.1.2
+    q#1.2.0
     moment#2.9.0
     relatively-sticky#2.0.0
-    ng-flow#2.6.0
+    ng-flow#2.6.1
     nidico/socialshareprivacy#protocol-relative-urls
     webshim#1.15.7
 


### PR DESCRIPTION
I updated some Javascript libraries to their newest versions. Notable exceptions:

-   moment.js: The dates were rendered in chinese. They had a big refactoring in version 2.10.0 so maybe they need some more time to stabilize. We can look into this sometime else.
-   protractor: I was not invloved in protractor integration yet, so I did not want to break something.
-   mailparser/sync-exec: I didn't even know we had these.