### PR TITLE
improved error handling for kiezkassen proposal create form

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
@@ -236,6 +236,7 @@ export var getFirstFormError = (form, element) => {
 export var submitIfValid = (
     $q : angular.IQService
 ) => (
+    scope : {errors : AdhHttp.IBackendErrorItem[]},
     element,
     form : angular.IFormController,
     submitFn : () => angular.IPromise<any>
@@ -245,8 +246,12 @@ export var submitIfValid = (
     if (form.$valid) {
         return submitFn()
             .then((result) => {
+                scope.errors = [];
                 return result;
             }, (errors : AdhHttp.IBackendErrorItem[]) => {
+                // FIXME this also happens in resourceWidgets. Should not do any harm though.
+                scope.errors = errors;
+
                 container.scrollTopAnimated(0);
                 throw errors;
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
@@ -178,7 +178,7 @@ export var showError = (form : angular.IFormController, field : angular.INgModel
 /**
  * Wrapper around clickable element that adds a sglclick event.
  *
- * sglclick is triggered with on a click event that is not followed
+ * sglclick is triggered on a click event that is not followed
  * by another click or dblclick event within given timeout.
  */
 export var singleClickWrapperFactory = ($timeout : angular.ITimeoutService) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
@@ -220,13 +220,20 @@ export var singleClickWrapperFactory = ($timeout : angular.ITimeoutService) => {
 /**
  * Return the first element within a form that has an error.
  *
+ * Will also search through all subforms.
  * Used to scroll to that element on submit atempt.
  */
 export var getFirstFormError = (form, element) => {
-    var getErrorControllers = (ctrl) => _.flatten(_.values(ctrl.$error));
+    var getErrorControllers = (ctrl) => {
+        if (ctrl.hasOwnProperty("$modelValue")) {
+            return [ctrl];
+        } else {
+            var childCtrls = _.flatten(_.values(ctrl.$error));
+            return _.flatten(_.map(childCtrls, getErrorControllers));
+        }
+    };
 
-    var errorForms = getErrorControllers(form);
-    var errorControllers = _.flatten(_.map(errorForms, getErrorControllers));
+    var errorControllers = getErrorControllers(form);
     var names = _.unique(_.map(errorControllers, "$name"));
     var selector = _.map(names, (name) => "[name=\"" + name + "\"]").join(", ");
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
@@ -65,7 +65,7 @@ export var logBackendBatchError = (
     response : angular.IHttpPromiseCallbackArg<{
         responses : {
             code : number;
-            body : IBackendError;
+            body? : IBackendError;
         }[];
         /* tslint:disable:variable-name */
         updated_resources : any;
@@ -76,9 +76,19 @@ export var logBackendBatchError = (
 
     renderBackendError(response);
 
-    var lastBatchItemResponse : IBackendError = response.data.responses[response.data.responses.length - 1].body;
-    var errors : IBackendErrorItem[] = lastBatchItemResponse.errors;
-    throw errors;
+    var lastBatchItemResponse = response.data.responses[response.data.responses.length - 1];
+
+    // FIXME: work around #1019
+    if (lastBatchItemResponse.code === 403) {
+        throw [{
+            name: "forbidden",
+            location: "unknown",
+            description: "TR__ERROR_HTTP_FORBIDDEN"
+        }];
+    } else {
+        var errors : IBackendErrorItem[] = lastBatchItemResponse.body.errors;
+        throw errors;
+    }
 };
 
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceWidgets/ResourceWidgets.ts
@@ -261,7 +261,9 @@ export class ResourceWidget<R extends ResourcesBase.Resource, S extends IResourc
             self.setMode(instance, mode));
 
         var submitOff = wrapper.eventManager.on("submit", () =>
-            self.provide(instance).then((resources) => instance.deferred.resolve(resources)));
+            self.provide(instance).then(
+                (resources) => instance.deferred.resolve(resources),
+                (reason) => instance.deferred.reject(reason)));
 
         var cancelOff = wrapper.eventManager.on("cancel", () => {
             if (scope.mode === Mode.edit) {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
@@ -178,13 +178,14 @@ export var createDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhShowError,
+    adhSubmitIfValid,
     adhResourceUrlFilter,
     $location : angular.ILocationService
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
-        link: (scope) => {
+        link: (scope, element) => {
             scope.errors = [];
             scope.data = {};
             scope.showError = adhShowError;
@@ -197,14 +198,12 @@ export var createDirective = (
             scope.data.lng = undefined;
 
             scope.submit = () => {
-                // FIXME: handle success/error
-                postCreate(adhHttp, adhPreliminaryNames)(scope, adhConfig.rest_url)
-                    .then((result) => {
-                        scope.errors = [];
-                        $location.url(adhResourceUrlFilter(result[1].path));
-                    }, (errors : AdhHttp.IBackendErrorItem[]) => {
-                        scope.errors = errors;
-                    });
+                return adhSubmitIfValid(scope, element, scope.meinBerlinProposalForm, () => {
+                    return postCreate(adhHttp, adhPreliminaryNames)(scope, adhConfig.rest_url)
+                        .then((result) => {
+                            $location.url(adhResourceUrlFilter(result[1].path));
+                        });
+                });
             };
         }
     };
@@ -305,7 +304,15 @@ export var register = (angular) => {
         .directive("adhMeinBerlinKiezkassenProposalDetail", ["adhConfig", "adhHttp", detailDirective])
         .directive("adhMeinBerlinKiezkassenProposalListItem", ["adhConfig", "adhHttp", listItemDirective])
         .directive("adhMeinBerlinKiezkassenProposalCreate", [
-            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhResourceUrlFilter", "$location", createDirective])
+            "adhConfig",
+            "adhHttp",
+            "adhPreliminaryNames",
+            "adhShowError",
+            "adhSubmitIfValid",
+            "adhResourceUrlFilter",
+            "$location",
+            createDirective
+        ])
         .directive("adhMeinBerlinKiezkassenProposalList", ["adhConfig", listDirective])
         .controller("meinBerlinKiezkassenProposalFormController", [meinBerlinProposalFormController]);
 };

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -1074,7 +1074,7 @@ export var mercatorProposalFormController = ($scope : IControllerScope, $element
             imgUploadController.$setValidity("required", imageExists());
         }
 
-        return adhSubmitIfValid($element, $scope.mercatorProposalForm, () => {
+        return adhSubmitIfValid($scope, $element, $scope.mercatorProposalForm, () => {
             // append a random number to the nick to allow duplicate titles
             $scope.data.introduction.nickInstance = $scope.data.introduction.nickInstance ||
                 Math.floor((Math.random() * 10000) + 1);

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -977,7 +977,7 @@ export var imageUriFilter = () => {
 };
 
 
-export var mercatorProposalFormController = ($scope : IControllerScope, $element, $window, adhShowError) => {
+export var mercatorProposalFormController = ($scope : IControllerScope, $element, $window, adhShowError, adhSubmitIfValid) => {
     var heardFromCheckboxes = [
         "heard-from-colleague",
         "heard-from-website",
@@ -1068,43 +1068,31 @@ export var mercatorProposalFormController = ($scope : IControllerScope, $element
         }
     });
 
-    $scope.submitIfValid = (callCount = 0) => {
-        var container = $element.parents("[data-du-scroll-container]");
-
-        if (callCount > 10) {
-            throw "maximum number of post attempts reached!";
-        }
-
+    $scope.submitIfValid = (callCount = 0) : angular.IPromise<any> => {
         if ($scope.$flow && $scope.$flow.support) {
             var imgUploadController = $scope.mercatorProposalIntroductionForm["introduction-picture-upload"];
             imgUploadController.$setValidity("required", imageExists());
         }
 
-        if ($scope.mercatorProposalForm.$valid) {
+        return adhSubmitIfValid($element, $scope.mercatorProposalForm, () => {
             // append a random number to the nick to allow duplicate titles
             $scope.data.introduction.nickInstance = $scope.data.introduction.nickInstance ||
                 Math.floor((Math.random() * 10000) + 1);
 
-            $scope.submit()
+            return $scope.submit()
                 .catch((errors) => {
                     if (errors && _.every(errors, { "name": "data.adhocracy_core.sheets.name.IName.name" })) {
                         $scope.data.introduction.nickInstance++;
-                        return $scope.submitIfValid(callCount + 1);
+                        if (callCount < 10) {
+                            return $scope.submitIfValid(callCount + 1);
+                        } else {
+                            throw "maximum number of post attempts reached!";
+                        }
                     } else {
-                        container.scrollTopAnimated(0);
+                        throw errors;
                     }
                 });
-        } else {
-            var getErrorControllers = (ctrl) => _.flatten(_.values(ctrl.$error));
-
-            var errorForms = getErrorControllers($scope.mercatorProposalForm);
-            var errorControllers = _.flatten(_.map(errorForms, getErrorControllers));
-            var names = _.unique(_.map(errorControllers, "$name"));
-            var selector = _.map(names, (name) => "[name=\"" + name + "\"]").join(", ");
-
-            var element = $element.find(selector).first();
-            container.scrollToElementAnimated(element, 20);
-        }
+        });
     };
 };
 
@@ -1232,5 +1220,6 @@ export var register = (angular) => {
         .directive("adhMercatorUserProposalListing", ["adhConfig", userListing])
         .directive("adhMercatorProposalAddButton", ["adhConfig", addButton])
         .filter("adhImageUri", imageUriFilter)
-        .controller("mercatorProposalFormController", ["$scope", "$element", "$window", "adhShowError", mercatorProposalFormController]);
+        .controller("mercatorProposalFormController", [
+            "$scope", "$element", "$window", "adhShowError", "adhSubmitIfValid", mercatorProposalFormController]);
 };

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -1082,14 +1082,14 @@ export var mercatorProposalFormController = ($scope : IControllerScope, $element
 
         if ($scope.mercatorProposalForm.$valid) {
             // append a random number to the nick to allow duplicate titles
-            $scope.data.introduction.nickInstance = $scope.data.introduction.nickInstance  ||
+            $scope.data.introduction.nickInstance = $scope.data.introduction.nickInstance ||
                 Math.floor((Math.random() * 10000) + 1);
 
             $scope.submit()
-                .catch((error) => {
-                    if (error && _.every(error, { "name": "data.adhocracy_core.sheets.name.IName.name" })) {
+                .catch((errors) => {
+                    if (errors && _.every(errors, { "name": "data.adhocracy_core.sheets.name.IName.name" })) {
                         $scope.data.introduction.nickInstance++;
-                        $scope.submitIfValid(callCount + 1);
+                        return $scope.submitIfValid(callCount + 1);
                     } else {
                         container.scrollTopAnimated(0);
                     }

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -232,7 +232,8 @@ export var uploadImageFile = (
         .then((mercatorPool) => {
             var postPath : string = mercatorPool.data[SIHasAssetPool.nick].asset_pool;
             return adhHttp.postRaw(postPath, formData)
-                .then((rsp) => rsp.data.path);
+                .then((rsp) => rsp.data.path)
+                .catch(<any>AdhHttp.logBackendError);
         });
 };
 


### PR DESCRIPTION
I factored some error handling code out of the mercator form and reused it for kiezkassen proposal.

I moved the code to angularHelpers. Not really sure if it belongs there. I wanted to keep it close to `adhShowError`.

On my way I found and fixed/worked around some related issues, especially in 8ff72fb and 1abde8c.