### PR TITLE
2015 04 jk run all tests+1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ install:
   - "python bootstrap.py --setuptools-version=12.0.4"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/buildout 2>/dev/null"
 script:
-  - "./bin/py.test_run_unittests_with_coverage"
-  - "./bin/py.test_run_all"
+  - "./bin/polytester -v pyunit,pyfunc,jsunit,jsint"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/protractor etc/protractorConfSauce.js"
 notifications:
   email: false

--- a/base.cfg
+++ b/base.cfg
@@ -1,0 +1,39 @@
+# Base buildout to develop adhoracy backend/frontend extensions packages
+[buildout]
+extends =
+    src/adhocracy_core/sources.cfg
+    src/adhocracy_core/base.cfg
+    src/adhocracy_core/checkcode.cfg
+    src/adhocracy_core/sphinx.cfg
+    src/adhocracy_core/wheels.cfg
+#    src/adhocracy_core/varnish.cfg
+    src/adhocracy_frontend/sources.cfg
+    src/adhocracy_frontend/base.cfg
+    src/adhocracy_frontend/checkcode_and_compile.cfg
+# local development packages
+develop =
+    src/adhocracy_core
+    src/adhocracy_sample
+    src/adhocracy_frontend
+    src/adhocracy_mercator
+    src/adhocracy_meinberlin
+    src/mercator
+    src/meinberlin
+# enable script to build wheels for adhocracy packages
+parts +=
+    make_wheels
+# packages for all install / testing / documentation buildout parts
+eggs =  adhocracy_core[debug]
+        adhocracy_frontend[debug]
+        adhocracy_mercator[debug]
+        adhocracy_meinberlin
+        adhocracy_sample
+        mercator[debug]
+        meinberlin[debug]
+       
+[test_run_unit]
+package_paths = src/adhocracy_*  src/adhocracy_frontend/adhocracy_frontend/tests/unit
+
+[test_run_all]
+package_paths = src/meinberlin/meinberlin/tests src/mercator/mercator/tests src/adhocracy_frontend/adhocracy_frontend/tests ${test_run_unit:package_paths}
+ 

--- a/buildout-core.cfg
+++ b/buildout-core.cfg
@@ -1,20 +1,6 @@
 [buildout]
 extends =
-    src/adhocracy_core/sources.cfg
-    src/adhocracy_core/base.cfg
-    src/adhocracy_core/checkcode.cfg
-    src/adhocracy_core/sphinx.cfg
-    src/adhocracy_core/wheels.cfg
-#    src/adhocracy_core/varnish.cfg
-    src/adhocracy_frontend/sources.cfg
-    src/adhocracy_frontend/base.cfg
-    src/adhocracy_frontend/checkcode_and_compile.cfg
-develop =
-    src/adhocracy_core
-    src/adhocracy_sample
-    src/adhocracy_frontend
-parts +=
-    make_wheels
+    base.cfg
 
 [adhocracy]
 frontend.static_dir = src/adhocracy_frontend/adhocracy_frontend/build
@@ -41,5 +27,3 @@ vcl = ${buildout:directory}/etc/varnish.vcl
 [make_wheels]
 wheels +=
        src/adhocracy_frontend
-
-[eggs]

--- a/buildout-meinberlin.cfg
+++ b/buildout-meinberlin.cfg
@@ -1,33 +1,11 @@
 [buildout]
 extends =
-    src/adhocracy_core/sources.cfg
-    src/adhocracy_core/base.cfg
-    src/adhocracy_core/checkcode.cfg
-    src/adhocracy_core/sphinx.cfg
-    src/adhocracy_core/wheels.cfg
-#    src/adhocracy_core/varnish.cfg
-    src/adhocracy_frontend/sources.cfg
-    src/adhocracy_frontend/base.cfg
-    src/adhocracy_frontend/checkcode_and_compile.cfg
-develop =
-    src/adhocracy_core
-    src/adhocracy_meinberlin
-    src/adhocracy_sample
-    src/adhocracy_frontend
-    src/meinberlin
-parts +=
-    make_wheels
+    base.cfg
 
 [adhocracy]
 frontend.static_dir = src/meinberlin/meinberlin/build
 frontend_package_name = meinberlin
 backend_package_name = adhocracy_meinberlin
