### PR TITLE
Move kiezkassen frontend to use actual backend process

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -106,7 +106,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         adhTopLevelStateProvider
             .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
                 $location.replace();
-                $location.path("/r/adhocracy/");
+                $location.path("/r/organisation/kiezkasse/");
                 return {
                     skip: true
                 };
@@ -121,7 +121,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
                 resourceUrl: "/principals/users/"
             })
             .space("content", {
-                resourceUrl: "/adhocracy/"  // FIXME
+                resourceUrl: "/organisation/kiezkasse/"
             });
     }]);
     app.config(["$compileProvider", ($compileProvider) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -40,52 +40,56 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIKiezkassenProcess) => {
-                    return {
-                        processUrl: resource.path
-                    };
-                }])
+                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    () => (resource : RIKiezkassenProcess) => {
+                        return {
+                            processUrl: resource.path
+                        };
+                    }])
                 .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "adhUser", (
-                    adhHttp : AdhHttp.Service<any>,
-                    adhUser : AdhUser.Service
-                ) => (resource : RIKiezkassenProcess) => {
-                    return adhUser.ready.then(() => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {
-                                    processUrl: resource.path
-                                };
-                            }
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    "adhHttp", "adhUser", (
+                        adhHttp : AdhHttp.Service<any>,
+                        adhUser : AdhUser.Service
+                    ) => (resource : RIKiezkassenProcess) => {
+                        return adhUser.ready.then(() => {
+                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                                if (!options.POST) {
+                                    throw 401;
+                                } else {
+                                    return {
+                                        processUrl: resource.path
+                                    };
+                                }
+                            });
                         });
-                    });
-                }])
+                    }])
                 .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIProposalVersion) => {
-                    return {
-                        proposalUrl: resource.path,
-                        processUrl: "/adhocracy"  // FIXME
-                    };
-                }])
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    () => (resource : RIProposalVersion) => {
+                        return {
+                            proposalUrl: resource.path,
+                            processUrl: "/adhocracy"  // FIXME
+                        };
+                    }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIProposalVersion) => {
-                    return {
-                        commentableUrl: resource.path,
-                        proposalUrl: resource.path,
-                        processUrl: "/adhocracy"  // FIXME
-                    };
-                }])
+                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    () => (resource : RIProposalVersion) => {
+                        return {
+                            commentableUrl: resource.path,
+                            proposalUrl: resource.path,
+                            processUrl: "/adhocracy"  // FIXME
+                        };
+                    }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -7,7 +7,7 @@ import AdhUser = require("../../../User/User");
 import AdhMeinBerlinWorkbench = require("../../Workbench/Workbench");
 
 import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
-import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_core/resources/pool/IBasicPool");  // FIXME
+import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess");
 import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
 import SIComment = require("../../../../Resources_/adhocracy_core/sheets/comment/IComment");
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -40,12 +40,6 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    () => (resource : RIKiezkassenProcess) => {
-                        return {
-                            processUrl: resource.path
-                        };
-                    }])
                 .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
@@ -60,9 +54,7 @@ export var register = (angular) => {
                                 if (!options.POST) {
                                     throw 401;
                                 } else {
-                                    return {
-                                        processUrl: resource.path
-                                    };
+                                    return {};
                                 }
                             });
                         });
@@ -74,8 +66,7 @@ export var register = (angular) => {
                 .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [
                     () => (resource : RIProposalVersion) => {
                         return {
-                            proposalUrl: resource.path,
-                            processUrl: "/organisation/kiezkasse"  // FIXME
+                            proposalUrl: resource.path
                         };
                     }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
@@ -86,8 +77,7 @@ export var register = (angular) => {
                     () => (resource : RIProposalVersion) => {
                         return {
                             commentableUrl: resource.path,
-                            proposalUrl: resource.path,
-                            processUrl: "/organisation/kiezkasse"  // FIXME
+                            proposalUrl: resource.path
                         };
                     }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
@@ -111,8 +101,7 @@ export var register = (angular) => {
                         return getCommentableUrl(resource).then((commentable) => {
                             return {
                                 commentableUrl: commentable.path,
-                                proposalUrl: commentable.path,
-                                processUrl: "/organisation/kiezkasse"  // FIXME
+                                proposalUrl: commentable.path
                             };
                         });
                     };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -36,20 +36,20 @@ export var register = (angular) => {
                 ) => {
                     return $templateRequest(adhConfig.pkg_path + pkgLocation + "/template.html");
                 }])
-                .default(RIKiezkassenProcess.content_type, "", "", "kiezkassen", {
+                .default(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", "", "kiezkassen", [() => (resource : RIKiezkassenProcess) => {
+                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIKiezkassenProcess) => {
                     return {
                         processUrl: resource.path
                     };
                 }])
-                .default(RIKiezkassenProcess.content_type, "create_proposal", "", "kiezkassen", {
+                .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", "", "kiezkassen", ["adhHttp", "adhUser", (
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "adhUser", (
                     adhHttp : AdhHttp.Service<any>,
                     adhUser : AdhUser.Service
                 ) => (resource : RIKiezkassenProcess) => {
@@ -65,32 +65,32 @@ export var register = (angular) => {
                         });
                     });
                 }])
