### PR TITLE
improve HTML title

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <title>adhocracy root page</title>
+        <title>Adhocracy</title>
         <meta charset="utf-8">
         % for url in css:
             <link rel="stylesheet" href="${url}"/>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
@@ -18,6 +18,7 @@
         <script type="text/javascript">
             require(["Adhocracy", "text!${config}", "text!${meta_api}"], function(Adh, config_string, meta_api_string) {
                 var config = JSON.parse(config_string);
+                document.title = config.site_name;
                 var meta_api = JSON.parse(meta_api_string);
                 $(document).ready(function() {
                     Adh.init(config, meta_api);


### PR DESCRIPTION
we did neglect the `<title>` in adhocracy for some time now. This pull requests sets a sane default and uses `site_name` from the frontend config once that is available.

In the future we might want to hook the title into routing, but that is not required just yet.

Note that `site_name` is probably not set properly on all our production setups. @slomo can you please take care of that?