### PR TITLE
Add a script to create process for region

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
@@ -6,6 +6,7 @@ import textwrap
 import inspect
 
 from pyramid.paster import bootstrap
+from pyramid.traversal import find_resource
 
 import transaction
 
@@ -13,7 +14,6 @@ from adhocracy_core.utils import get_sheet
 from adhocracy_core.utils import get_sheet_field
 from adhocracy_core.sheets.pool import IPool
 from adhocracy_core.sheets.geo import IMultiPolygon
-from adhocracy_core.resources.organisation import IOrganisation
 from adhocracy_core.sheets.name import IName
 from adhocracy_core.sheets.title import ITitle
 
@@ -64,20 +64,13 @@ def _fetch_district_by_name(root, district):
     sys.exit()
 
 
-def _fetch_organisation_by_name(root, organisation):
-    pool = get_sheet(root, IPool)
-    params = {'depth': 3,
-              'content_type': IOrganisation,
-              'elements': 'content',
-              }
-    results = pool.get(params)
-    organisations = results['elements']
-    for org in organisations:
-        if get_sheet_field(org, IName, 'name') == organisation:
-            return org
-
-    print('could not find organisation %s' % (organisation))
-    sys.exit()
+def _fetch_organisation_by_name(root, organisation_path):
+    organisation = find_resource(root, organisation_path)
+    if organisation is None:
+        print('could not find organisation %s' % (organisation))
+        sys.exit()
+    else:
+        return organisation
 
 
 def _create_process(root, registry, organisation, district):

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
@@ -1,0 +1,100 @@
+"""Create Process for region."""
+
+import sys
+import optparse
+import textwrap
+import inspect
+
+from pyramid.paster import bootstrap
+
+import transaction
+
+from adhocracy_core.utils import get_sheet
+from adhocracy_core.utils import get_sheet_field
+from adhocracy_core.sheets.pool import IPool
+from adhocracy_core.sheets.geo import IMultiPolygon
+from adhocracy_core.resources.organisation import IOrganisation
+from adhocracy_core.sheets.name import IName
+from adhocracy_core.sheets.title import ITitle
+
+from adhocracy_meinberlin.resources.kiezkassen import IProcess
+from adhocracy_core.sheets.geo import ILocationReference
+
+
+def create_process_for_region():
+    """Import Berlin districts to adhocracy meinBerlin.
+
+    usage::
+
+      bin/import_bezirke etc/development.ini <regionname> <organisationname>
+    """
+    usage = 'usage: %prog config_file'
+    parser = optparse.OptionParser(
+        usage=usage,
+        description=textwrap.dedent(inspect.getdoc(create_process_for_region))
+    )
+    options, args = parser.parse_args(sys.argv[1:])
+    if not len(args) >= 3:
+        print('You must provide at least three argument')
+        return 2
+
+    env = bootstrap(args[0])
+    root = env['root']
+    registry = env['registry']
+
+    district = _fetch_district_by_name(root, args[1])
+    organisation = _fetch_organisation_by_name(root, args[2])
+
+    _create_process(root, registry, organisation, district)
+
+
+def _fetch_district_by_name(root, district):
+    pool = get_sheet(root, IPool)
+    params = {'depth': 3,
+              'content_type': IMultiPolygon,
+              'elements': 'content',
+              }
+    results = pool.get(params)
+    locations = results['elements']
+    for location in locations:
+        if get_sheet_field(location, IName, 'name') == district:
+            return location
+
+    print('could not find district %s' % (district))
+    sys.exit()
+
+
+def _fetch_organisation_by_name(root, organisation):
+    pool = get_sheet(root, IPool)
+    params = {'depth': 3,
+              'content_type': IOrganisation,
+              'elements': 'content',
+              }
+    results = pool.get(params)
+    organisations = results['elements']
+    for org in organisations:
+        if get_sheet_field(org, IName, 'name') == organisation:
+            return org
+
+    print('could not find organisation %s' % (organisation))
+    sys.exit()
+
+
+def _create_process(root, registry, organisation, district):
+
+    name = get_sheet_field(district, IName, 'name')
+    title = get_sheet_field(district, ITitle, 'title')
+
+    appstructs = {IName.__identifier__:
+                  {'name': name},
+                  ITitle.__identifier__:
+                  {'title': 'Kiezkasse für %s' % (title)},
+                  ILocationReference.__identifier__:
+                  {'location': district}
+                  }
+
+    registry.content.create(IProcess.__identifier__,
+                            parent=root['organisation'],
+                            appstructs=appstructs)
+
+    transaction.commit()

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/create_process_for_region.py
@@ -22,13 +22,13 @@ from adhocracy_core.sheets.geo import ILocationReference
 
 
 def create_process_for_region():
-    """Import Berlin districts to adhocracy meinBerlin.
+    """Create sample Kiezkassen process for a given region and organisation.
 
     usage::
 
-      bin/import_bezirke etc/development.ini <regionname> <organisationname>
+      bin/create_process_for_region <config> <regionname> <organisationname>
     """
-    usage = 'usage: %prog config_file'
+    usage = 'usage: %prog config_file region organisation'
     parser = optparse.OptionParser(
         usage=usage,
         description=textwrap.dedent(inspect.getdoc(create_process_for_region))

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/import_geodata.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/import_geodata.py
@@ -162,9 +162,9 @@ def _slugify(value: str) -> str:
 def _download_geodata(filename: str, url: str, layer: str):
     call = 'ogr2ogr -s_srs EPSG:25833'\
            ' -t_srs WGS84 -f'\
-           ' geoJSON %s%s WFS:"%s" %s' % (
-               filename, '?TYPENAMES=GML2' if GDAL_LEGACY else '',
-               url, layer)
+           ' geoJSON %s WFS:"%s%s" %s' % (
+               filename, url, '?TYPENAMES=GML2' if GDAL_LEGACY else '',
+               layer)
     try:
         os.remove(filename)
     except:

--- a/src/adhocracy_meinberlin/setup.py
+++ b/src/adhocracy_meinberlin/setup.py
@@ -46,5 +46,7 @@ setup(name='adhocracy_meinberlin',
           adhocracy_meinberlin.scripts.import_geodata:import_bezirksregions
       import_bezirke =\
           adhocracy_meinberlin.scripts.import_geodata:import_bezirke
+      create_process_for_region =\
+          adhocracy_meinberlin.scripts.create_process_for_region:create_process_for_region
       """,
       )


### PR DESCRIPTION
The script can be used to add processes based on a bezirksregion. Then run:

 bin/create_process_for_region path_ to_development.ini name_ of_ the_ bezirgsregion name _of_organisation

eg. bin/create_process_for_region etc/development.ini sudliche-luisenstadt organisation

NOTE: in order to get that working you have to add the bezirke first and after that the bezirksregion:

required: GDAL (Version 1.10.1) is installed.

First run: bin/import_bezirke ./etc/development.ini
Second run: bin/import_bezirksregions ./etc/development.ini