-
-[test_run_unit]
-package_paths = src/adhocracy_*  src/adhocracy_frontend/adhocracy_frontend/tests/unit
-
-[test_run_all]
-package_paths = src/meinberlin/meinberlin/tests src/adhocracy_frontend/adhocracy_frontend/tests ${test_run_unit:package_paths}
 
 [merge_static_directories]
 static_directories = src/meinberlin/meinberlin/static ${adhocracy:frontend.core.static_dir}
@@ -38,13 +16,6 @@ groups =
 #    10 adhocracy zeo,autobahn,backend,varnish,frontend
     20 adhocracy_test test_zeo,test_autobahn,test_backend,test_frontend
 
-[sphinx_documentation]
-recipe = zc.recipe.egg
-dependent-scripts = true
-eggs +=
-       meinberlin[debug]
-       adhocracy_meinberlin[debug]
-
 [varnish]
 port = 8088
 vcl = ${buildout:directory}/etc/varnish.vcl
@@ -54,8 +25,3 @@ wheels +=
        src/adhocracy_frontend
        src/adhocracy_meinberlin
        src/meinberlin
-
-[eggs]
-
-[sphinx]
-eggs += meinberlin[debug]

--- a/buildout-mercator.cfg
+++ b/buildout-mercator.cfg
@@ -1,33 +1,11 @@
 [buildout]
 extends =
-    src/adhocracy_core/sources.cfg
-    src/adhocracy_core/base.cfg
-    src/adhocracy_core/checkcode.cfg
-    src/adhocracy_core/sphinx.cfg
-    src/adhocracy_core/wheels.cfg
-#    src/adhocracy_core/varnish.cfg
-    src/adhocracy_frontend/sources.cfg
-    src/adhocracy_frontend/base.cfg
-    src/adhocracy_frontend/checkcode_and_compile.cfg
-develop =
-    src/adhocracy_core
-    src/adhocracy_mercator
-    src/adhocracy_sample
-    src/adhocracy_frontend
-    src/mercator
-parts +=
-    make_wheels
+    base.cfg 
 
 [adhocracy]
 frontend.static_dir = src/mercator/mercator/build
 frontend_package_name = mercator
 backend_package_name = adhocracy_mercator
-
-[test_run_unit]
-package_paths = src/adhocracy_* src/adhocracy_frontend/adhocracy_frontend/tests/unit
-
-[test_run_all]
-package_paths = src/mercator/mercator/tests src/adhocracy_frontend/adhocracy_frontend/tests ${test_run_unit:package_paths}
 
 [merge_static_directories]
 static_directories = src/mercator/mercator/static ${adhocracy:frontend.core.static_dir}
@@ -38,13 +16,6 @@ groups =
 #    10 adhocracy zeo,autobahn,backend,varnish,frontend
     20 adhocracy_test test_zeo,test_autobahn,test_backend,test_frontend
 
-[sphinx_documentation]
-recipe = zc.recipe.egg
-dependent-scripts = true
-eggs +=
-       mercator[debug]
-       adhocracy_mercator[debug]
-
 [varnish]
 port = 8088
 vcl = ${buildout:directory}/etc/varnish.vcl
@@ -54,8 +25,3 @@ wheels +=
        src/adhocracy_frontend
        src/adhocracy_mercator
        src/mercator
-
-[eggs]
-
-[sphinx]
-eggs += mercator[debug]

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -88,10 +88,6 @@ frontend integration tests:
            any tricks, because we don't run blanket for test coverage
            reporting.
 
-frontend functional tests::
-
-    bin/py.test ./src/adhocracy_frontend/adhocracy_frontend/tests/functional
-
 protractor acceptance tests::
 
     bin/protractor etc/protractorConf.js

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -48,27 +48,6 @@ frontend unit tests:
                make -C ./parts/static/js/ compile_tests_browser test-no-blanket
                xdg-open http://localhost:6551/static/test-no-blanket.html
 
