### PR TITLE
Hide user profile links if not available

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -171,6 +171,11 @@ export class Service implements AdhTopLevelState.IAreaInput {
         });
     }
 
+    public has(resourceType : string, view : string = "", processType : string = "") : boolean {
+        var key : string = resourceType + "@" + view + "@" + processType;
+        return this.provider.defaults.hasOwnProperty(key) || this.provider.specifics.hasOwnProperty(key);
+    }
+
     public route(path : string, search : Dict) : angular.IPromise<Dict> {
         var self : Service = this;
         var segs : string[] = path.replace(/\/+$/, "").split("/");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Meta.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Meta.html
@@ -1,2 +1,2 @@
 <!-- as this is an inline directive, whitespace is relevant, including no newline at end of file
---><span data-ng-if="isAnonymous">{{name || userBasic.name}}</span><a data-ng-href="{{ path | adhResourceUrl }}" data-ng-if="!isAnonymous">{{name || userBasic.name}}</a>
+--><span data-ng-if="noLink">{{name || userBasic.name}}</span><a data-ng-href="{{ path | adhResourceUrl }}" data-ng-if="!noLink">{{name || userBasic.name}}</a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -269,7 +269,7 @@ export var indicatorDirective = (adhConfig : AdhConfig.IService) => {
 };
 
 
-export var metaDirective = (adhConfig : AdhConfig.IService) => {
+export var metaDirective = (adhConfig : AdhConfig.IService, adhResourceArea : AdhResourceArea.Service) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Meta.html",
@@ -282,7 +282,7 @@ export var metaDirective = (adhConfig : AdhConfig.IService) => {
                 adhHttp.resolve($scope.path)
                     .then((res) => {
                         $scope.userBasic = res.data[SIUserBasic.nick];
-                        $scope.isAnonymous = false;
+                        $scope.noLink = !adhResourceArea.has(RIUser.content_type);
                     });
             } else {
                 $translate("TR__GUEST").then((translated) => {
@@ -290,7 +290,7 @@ export var metaDirective = (adhConfig : AdhConfig.IService) => {
                         name: translated
                     };
                 });
-                $scope.isAnonymous = true;
+                $scope.noLink = true;
             }
         }]
     };
@@ -531,7 +531,7 @@ export var register = (angular) => {
         .directive("adhCreatePasswordReset", ["adhConfig", "adhHttp", "adhTopLevelState", createPasswordResetDirective])
         .directive("adhRegister", ["adhConfig", "adhUser", "adhTopLevelState", "adhShowError", registerDirective])
         .directive("adhUserIndicator", ["adhConfig", indicatorDirective])
-        .directive("adhUserMeta", ["adhConfig", metaDirective])
+        .directive("adhUserMeta", ["adhConfig", "adhResourceArea", metaDirective])
         .directive("adhUserMessage", ["adhConfig", "adhHttp", userMessageDirective])
         .directive("adhUserDetailColumn", ["adhBindVariablesAndClear", "adhPermissions", "adhConfig", userDetailColumnDirective])
         .directive("adhUserListingColumn", ["adhBindVariablesAndClear", "adhConfig", userListingColumnDirective]);


### PR DESCRIPTION
if no user profiles are available on a platform (e.g. embedded) we should not link to that profile. Thsi pull requests implements that by using information that is already available in adhResourceArea.