### PR TITLE
use adhRecompileOnChange on proposal detail

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/AngularHelpers/AngularHelpers.ts
@@ -105,7 +105,10 @@ export var recompileOnChange = ($compile : angular.ICompileService) => {
                         }
 
                         innerScope = scope.$new();
-                        innerScope[attrs["key"]] = value;
+
+                        if (typeof attrs["key"] !== "undefined") {
+                            innerScope[attrs["key"]] = value;
+                        }
 
                         compiledContents(innerScope, (clone) => {
                             element.append(clone);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -33,8 +33,8 @@
                         {{ "TR__DELETE" | translate }}
                     </a>
                 </span>
-                <adh-recompile-on-change data-value="{{data.path}}" data-key="path2">
-                    <adh-rate data-refers-to="{{path2}}"></adh-rate>
+                <adh-recompile-on-change data-value="{{data.path}}">
+                    <adh-rate data-refers-to="{{data.path}}"></adh-rate>
                 </adh-recompile-on-change>
             </div>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Listing.html
@@ -1,6 +1,6 @@
 <!-- FIXME: only for manual testing -->
 <a data-ng-click="changeData()" href="">test filter</a>
-<adh-recompile-on-change data-value="{{elements}}" data-key="items">
+<adh-recompile-on-change data-value="{{elements}}">
     <adh-map-listing-internal data-ng-if="polygon && elements" data-items="elements" data-height="400" data-polygon="polygon">
     </adh-map-listing-internal>
 </adh-recompile-on-change>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -13,7 +13,6 @@
 
     <adh-recompile-on-change
         data-ng-switch-when="body"
-        data-key="userUrl"
         data-value="{{userUrl}}">
         <adh-user-profile
             data-path="{{userUrl}}">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/KiezkassenProposalDetailColumn.html
@@ -9,9 +9,12 @@
 
     <a data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhResourceUrl }}"><i class="icon-document moving-column-icon"></i></a>
 
-    <adh-mein-berlin-kiezkassen-proposal-detail
-        data-ng-switch-when="body"
-        data-ng-if="proposalUrl"
-        data-path="{{proposalUrl}}">
-    </adh-mein-berlin-kiezkassen-proposal-detail>
+    <adh-recompile-on-change
+            data-ng-switch-when="body"
+            data-value="{{proposalUrl}}">
+        <adh-mein-berlin-kiezkassen-proposal-detail
+            data-ng-if="proposalUrl"
+            data-path="{{proposalUrl}}">
+        </adh-mein-berlin-kiezkassen-proposal-detail>
+    </adh-recompile-on-change>
 </div>

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalDetailColumn.html
@@ -13,7 +13,7 @@
 
     <a data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhResourceUrl }}"><i class="icon-document moving-column-icon"></i></a>
 
-    <adh-recompile-on-change data-ng-switch-when="body" data-value="{{proposalUrl}}" data-key="proposalUrl">
+    <adh-recompile-on-change data-ng-switch-when="body" data-value="{{proposalUrl}}">
         <adh-resource-wrapper>
             <adh-mercator-proposal-detail-view data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-proposal-detail-view>
         </adh-resource-wrapper>


### PR DESCRIPTION
This fixes an issue where the rate object did not update when the
proposal changed.

One solution was to only wrap the rate in adhRecompileOnChange. I choose
to wrap the whole proposal detail in order to avoid similar issues in
the future.

Something similar is also used in mercator.