### PR TITLE
keep unittests from failing

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceAreaSpec.ts
@@ -24,11 +24,12 @@ export var register = () => {
                     templates: {}
                 };
 
-                adhHttpMock = jasmine.createSpyObj("adhHttp", ["get"]);
+                adhHttpMock = jasmine.createSpyObj("adhHttp", ["get", "withTransaction"]);
                 adhHttpMock.get.and.returnValue(q.when({
                     content_type: "content_type",
                     data: {}
                 }));
+                adhHttpMock.withTransaction.and.returnValue(q.when([]));
 
                 $injectorMock = jasmine.createSpyObj("$injector", ["invoke"]);
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
@@ -112,7 +112,9 @@ export var register = () => {
                 var scopeMock;
 
                 beforeEach(() => {
-                    scopeMock = {};
+                    scopeMock = {
+                        $watch: () => undefined
+                    };
                     directive.link(scopeMock);
                 });
 


### PR DESCRIPTION
These are just workarounds. It will be a bigger task to make our unittesting useful again.