### PR TITLE
Embed contexts

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
@@ -186,35 +186,23 @@
         }
         iframe.data("autoresize", autoresize);
 
-        var url;
-        if (widget === "plain") {
+        if (data.autourl) {
+            if (hasAutourl()) {
+                throw "There's already an embedded element with enabled autourl";
+            }
+            data.initialUrl = getUrlFromHash() || data.initialUrl;
 
-            var initialUrl;
-            if (data.autourl) {
-                if (hasAutourl()) {
-                    throw "There's already an embedded element with enabled autourl";
+            adhocracy.registerMessageHandler("urlchange", (data, source) => {
+                if (getIFrameByWindow(source) === iframe[0]) {
+                    setHashFromUrl(data.url);
                 }
-                initialUrl = getUrlFromHash();
-
-                adhocracy.registerMessageHandler("urlchange", (data, source) => {
-                    if (getIFrameByWindow(source) === iframe[0]) {
-                        setHashFromUrl(data.url);
-                    }
-                });
-            }
-            if (typeof initialUrl === "undefined") {
-                initialUrl = data.initialUrl;
-            }
-            if (typeof initialUrl === "undefined") {
-                initialUrl = "/";
-            }
-            url = origin + initialUrl;
-        } else {
-            url = origin + appUrl + widget;
+            });
         }
+
+        var url = origin + appUrl + widget;
+
         delete data.autourl;
         delete data.autoresize;
-        delete data.initialUrl;
         url = addParamsToUrl(url, data);
         iframe.attr("src", url);
         iframe.addClass("adhocracy-embed");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -15,6 +15,7 @@ var metaParams = [
 
 export class Provider {
     public embeddableDirectives : string[];
+    public contexts : string[];
     public $get;
 
     /**
@@ -34,6 +35,10 @@ export class Provider {
             "empty"
         ];
 
+        this.contexts = [
+            "plain"
+        ];
+
         this.$get = () => new Service(this);
     }
 
@@ -46,11 +51,16 @@ export class Provider {
             }
         }
     }
+
+    public registerContext(name : string) : void {
+        this.contexts.push(name);
+    }
 }
 
 export class Service {
-    constructor(private provider : Provider) {}
+    public widget : string;
 
+    constructor(private provider : Provider) {}
 
     private location2template(widget : string, search) {
         var attrs = [];
@@ -87,6 +97,13 @@ export class Service {
 
             return {
                 template: template
+            };
+        } else if ((<any>_).includes(this.provider.contexts, widget)) {
+            $location.url(search.initialUrl || "/");
+            $location.replace();
+
+            return {
+                skip: true
             };
         } else {
             throw "unknown widget: " + widget;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -8,6 +8,7 @@ import AdhUtil = require("../Util/Util");
 
 var metaParams = [
     "autoresize",
+    "initialUrl",
     "locale",
     "nocenter",
     "noheader"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -80,6 +80,9 @@ export class Service {
         var widget : string = $location.path().split("/")[2];
         var search = $location.search();
 
+        // For later use
+        this.widget = widget;
+
         // FIXME: DefinitelyTyped: remove <any> when borisyankov/DefinitelyTyped#3573 is resolved
         if ((<any>_).includes(this.provider.embeddableDirectives, widget)) {
             var template = this.location2template(widget, search);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/EmbedSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/EmbedSpec.ts
@@ -14,8 +14,6 @@ export var register = () => {
             $locationMock.protocol.and.returnValue("http");
             $locationMock.path.and.returnValue("/embed/document-workbench");
             $locationMock.search.and.returnValue({
-                path: "/this/is/a/path",
-                test: "\"'&"
             });
             $compileMock = jasmine.createSpy("$compileMock")
                 .and.returnValue(() => undefined);
@@ -71,30 +69,41 @@ export var register = () => {
                 it("compiles a template from the parameters given in $location", () => {
                     var expected = "<adh-document-workbench data-path=\"/this/is/a/path\" " +
                         "data-test=\"&quot;&#39;&amp;\"></adh-document-workbench>";
-                    expect(service.location2template($locationMock)).toBe(expected);
+                    var widget = "document-workbench";
+                    var search = {
+                        path: "/this/is/a/path",
+                        test: "\"'&"
+                    };
+                    expect(service.location2template(widget, search)).toBe(expected);
                 });
                 it("does not include meta params as attributes", () => {
                     var expected = "<adh-document-workbench data-path=\"/this/is/a/path\"></adh-document-workbench>";
-                    $locationMock.search.and.returnValue({
+                    var widget = "document-workbench";
+                    var search = {
                         path: "/this/is/a/path",
                         noheader: "",
                         nocenter: "",
                         locale: "de"
-                    });
-                    expect(service.location2template($locationMock)).toBe(expected);
+                    };
+                    expect(service.location2template(widget, search)).toBe(expected);
                 });
                 it("returns '' if widget is 'empty'", () => {
                     var expected = "";
-                    $locationMock.path.and.returnValue("/embed/empty");
-                    expect(service.location2template($locationMock)).toBe(expected);
+                    var widget = "empty";
+                    var search =  {};
+                    expect(service.location2template(widget, search)).toBe(expected);
                 });
+
+            });
+
+            describe("route", () => {
                 it("throws if $location does not specify a widget", () => {
                     $locationMock.path.and.returnValue("/embed/");
-                    expect(() => service.location2template($locationMock)).toThrow();
+                    expect(() => service.route($locationMock)).toThrow();
                 });
                 it("throws if the requested widget is not available for embedding", () => {
                     $locationMock.path.and.returnValue("/embed/do-not-embed");
-                    expect(() => service.location2template($locationMock)).toThrow();
+                    expect(() => service.route($locationMock)).toThrow();
                 });
             });
         });


### PR DESCRIPTION
This is a first step of severl canges to adhEmbed that aim at allowing navigation in embedded widgets. This pull request introduces "contexts" to the embed API. A context is basically the whole platform (already availbe on the SDK level as "plain" widget). In the future, different context are supposed to have different functionality.