### PR TITLE
route based on embed context

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
@@ -60,25 +60,25 @@ export var register = (angular) => {
         }])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIBasicPool.content_type, "", "", {
+                .default(RIBasicPool.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide",
                     content2Url: ""
                 })
-                .default(RIProposalVersion.content_type, "", "", {
+                .default(RIProposalVersion.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", "", () => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "", "", "", () => (resource : RIProposalVersion) => {
                     return {
                         content2Url: resource.path
                     };
                 })
-                .default(RIUser.content_type, "", "", {
+                .default(RIUser.content_type, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 })
-                .default(RIUsersService.content_type, "", "", {
+                .default(RIUsersService.content_type, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -59,7 +59,7 @@ export class Provider {
 }
 
 export class Service {
-    public widget : string;
+    private widget : string;
 
     constructor(private provider : Provider) {}
 
@@ -75,6 +75,18 @@ export class Service {
             }
         }
         return AdhUtil.formatString("<adh-{0} {1}></adh-{0}>", _.escape(widget), attrs.join(" "));
+    }
+
+    public isEmbedded() : boolean {
+        return typeof this.widget !== "undefined";
+    }
+
+    public getContext() : string {
+        if (!this.isEmbedded() || this.widget === "plain") {
+            return "";
+        } else {
+            return this.widget;
+        }
     }
 
     public route($location : angular.ILocationService) : AdhTopLevelState.IAreaInput {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -210,9 +210,10 @@ export class Service implements AdhTopLevelState.IAreaInput {
             }
 
             return self.getSpecifics(resource, view, processType, embedContext).then((specifics : Dict) => {
-                var defaults : Dict = self.getDefaults(resource.content_type, view, processType);
+                var defaults : Dict = self.getDefaults(resource.content_type, view, processType, embedContext);
 
                 var meta : Dict = {
+                    embedContext: embedContext,
                     processType: processType,
                     platformUrl: self.adhConfig.rest_url + "/" + segs[1],
                     contentType: resource.content_type,
@@ -228,7 +229,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
     }
 
     public reverse(data : Dict) : { path : string; search : Dict; } {
-        var defaults = this.getDefaults(data["contentType"], data["view"], data["processType"]);
+        var defaults = this.getDefaults(data["contentType"], data["view"], data["processType"], data["embedContext"]);
         var path = path = data["resourceUrl"].replace(this.adhConfig.rest_url, "");
 
         if (path.substr(-1) !== "/") {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -210,7 +210,8 @@ export class Service implements AdhTopLevelState.IAreaInput {
     }
 
     public has(resourceType : string, view : string = "", processType : string = "") : boolean {
-        var key : string = resourceType + "@" + view + "@" + processType;
+        var embedContext = this.adhEmbed.getContext();
+        var key : string = resourceType + "@" + view + "@" + processType + "@" + embedContext;
         return this.provider.defaults.hasOwnProperty(key) || this.provider.specifics.hasOwnProperty(key);
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -187,7 +187,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
         }
 
         var view : string = "";
-        var embedContext  = (<any>this.adhEmbed).widget || "";
+        var embedContext = this.adhEmbed.getContext();
 
         // if path has a view segment
         if (_.last(segs).match(/^@/)) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
@@ -10,6 +10,7 @@ export var register = () => {
         describe("Service", () => {
             var providerMock;
             var adhHttpMock;
+            var adhEmbedMock;
             var adhConfigMock;
             var $injectorMock;
             var $locationMock;
@@ -36,10 +37,12 @@ export var register = () => {
                     rest_url: "rest_url"
                 };
 
+                adhEmbedMock = {};
+
                 adhResourceUrlFilterMock = (path) => path;
 
                 service = new AdhResourceArea.Service(providerMock, <any>q, $injectorMock, $locationMock, adhHttpMock, adhConfigMock,
-                    adhResourceUrlFilterMock);
+                    adhEmbedMock, adhResourceUrlFilterMock);
             });
 
             describe("route", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
@@ -20,7 +20,8 @@ export var register = () => {
             beforeEach(() => {
                 providerMock = {
                     defaults: {},
-                    specifics: {}
+                    specifics: {},
+                    templates: {}
                 };
 
                 adhHttpMock = jasmine.createSpyObj("adhHttp", ["get"]);
@@ -37,7 +38,8 @@ export var register = () => {
                     rest_url: "rest_url"
                 };
 
-                adhEmbedMock = {};
+                adhEmbedMock = jasmine.createSpyObj("adhEmbed", ["getContext"]);
+                adhEmbedMock.getContext.and.returnValue("");
 
                 adhResourceUrlFilterMock = (path) => path;
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -507,16 +507,16 @@ export var register = (angular) => {
         }])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIUser.content_type, "", "", {
+                .default(RIUser.content_type, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIUser.content_type, "", "", () => (resource : RIUser) => {
+                .specific(RIUser.content_type, "", "", "", () => (resource : RIUser) => {
                     return {
                         userUrl: resource.path
                     };
                 })
-                .default(RIUsersService.content_type, "", "", {
+                .default(RIUsersService.content_type, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-hide-hide",
                     userUrl: "",  // not used by default, but should be overridable

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Workbench/Workbench.ts
@@ -99,20 +99,20 @@ export var register = (angular) => {
         // FIXME: the following should be specific to kiezkassen process
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIKiezkassenProcess.content_type, "", "", {
+                .default(RIKiezkassenProcess.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", "", [() => (resource : RIKiezkassenProcess) => {
+                .specific(RIKiezkassenProcess.content_type, "", "", "", [() => (resource : RIKiezkassenProcess) => {
                     return {
                         processUrl: resource.path
                     };
                 }])
-                .default(RIKiezkassenProcess.content_type, "create_proposal", "", {
+                .default(RIKiezkassenProcess.content_type, "create_proposal", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", "", ["adhHttp", "adhUser", (
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", "", "", ["adhHttp", "adhUser", (
                     adhHttp : AdhHttp.Service<any>,
                     adhUser : AdhUser.Service
                 ) => (resource : RIKiezkassenProcess) => {
@@ -128,32 +128,32 @@ export var register = (angular) => {
                         });
                     });
                 }])
-                .default(RIProposalVersion.content_type, "", "", {
+                .default(RIProposalVersion.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", "", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "", "", "", [() => (resource : RIProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RIProposalVersion.content_type, "comments", "", {
+                .default(RIProposalVersion.content_type, "comments", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", "", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "comments", "", "", [() => (resource : RIProposalVersion) => {
                     return {
                         commentableUrl: resource.path,
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RICommentVersion.content_type, "", "", {
+                .default(RICommentVersion.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", "", ["adhHttp", "$q", (
+                .specific(RIProposalVersion.content_type, "", "", "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -1117,20 +1117,20 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIMercatorProposalVersion.content_type, "", "", {
+                .default(RIMercatorProposalVersion.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion.content_type, "", "", "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path
                     };
                 })
-                .default(RIMercatorProposalVersion.content_type, "edit", "", {
+                .default(RIMercatorProposalVersion.content_type, "edit", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-hide"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "edit", "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
+                .specific(RIMercatorProposalVersion.content_type, "edit", "", "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
                     return (resource : RIMercatorProposalVersion) => {
                         var poolPath = AdhUtil.parentPath(resource.path);
 
@@ -1145,11 +1145,11 @@ export var register = (angular) => {
                         });
                     };
                 }])
-                .default(RIMercatorProposalVersion.content_type, "comments", "", {
+                .default(RIMercatorProposalVersion.content_type, "comments", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "comments", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion.content_type, "comments", "", "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         commentableUrl: resource.path
@@ -1158,11 +1158,11 @@ export var register = (angular) => {
 
             _(SIMercatorSubResources.Sheet._meta.readable).forEach((section : string) => {
                 adhResourceAreaProvider
-                    .default(RIMercatorProposalVersion.content_type, "comments:" + section, "", {
+                    .default(RIMercatorProposalVersion.content_type, "comments:" + section, "", "", {
                         space: "content",
                         movingColumns: "is-collapse-show-show"
                     })
-                    .specific(RIMercatorProposalVersion.content_type, "comments:" + section, "", () =>
+                    .specific(RIMercatorProposalVersion.content_type, "comments:" + section, "", "", () =>
                         (resource : RIMercatorProposalVersion) => {
                             return {
                                 proposalUrl: resource.path,

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -179,11 +179,11 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RICommentVersion.content_type, "", "", {
+                .default(RICommentVersion.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RICommentVersion.content_type, "", "", ["adhHttp", "$q", (
+                .specific(RICommentVersion.content_type, "", "", "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => (resource : RICommentVersion) => {
@@ -214,17 +214,17 @@ export var register = (angular) => {
                     })
                     .then(() => specifics);
                 }])
-                .default(RIPoolWithAssets.content_type, "", "", {
+                .default(RIPoolWithAssets.content_type, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide",
                     proposalUrl: "",  // not used by default, but should be overridable
                     focus: "0"
                 })
-                .default(RIPoolWithAssets.content_type, "create_proposal", "", {
+                .default(RIPoolWithAssets.content_type, "create_proposal", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIPoolWithAssets.content_type, "create_proposal", "", ["adhHttp", "adhUser",
+                .specific(RIPoolWithAssets.content_type, "create_proposal", "", "", ["adhHttp", "adhUser",
                     (adhHttp : AdhHttp.Service<any>, adhUser) => {
                         return (resource : RIPoolWithAssets) => {
                             return adhUser.ready.then(() => {


### PR DESCRIPTION
The embed contexts introduced in #1051 are here put to use in order to have separate routing and a separate template on `adhResourceArea`.

Unfortunately, my local unittest setup seems to be broken and I was not able to execute the tests.