### PR TITLE
2015 04 cc core moving columns sass change

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -7,7 +7,7 @@
             data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
 
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ '/principals/users/' | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ '/principals/users/' | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -228,7 +228,7 @@ States:
          }
     }
 
-    a,
+    .moving-column-menu-nav-button,
     .moving-column-menu-sort-label {
         @include inline-block;
         color: $color-text-highlight-introvert;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -216,7 +216,7 @@ States:
     line-height: $moving-column-menu-height * ($font-size-normal / $font-size-small) / 1em;
     padding: 0 0 0 $padding-small;
 
-    a {
+    .moving-column-menu-nav-button {
         text-decoration: none;
 
         &:hover, &:focus {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/CommentColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/CommentColumn.html
@@ -2,7 +2,7 @@
     <div data-ng-switch-when="menu">
         <i class="icon-speechbubble-unfilled moving-column-icon"></i>
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalCreateColumn.html
@@ -3,7 +3,7 @@
         <i class="icon-document moving-column-icon"></i>
 
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
@@ -3,7 +3,7 @@
         <i class="icon-document moving-column-icon"></i>
 
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/CommentColumn.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/CommentColumn.html
@@ -2,7 +2,7 @@
     <div data-ng-switch-when="menu">
         <i class="icon-speechbubble-unfilled moving-column-icon"></i>
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
@@ -7,7 +7,7 @@
         <a data-ng-if="proposalItemOptions.hide" href="" data-ng-click="delete()">{{ "TR__DELETE" | translate }}</a>
 
         <div class="moving-column-menu-nav">
-            <a data-ng-href="{{ platformUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ platformUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 


### PR DESCRIPTION
I have updated core themes as previously links in the moving column menu were referred to as .moving-column-menu a, I have now give this 'a' its own class as it was causing compatibility problems in meinberlin and it is also better practice.