-                .default(RIProposalVersion.content_type, "", "", "kiezkassen", {
+                .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", "", "kiezkassen", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RIProposalVersion.content_type, "comments", "", "kiezkassen", {
+                .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", "", "kiezkassen", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [() => (resource : RIProposalVersion) => {
                     return {
                         commentableUrl: resource.path,
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RICommentVersion.content_type, "", "", "kiezkassen", {
+                .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", "", "kiezkassen", ["adhHttp", "$q", (
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -75,7 +75,7 @@ export var register = (angular) => {
                     () => (resource : RIProposalVersion) => {
                         return {
                             proposalUrl: resource.path,
-                            processUrl: "/adhocracy"  // FIXME
+                            processUrl: "/organisation/kiezkasse"  // FIXME
                         };
                     }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
@@ -87,7 +87,7 @@ export var register = (angular) => {
                         return {
                             commentableUrl: resource.path,
                             proposalUrl: resource.path,
-                            processUrl: "/adhocracy"  // FIXME
+                            processUrl: "/organisation/kiezkasse"  // FIXME
                         };
                     }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
@@ -112,7 +112,7 @@ export var register = (angular) => {
                             return {
                                 commentableUrl: commentable.path,
                                 proposalUrl: commentable.path,
-                                processUrl: "/adhocracy"  // FIXME
+                                processUrl: "/organisation/kiezkasse"  // FIXME
                             };
                         });
                     };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Process/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Process/Detail.html
@@ -12,7 +12,7 @@
 
     <div class="mein-berlin-kiezkassen-detail-listing">
         <adh-listing
-            data-path="/"
+            data-path="{{path}}"
             data-ng-show="!showMap"
             data-no-create-form="true"
             data-empty-text="{{ 'TR__PROPOSAL_EMPTY_TEXT' | translate }}"
@@ -24,7 +24,7 @@
 
         <adh-wait condition="showMap">
             <adh-map-listing
-                data-path="/"
+                data-path="{{path}}"
                 data-ng-show="showMap"
                 data-polygon="polygon"
                 data-no-create-form="true"

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
@@ -242,6 +242,7 @@ export var createDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhShowError,
     adhSubmitIfValid,
     adhResourceUrlFilter,
@@ -262,9 +263,11 @@ export var createDirective = (
             scope.data.lat = undefined;
             scope.data.lng = undefined;
 
+            var processUrl = adhTopLevelState.get("processUrl");
+
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.meinBerlinProposalForm, () => {
-                    return postCreate(adhHttp, adhPreliminaryNames)(scope, adhConfig.rest_url)
+                    return postCreate(adhHttp, adhPreliminaryNames)(scope, processUrl)
                         .then((result) => {
                             $location.url(adhResourceUrlFilter(result[1].path));
                         });
@@ -377,6 +380,7 @@ export var register = (angular) => {
             "adhConfig",
             "adhHttp",
             "adhPreliminaryNames",
+            "adhTopLevelState",
             "adhShowError",
             "adhSubmitIfValid",
             "adhResourceUrlFilter",

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -142,7 +142,7 @@ export var register = (angular) => {
                     () => (resource : RIProposalVersion) => {
                         return {
                             proposalUrl: resource.path,
-                            processUrl: "/adhocracy"  // FIXME
+                            processUrl: "/organisation/kiezkasse"  // FIXME
                         };
                     }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", {
@@ -154,7 +154,7 @@ export var register = (angular) => {
                         return {
                             commentableUrl: resource.path,
                             proposalUrl: resource.path,
-                            processUrl: "/adhocracy"  // FIXME
+                            processUrl: "/organisation/kiezkasse"  // FIXME
                         };
                     }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
@@ -179,7 +179,7 @@ export var register = (angular) => {
                             return {
                                 commentableUrl: commentable.path,
                                 proposalUrl: commentable.path,
-                                processUrl: "/adhocracy"  // FIXME
+                                processUrl: "/organisation/kiezkasse"  // FIXME
                             };
                         });
                     };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -12,7 +12,7 @@ import AdhMeinBerlinKiezkassenProcess = require("../Process/Process");
 import AdhMeinBerlinKiezkassenProposal = require("../Proposal/Proposal");
 
 import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
-import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_core/resources/pool/IBasicPool");  // FIXME
+import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess");
 import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
 import SIComment = require("../../../../Resources_/adhocracy_core/sheets/comment/IComment");
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -101,23 +101,22 @@ export var register = (angular) => {
             AdhResourceArea.moduleName,
             AdhUser.moduleName
         ])
-        // FIXME: the following should be specific to kiezkassen process
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIKiezkassenProcess.content_type, "", "", "", {
+                .default(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", "", "", [() => (resource : RIKiezkassenProcess) => {
+                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", [() => (resource : RIKiezkassenProcess) => {
                     return {
                         processUrl: resource.path
                     };
                 }])
-                .default(RIKiezkassenProcess.content_type, "create_proposal", "", "", {
+                .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", "", "", ["adhHttp", "adhUser", (
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", ["adhHttp", "adhUser", (
                     adhHttp : AdhHttp.Service<any>,
                     adhUser : AdhUser.Service
                 ) => (resource : RIKiezkassenProcess) => {
@@ -133,32 +132,32 @@ export var register = (angular) => {
                         });
                     });
                 }])