-    C.  With node.js::
-
-            make -C ./parts/static/js/ compile_tests_node
-            bin/jasmine-node ./parts/static/js/
-
-        .. note::
-
-           Node only works with the commonjs module system;
-           whereas the frontend currently uses requirejs and the amd
-           module system (rationale: requirejs is more powerful with
-           importing module-system-oblivious libraries like angular,
-           underscore, ...).  You know that you have run into this
-           problem if this appears in your browser console::
-
-               Uncaught Error: Module name "Adhocracy/UtilSpec" has not been loaded yet for context: _. Use require([])
-               http://requirejs.org/docs/errors.html#notloaded
-
-           In order for the javascript code to work in the browser, you
-           need to revert to adm::
-
-               make -C ./parts/static/js/ compile_tests_browser
 
 frontend integration tests:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,7 +27,7 @@ frontend unit tests:
 
     A.  Integrated with py.test::
 
-            bin/py.test ./src/adhocracy_frontend/adhocracy_frontend/tests/unit/
+           bin/polytester jsunit
 
     B.  In browser::
 
@@ -49,7 +49,7 @@ frontend unit tests:
                xdg-open http://localhost:6551/static/test-no-blanket.html
 
 
-frontend integration tests:
+frontend integration tests (jsint):
 
     Frontend integration tests behave like unit tests in the sense
     that they are driven by jasmine and can access all exports of all
@@ -72,7 +72,7 @@ frontend integration tests:
 
     A.  Integrated with py.test::
 
-            bin/py.test ./tests/integration/
+           bin/polytester jsint
 
     B.  In browser::
 
@@ -90,19 +90,30 @@ frontend integration tests:
 
 protractor acceptance tests::
 
-    bin/protractor etc/protractorConf.js
+     bin/polytester acceptance
 
 run backend functional tests::
 
-    bin/py.test -m"functional" src/adhocracy_core/adhocracy_core/websocket src/adhocracy_core/docs
+    bin/polytester pyfunc
 
 run backend unit tests and show python test code coverage::
 
-    bin/py.test_run_unittests_with_coverage
+    bin/polytester pyunit
+    xdg-open ./htmlcov/index.html
 
-run all tests (without protractor acceptance tests)::
+run all test::
 
-    bin/py.test_run_all
+    bin/polytester
+
+to display console output::
+
+    bin/polytester -v
+
+modify test config:
+
+     tests.ini  (run all tests with polytester)
+     pytest.ini (python/jasmin tests with pytest)
+     etc/protractorConf (acceptantance tests with protractor)
 
 delete database (works best on development systems without valuable data!)::
 

--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -182,7 +182,6 @@ class BatchView(RESTView):
             code = 500
             error_dict = internal_exception_to_dict(err)
             body = {'status': 'error', 'errors': [error_dict]}
