### PR TITLE
fix input background in standalone header

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_standalone_wrapper.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_standalone_wrapper.scss
@@ -5,12 +5,20 @@ name: standalone-wrapper
 category: layout
 ---
 
-A wrapper for pages that are not embedded in the application such as pages that are opened
-when you follow an Adhocracy link from your email. Could contain branding.
+A wrapper for pages that are not embedded in the application such as pages that
+are opened when you follow an Adhocracy link from your email. Could contain
+branding.
 
 ```html_example
 <div class="standalone-wrapper">
-    You have activated your account, well done!
+    <h1 class="standalone-wrapper-title">Some title</h1>
+
+    <label>
+        <span class="label-text">write something</span>
+        <input type="text" />
+    </label>
+
+    <p>You have activated your account, well done!</p>
 </div>
 ```
 */

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_standalone_wrapper_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_standalone_wrapper_theme.scss
@@ -15,4 +15,16 @@
         top: -30px;
         width: 100%;
     }
+
+    input[type="text"],
+    input[type="url"],
+    input[type="password"],
+    input[type="email"],
+    input[type="date"],
+    input[type="time"],
+    input[type="number"],
+    select,
+    textarea {
+        background-color: $color-background-base;
+    }
 }


### PR DESCRIPTION
see for example in password reset flow (after you clicked the link in the email).

The inputs were gray on grey before.