### PR TITLE
reference leaflet.css by absolute path (fixes #1097)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -101,6 +101,8 @@ def root_view(request):
         'adhocracy_frontend:build/root.html.mako',
         {'css': [request.cachebusted_url('adhocracy_frontend:build/'
                                          + css_path),
+                 request.cachebusted_url('adhocracy_frontend:build/'
+                                         'lib/leaflet/dist/leaflet.css'),
                  ],
          'js': [request.cachebusted_url('adhocracy_frontend:build/'
                                         'lib/requirejs/require.js'),

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
@@ -66,5 +66,3 @@
 @import "overwrite";
 
 @import "print";
-
-@import "../lib/leaflet/dist/leaflet.css";


### PR DESCRIPTION
Note that leaflet.css is now also loaded for core and mercator.