-            logger.exception('Unexpected exception processing nested request')
         return BatchItemResponse(code, body)
 
     def _extend_path_map(self, path_map: dict, result_path: str,

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -2,6 +2,7 @@
 from unittest.mock import Mock
 from configparser import ConfigParser
 from shutil import rmtree
+from subprocess import CalledProcessError
 import json
 import os
 import subprocess
@@ -454,11 +455,13 @@ def supervisor(request) -> str:
     pid_file = 'var/supervisord.pid'
     if _is_running(pid_file):
         return True
-    output = subprocess.check_output('bin/supervisord',
-                                     shell=True,
-                                     stderr=subprocess.STDOUT)
-    assert bool(output) is False  # assert there are no error messages
-    return output
+    try:
+        subprocess.check_output('bin/supervisord',
+                                shell=True,
+                                stderr=subprocess.STDOUT)
+    # workaround if pid file is missing but supervisord is still running
+    except CalledProcessError as err:
+        print(err)
 
 
 @fixture(scope='class')

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -16,6 +16,9 @@ parts +=
      test_run_unit
      checkversions
      supervisor
+eggs =
+    pip
+    adhocracy_core[debug]
 
 [servers]
 proxy_ip = 127.0.0.1
@@ -35,10 +38,8 @@ paths = etc
 [adhocracy]
 recipe = zc.recipe.egg
 dependent-scripts = true
-eggs =
-    pip
-    adhocracy_core[debug]
-backend_package_name = adhocracy_sample
+eggs = {buildout:eggs}
+ackend_package_name = adhocracy_sample
 
 [development.ini]
 recipe = collective.recipe.template

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -13,7 +13,6 @@ parts +=
      test_with_ws.ini
      noserver.ini
      omelette
-     test_run_unit
      checkversions
      supervisor
 eggs =
@@ -65,18 +64,6 @@ output = ${buildout:directory}/etc/noserver.ini
 recipe = collective.recipe.omelette
 eggs =
     ${adhocracy:eggs}
-
-[test_run_unit]
-recipe = collective.recipe.template
-package_paths = adhocracy_core
-input = inline:
-    #!/bin/bash
-    cd ${buildout:directory}
-    bin/coverage run bin/py.test -m"not functional and not jasmine" ${:package_paths} "$@"
-    bin/coverage report
-    bin/coverage html
-output = ${buildout:bin-directory}/py.test_run_unittests_with_coverage
-mode = 755
 
 # check for new python packages with something like
 # bin/checkversions -v -l 0 versions.cfg | grep was

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -31,6 +31,7 @@ if sys.version_info < (3, 4):
 
 test_requires = [
     'pytest',
+    'polytester',
     'selenium',
     'webtest',
     'pytest-splinter',

--- a/src/adhocracy_core/sphinx.cfg
+++ b/src/adhocracy_core/sphinx.cfg
@@ -29,9 +29,7 @@ mode = 755
 [sphinx]
 recipe = zc.recipe.egg
 dependent-scripts = true
-eggs = Sphinx
+eggs = ${buildout:eggs}
+       Sphinx
        repoze.sphinx.autointerface
        sphinx-autodoc-annotation
-       adhocracy_core[debug]
-       adhocracy_sample
-       adhocracy_frontend[debug]

--- a/src/adhocracy_frontend/base.cfg
+++ b/src/adhocracy_frontend/base.cfg
@@ -10,6 +10,9 @@ parts +=
      source_env
      test_run_all
      supervisor
+eggs =
+    pip
+    adhocracy_frontend[debug]
 
 [servers]
 proxy_ip = 127.0.0.1
@@ -17,9 +20,7 @@ proxy_ip = 127.0.0.1
 [adhocracy]
 recipe = zc.recipe.egg
 dependent-scripts = true
-eggs =
-    pip
-    adhocracy_frontend[debug]
+eggs = ${buildout:eggs}
 frontend.core.static_dir = src/adhocracy_frontend/adhocracy_frontend/static
 frontend.static_dir = parts/static
 frontend_package_name = adhocracy_frontend

--- a/src/adhocracy_frontend/base.cfg
+++ b/src/adhocracy_frontend/base.cfg
@@ -8,7 +8,6 @@ parts +=
      frontend_test.ini
      phantomjs
      source_env
-     test_run_all
      supervisor
 eggs =
     pip
@@ -46,17 +45,6 @@ input = inline:
    export A3_ROOT=${buildout:directory}
    export LD_LIBRARY_PATH=${buildout:directory}/python/parts/opt/lib/
 output =${buildout:directory}/source_env
-
-[test_run_all]
-recipe = collective.recipe.template
-package_paths =adhocracy_frontend/tests
-input = inline:
-    #!/bin/bash
-    cd ${buildout:directory}
-    source ${source_env:output}
-    bin/py.test --capture=fd --timeout=60 ${:package_paths}
-output = ${buildout:bin-directory}/py.test_run_all
-mode = 755
 
 [supervisor]
 recipe = collective.recipe.supervisor

--- a/tests.yml
+++ b/tests.yml
@@ -1,0 +1,10 @@
+pyunit:
+    command: bin/coverage run bin/py.test --timeout=60 -m"not functional and not jasmine" src/adhocracy_*  && bin/coverage report && bin/coverage html 
+pyfunc:
+    command: bin/py.test --timeout=60 -m"functional and not jasmine" src/adhocracy_*
+jsunit:
+    command: bin/py.test -m"jasmine" src/adhocracy_frontend/adhocracy_frontend/tests/unit/
+jsint:
+    command: bin/py.test -m"jasmine" src/adhocracy_frontend/adhocracy_frontend/tests/integration/
+acceptance:
+    command: bin/protractor etc/protractorConf.js


### PR DESCRIPTION


Problem:

    no script to run all tests
    documentation how to run tests complicated/broken
    broken tests because nobody runs them (happend twice in python test)

Proposal:

    user polytester to run all python and available javascript/acceptance tests
    simplify buildout config to create testscripts and add dependencies to python path
    updated documentation

Example:

run all:

    bin/polytester 

restrict tests:

    bin/polytester  pyunit,pyfunc

enable verbose output:

       bin/polytester -v  pyunit