-                .default(RIProposalVersion.content_type, "", "", "", {
+                .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", "", "", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", [() => (resource : RIProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RIProposalVersion.content_type, "comments", "", "", {
+                .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", "", "", [() => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", [() => (resource : RIProposalVersion) => {
                     return {
                         commentableUrl: resource.path,
                         proposalUrl: resource.path,
                         processUrl: "/adhocracy"  // FIXME
                     };
                 }])
-                .default(RICommentVersion.content_type, "", "", "", {
+                .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", "", "", ["adhHttp", "$q", (
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {
@@ -183,7 +182,7 @@ export var register = (angular) => {
                 }]);
         }])
         .config(["adhProcessProvider", (adhProcessProvider : AdhProcess.Provider) => {
-            adhProcessProvider.templateFactories[""] = ["$q", ($q : angular.IQService) => {
+            adhProcessProvider.templateFactories[RIKiezkassenProcess.content_type] = ["$q", ($q : angular.IQService) => {
                 return $q.when("<adh-mein-berlin-workbench></adh-mein-berlin-workbench>");
             }];
         }])

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -107,52 +107,56 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", [() => (resource : RIKiezkassenProcess) => {
-                    return {
-                        processUrl: resource.path
-                    };
-                }])
+                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", [
+                    () => (resource : RIKiezkassenProcess) => {
+                        return {
+                            processUrl: resource.path
+                        };
+                    }])
                 .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", ["adhHttp", "adhUser", (
-                    adhHttp : AdhHttp.Service<any>,
-                    adhUser : AdhUser.Service
-                ) => (resource : RIKiezkassenProcess) => {
-                    return adhUser.ready.then(() => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {
-                                    processUrl: resource.path
-                                };
-                            }
+                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", [
+                    "adhHttp", "adhUser", (
+                        adhHttp : AdhHttp.Service<any>,
+                        adhUser : AdhUser.Service
+                    ) => (resource : RIKiezkassenProcess) => {
+                        return adhUser.ready.then(() => {
+                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                                if (!options.POST) {
+                                    throw 401;
+                                } else {
+                                    return {
+                                        processUrl: resource.path
+                                    };
+                                }
+                            });
                         });
-                    });
-                }])
+                    }])
                 .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", [() => (resource : RIProposalVersion) => {
-                    return {
-                        proposalUrl: resource.path,
-                        processUrl: "/adhocracy"  // FIXME
-                    };
-                }])
+                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", [
+                    () => (resource : RIProposalVersion) => {
+                        return {
+                            proposalUrl: resource.path,
+                            processUrl: "/adhocracy"  // FIXME
+                        };
+                    }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", [() => (resource : RIProposalVersion) => {
-                    return {
-                        commentableUrl: resource.path,
-                        proposalUrl: resource.path,
-                        processUrl: "/adhocracy"  // FIXME
-                    };
-                }])
+                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", [
+                    () => (resource : RIProposalVersion) => {
+                        return {
+                            commentableUrl: resource.path,
+                            proposalUrl: resource.path,
+                            processUrl: "/adhocracy"  // FIXME
+                        };
+                    }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -107,12 +107,6 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", [
-                    () => (resource : RIKiezkassenProcess) => {
-                        return {
-                            processUrl: resource.path
-                        };
-                    }])
                 .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
@@ -127,9 +121,7 @@ export var register = (angular) => {
                                 if (!options.POST) {
                                     throw 401;
                                 } else {
-                                    return {
-                                        processUrl: resource.path
-                                    };
+                                    return {};
                                 }
                             });
                         });
@@ -141,8 +133,7 @@ export var register = (angular) => {
                 .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", [
                     () => (resource : RIProposalVersion) => {
                         return {
-                            proposalUrl: resource.path,
-                            processUrl: "/organisation/kiezkasse"  // FIXME
+                            proposalUrl: resource.path
                         };
                     }])
                 .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", {
@@ -153,8 +144,7 @@ export var register = (angular) => {
                     () => (resource : RIProposalVersion) => {
                         return {
                             commentableUrl: resource.path,
-                            proposalUrl: resource.path,
-                            processUrl: "/organisation/kiezkasse"  // FIXME
+                            proposalUrl: resource.path
                         };
                     }])
                 .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
@@ -178,8 +168,7 @@ export var register = (angular) => {
                         return getCommentableUrl(resource).then((commentable) => {
                             return {
                                 commentableUrl: commentable.path,
-                                proposalUrl: commentable.path,
-                                processUrl: "/organisation/kiezkasse"  // FIXME
+                                proposalUrl: commentable.path
                             };
                         });
                     };


### PR DESCRIPTION
After #1065 there is now an actual kiezkassen process resource in the backend. I migrated all frontend code to use that. Among other things, this implements `getProcessType()` from #884.

You may have to run `bin/sd_evolve etc/development.ini` to actually create the backend resources.