### PR TITLE
added watch statements to rebuild list Fixes #1107

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -327,19 +327,13 @@ export class MapListingController {
             this.scrollToItem(this.$scope.selectedPath, false);
         });
 
-        var mcs = $element.parents(".moving-columns");
-        this.$scope.$watch(() => {
-            return mcs.find(".moving-column.is-show, .moving-column.is-collapse").length;
-        }, () => {
+        this.$scope.$watch(() => $element.find(".map-list").width(), () => {
+            this.scrollToItem(this.$scope.selectedPath, false);
+
             // FIXME: moving column load time hard coded
             this.$timeout(() => {
                 this.scrollToItem(this.$scope.selectedPath, true);
-            }, 550);
-        });
-        this.$scope.$watch(() => {
-            return this.map.getBounds().getSouthWest().lng;
-        }, () => {
-            this.scrollToItem(this.$scope.selectedPath, false);
+            }, 500);
         });
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -272,6 +272,7 @@ export class MapListingController {
     private selectedItemLeafletIcon;
     private itemLeafletIcon;
     private markers : {[path : string]: L.Marker};
+    private scrollToItem;
 
     constructor(
         private $scope : IMapListScope,
@@ -284,6 +285,7 @@ export class MapListingController {
         this.selectedItemLeafletIcon = (<any>leaflet).divIcon(cssSelectedItemIcon);
         this.itemLeafletIcon = (<any>leaflet).divIcon(cssItemIcon);
         this.markers = {};
+        this.scrollToItem = _.throttle((path, animate) => this._scrollToItem(path, animate), 10);
 
         this.map = this.createMap();
 
@@ -397,7 +399,7 @@ export class MapListingController {
         this.$scope.selectItem(this.indexToPath(index));
     }
 
-    private scrollToItem(path : string, animate = true) : void {
+    private _scrollToItem(path : string, animate = true) : void {
         // FIXME: this needs to be retriggered when the widget
         // is resized or the index of an item changes.
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -329,19 +329,15 @@ export class MapListingController {
         this.$scope.$watch(() => {
             return mcs.find(".moving-column.is-show, .moving-column.is-collapse").length;
         }, (newValue, oldValue) => {
-            if (newValue !== oldValue) {
-                // fixme: moving column load time hard coded
-                this.$timeout(() => {
-                    this.scrollToItem(this.$scope.selectedPath, true);
-                }, 550);
-            }
+            // FIXME: moving column load time hard coded
+            this.$timeout(() => {
+                this.scrollToItem(this.$scope.selectedPath, true);
+            }, 550);
         });
         this.$scope.$watch(() => {
-            return this.map.getBounds()._southWest.lng;
+            return this.map.getBounds().getSouthWest().lng;
         }, (newValue, oldValue) => {
-            if (newValue !== oldValue) {
-                this.scrollToItem(this.$scope.selectedPath, false);
-            }
+            this.scrollToItem(this.$scope.selectedPath, false);
         });
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -328,7 +328,7 @@ export class MapListingController {
         var mcs = $element.parents(".moving-columns");
         this.$scope.$watch(() => {
             return mcs.find(".moving-column.is-show, .moving-column.is-collapse").length;
-        }, (newValue, oldValue) => {
+        }, () => {
             // FIXME: moving column load time hard coded
             this.$timeout(() => {
                 this.scrollToItem(this.$scope.selectedPath, true);
@@ -336,7 +336,7 @@ export class MapListingController {
         });
         this.$scope.$watch(() => {
             return this.map.getBounds().getSouthWest().lng;
-        }, (newValue, oldValue) => {
+        }, () => {
             this.scrollToItem(this.$scope.selectedPath, false);
         });
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -278,7 +278,6 @@ export class MapListingController {
         private $element,
         private $attrs,
         private $timeout : angular.ITimeoutService,
-        private $window,
         private leaflet : typeof L
     ) {
         this.scrollContainer = this.$element.find(".map-list-scroll-container-inner");
@@ -338,7 +337,7 @@ export class MapListingController {
             }
         });
         this.$scope.$watch(() => {
-            return angular.element($window).width();
+            return this.map.getBounds()._southWest.lng;
         }, (newValue, oldValue) => {
             if (newValue !== oldValue) {
                 this.scrollToItem(this.$scope.selectedPath, false);
@@ -498,7 +497,7 @@ export var mapListingInternal = (
                 return adhConfig.pkg_path + pkgLocation + "/ListingInternalHorizontal.html";
             }
         },
-        controller: ["$scope", "$element", "$attrs", "$timeout", "$window", "leaflet", MapListingController]
+        controller: ["$scope", "$element", "$attrs", "$timeout", "leaflet", MapListingController]
     };
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -278,6 +278,7 @@ export class MapListingController {
         private $element,
         private $attrs,
         private $timeout : angular.ITimeoutService,
+        private $window,
         private leaflet : typeof L
     ) {
         this.scrollContainer = this.$element.find(".map-list-scroll-container-inner");
@@ -323,6 +324,25 @@ export class MapListingController {
 
         this.$scope.$watch("items", () => {
             this.scrollToItem(this.$scope.selectedPath, false);
+        });
+
+        var mcs = $element.parents(".moving-columns");
+        this.$scope.$watch(() => {
+            return mcs.find(".moving-column.is-show, .moving-column.is-collapse").length;
+        }, (newValue, oldValue) => {
+            if (newValue !== oldValue) {
+                // fixme: moving column load time hard coded
+                this.$timeout(() => {
+                    this.scrollToItem(this.$scope.selectedPath, true);
+                }, 550);
+            }
+        });
+        this.$scope.$watch(() => {
+            return angular.element($window).width();
+        }, (newValue, oldValue) => {
+            if (newValue !== oldValue) {
+                this.scrollToItem(this.$scope.selectedPath, false);
+            }
         });
     }
 
@@ -478,7 +498,7 @@ export var mapListingInternal = (
                 return adhConfig.pkg_path + pkgLocation + "/ListingInternalHorizontal.html";
             }
         },
-        controller: ["$scope", "$element", "$attrs", "$timeout", "leaflet", MapListingController]
+        controller: ["$scope", "$element", "$attrs", "$timeout", "$window", "leaflet", MapListingController]
     };
 };
 


### PR DESCRIPTION
Added a watch to column width and column amount to trigger an list items reload. Looks a bit wonkey as it can only trigger after moving columns have loaded. Fixes #1107 