### PR TITLE
item/version routing

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DocumentWorkbench/DocumentWorkbench.ts
@@ -60,25 +60,25 @@ export var register = (angular) => {
         }])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIBasicPool.content_type, "", "", "", {
+                .default(RIBasicPool, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide",
                     content2Url: ""
                 })
-                .default(RIProposalVersion.content_type, "", "", "", {
+                .default(RIProposalVersion, "", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", "", "", () => (resource : RIProposalVersion) => {
+                .specific(RIProposalVersion, "", "", "", () => (resource : RIProposalVersion) => {
                     return {
                         content2Url: resource.path
                     };
                 })
-                .default(RIUser.content_type, "", "", "", {
+                .default(RIUser, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 })
-                .default(RIUsersService.content_type, "", "", "", {
+                .default(RIUsersService, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -442,5 +442,6 @@ export var register = (angular) => {
         }])
         .provider("adhResourceArea", Provider)
         .directive("adhResourceArea", ["adhResourceArea", "$compile", directive])
+        .filter("adhParentPath", () => AdhUtil.parentPath)
         .filter("adhResourceUrl", ["adhConfig", resourceUrl]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -39,21 +39,27 @@ export class Provider implements angular.IServiceProvider {
         self, $q, $injector, $location, adhHttp, adhConfig, adhEmbed, adhResourceUrlFilter)];
     }
 
-    public default(resourceType : string, view : string, processType : string, embedContext : string, defaults : Dict) : Provider {
-        var key : string = resourceType + "@" + view + "@" + processType + "@" + embedContext;
+    public default(
+        resourceType : ResourcesBase.IResourceClass,
+        view : string,
+        processType : string,
+        embedContext : string,
+        defaults : Dict
+    ) : Provider {
+        var key : string = resourceType.content_type + "@" + view + "@" + processType + "@" + embedContext;
         this.defaults[key] = defaults;
         return this;
     }
 
     public specific(
-        resourceType : string,
+        resourceType : ResourcesBase.IResourceClass,
         view : string,
         processType : string,
         embedContext : string,
         factory : any,
         type? : string
     ) : Provider {
-        var key : string = resourceType + "@" + view + "@" + processType + "@" + embedContext;
+        var key : string = resourceType.content_type + "@" + view + "@" + processType + "@" + embedContext;
         this.specifics[key] = {
             factory: factory,
             type: type
@@ -65,8 +71,8 @@ export class Provider implements angular.IServiceProvider {
      * Shortcut to call `default()` for both an itemType and a versionType.
      */
     public defaultVersionable(
-        itemType : string,
-        versionType : string,
+        itemType : ResourcesBase.IResourceClass,
+        versionType : ResourcesBase.IResourceClass,
         view : string,
         processType : string,
         embedContext : string,
@@ -86,8 +92,8 @@ export class Provider implements angular.IServiceProvider {
      * be used.
      */
     public specificVersionable(
-        itemType : string,
-        versionType : string,
+        itemType : ResourcesBase.IResourceClass,
+        versionType : ResourcesBase.IResourceClass,
         view : string,
         processType : string,
         embedContext : string,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -527,16 +527,16 @@ export var register = (angular) => {
         }])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIUser.content_type, "", "", "", {
+                .default(RIUser, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIUser.content_type, "", "", "", () => (resource : RIUser) => {
+                .specific(RIUser, "", "", "", () => (resource : RIUser) => {
                     return {
                         userUrl: resource.path
                     };
                 })
-                .default(RIUsersService.content_type, "", "", "", {
+                .default(RIUsersService, "", "", "", {
                     space: "user",
                     movingColumns: "is-show-hide-hide",
                     userUrl: "",  // not used by default, but should be overridable

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
@@ -24,6 +24,9 @@ export function parentPath(path : string) : string {
 
     var result;
 
+    if (typeof path === "undefined") {
+        return undefined;
+    }
     if (path[path.length - 1] === "/") {
         result = path.substring(0, path.lastIndexOf("/", path.length - 2) + 1);
     } else {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -19,6 +19,13 @@ export class Sheet {
 }
 
 
+export interface IResourceClass {
+    /* tslint:disable:variable-name */
+    content_type : string;
+    /* tslint:enable:variable-name */
+}
+
+
 export class Resource {
     public data : Object;
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -3,7 +3,9 @@ export interface ISheetMetaApi {
     readable : string[];
     editable : string[];
     creatable : string[];
+    /* tslint:disable:variable-name */
     create_mandatory : string[];
+    /* tslint:enable:variable-name */
 
     // computed information
     references : string[];
@@ -28,7 +30,7 @@ export class Resource {
     public root_versions : string[];
     /* tslint:enable:variable-name */
 
-    constructor(public content_type: string) {
+    constructor(public content_type : string) {
         this.data = {};
     }
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -52,15 +52,15 @@ export var register = (angular) => {
                 ) => {
                     return $templateRequest(adhConfig.pkg_path + pkgLocation + "/template.html");
                 }])
-                .default(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RIKiezkassenProcess, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", [
+                .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
@@ -75,11 +75,11 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion.content_type, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
+                .specific(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
@@ -96,32 +96,32 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", [
+                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", [
                     () => (resource : RIProposalVersion) => {
                         return {
                             proposalUrl: resource.path
                         };
                     }])
-                .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
+                .specific(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
                     () => (resource : RIProposalVersion) => {
                         return {
                             commentableUrl: resource.path,
                             proposalUrl: resource.path
                         };
                     }])
-                .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .default(RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
+                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -4,12 +4,13 @@ import AdhHttp = require("../../../Http/Http");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
 import AdhUser = require("../../../User/User");
-import AdhUtil = require("../../../Util/Util");
 
 import AdhMeinBerlinWorkbench = require("../Workbench/Workbench");
 
+import RIComment = require("../../../../Resources_/adhocracy_core/resources/comment/IComment");
 import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
 import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess");
+import RIProposal = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposal");
 import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
 import SIComment = require("../../../../Resources_/adhocracy_core/sheets/comment/IComment");
 
@@ -75,53 +76,53 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
+                .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
-                    ) => (resource : RIProposalVersion) => {
+                    ) => (item : RIProposal, version : RIProposalVersion) => {
                         return adhUser.ready.then(() => {
-                            return adhHttp.options(AdhUtil.parentPath(resource.path)).then((options : AdhHttp.IOptions) => {
+                            return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                                 if (!options.POST) {
                                     throw 401;
                                 } else {
                                     return {
-                                        proposalUrl: resource.path
+                                        proposalUrl: version.path
                                     };
                                 }
                             });
                         });
                     }])
-                .default(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    () => (resource : RIProposalVersion) => {
+                .specificVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    () => (item : RIProposal, version : RIProposalVersion) => {
                         return {
-                            proposalUrl: resource.path
+                            proposalUrl: version.path
                         };
                     }])
-                .default(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    () => (resource : RIProposalVersion) => {
+                .specificVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
+                    () => (item : RIProposal, version : RIProposalVersion) => {
                         return {
-                            commentableUrl: resource.path,
-                            proposalUrl: resource.path
+                            commentableUrl: version.path,
+                            proposalUrl: version.path
                         };
                     }])
-                .default(RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
+                .defaultVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
+                .specificVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {
@@ -134,8 +135,8 @@ export var register = (angular) => {
                         }
                     };
 
-                    return (resource : RICommentVersion) => {
-                        return getCommentableUrl(resource).then((commentable) => {
+                    return (item : RIComment, version : RICommentVersion) => {
+                        return getCommentableUrl(version).then((commentable) => {
                             return {
                                 commentableUrl: commentable.path,
                                 proposalUrl: commentable.path

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Create.html
@@ -107,7 +107,7 @@
 
         <a data-ng-show="create" href="{{ processUrl | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
         {{ "TR__CANCEL" | translate }}</a>
-        <a data-ng-show="!create" href="{{ path | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
+        <a data-ng-show="!create" href="{{ path | adhParentPath | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
         {{ "TR__CANCEL" | translate }}</a>
     </footer>
 </form>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
@@ -24,7 +24,7 @@
     </header>
 
     <section class="mein-berlin-kiezkassen-proposal-detail-body">
-        <a href="{{ path | adhResourceUrl:'comments' }}" class="disguised-link mein-berlin-kiezkassen-proposal-detail-body-comments">
+        <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}" class="disguised-link mein-berlin-kiezkassen-proposal-detail-body-comments">
             <i class="icon-speechbubble-unfilled"></i> {{ data.commentCount }}
         </a>
         <p>{{data.detail}}</p>
@@ -35,7 +35,7 @@
                     <i class="icon-pin-detail"></i> {{data.locationText}}
                 </li>
                 <li class="mein-berlin-kiezkassen-proposal-detail-meta-item">
-                    <a href="{{ path | adhResourceUrl:'comments' }}" class="disguised-link">
+                    <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}" class="disguised-link">
                         <i class="icon-speechbubble-unfilled"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}
                     </a>
                 </li>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
@@ -1,5 +1,5 @@
 <!-- FIXME: may contain links in adh-user-meta -->
-<a class="meinberlin-kiezkassen-proposal-list-item {{selectedState}}" href="{{path | adhResourceUrl }}">
+<a class="meinberlin-kiezkassen-proposal-list-item {{selectedState}}" href="{{path | adhParentPath | adhResourceUrl }}">
     <div class="meinberlin-kiezkassen-proposal-list-item-col-left">
         <h3 class="meinberlin-kiezkassen-proposal-list-item-title">{{data.title}}</h3>
         {{ "TR__BY" | translate }}

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Proposal.ts
@@ -305,7 +305,7 @@ export var createDirective = (
                 return adhSubmitIfValid(scope, element, scope.meinBerlinProposalForm, () => {
                     return postCreate(adhHttp, adhPreliminaryNames)(scope, processUrl)
                         .then((result) => {
-                            $location.url(adhResourceUrlFilter(result[1].path));
+                            $location.url(adhResourceUrlFilter(AdhUtil.parentPath(result[1].path)));
                         });
                 });
             };
@@ -340,7 +340,7 @@ export var editDirective = (
                 return adhSubmitIfValid(scope, element, scope.meinBerlinProposalForm, () => {
                     return postEdit(adhHttp, adhPreliminaryNames)(scope, scope.resource)
                         .then((result) => {
-                            $location.url(adhResourceUrlFilter(result[0].path));
+                            $location.url(adhResourceUrlFilter(AdhUtil.parentPath(result[0].path)));
                     });
                 });
             };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/CommentColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/CommentColumn.html
@@ -5,7 +5,7 @@
             {{ "TR__COMMENTS" | translate }}
         </div>
         <div class="moving-column-menu-nav">
-            <a class="moving-column-menu-nav-button" data-ng-href="{{ proposalUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 
@@ -20,6 +20,6 @@
     <adh-report-abuse
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'abuse'"
-        data-url="{{ shared.abuseUrl | adhResourceUrl | adhCanonicalUrl }}">
+        data-url="{{ shared.abuseUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/KiezkassenProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/KiezkassenProposalDetailColumn.html
@@ -4,14 +4,14 @@
             <i class="icon-document moving-column-icon"></i>
             {{ "TR__PROPOSAL" | translate }}
         </div>
-        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
+        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
 
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 
-    <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhResourceUrl }}">
+    <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/KiezkassenProposalEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/KiezkassenProposalEditColumn.html
@@ -4,14 +4,14 @@
             <i class="icon-document moving-column-icon"></i>
             {{ "TR__PROPOSAL" | translate }}
         </div>
-        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
 
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
     </div>
 
-    <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhResourceUrl }}">
+    <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">
         <i class="icon-document moving-column-icon"></i>
     </a>
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -13,8 +13,10 @@ import AdhPermissions = require("../../../Permissions/Permissions");
 import AdhMeinBerlinKiezkassenProcess = require("../Process/Process");
 import AdhMeinBerlinKiezkassenProposal = require("../Proposal/Proposal");
 
+import RIComment = require("../../../../Resources_/adhocracy_core/resources/comment/IComment");
 import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
 import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess");
+import RIProposal = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposal");
 import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
 import SIComment = require("../../../../Resources_/adhocracy_core/sheets/comment/IComment");
 
@@ -176,53 +178,53 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", [
+                .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
-                    ) => (resource : RIProposalVersion) => {
+                    ) => (item : RIProposal, version : RIProposalVersion) => {
                         return adhUser.ready.then(() => {
-                            return adhHttp.options(AdhUtil.parentPath(resource.path)).then((options : AdhHttp.IOptions) => {
+                            return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                                 if (!options.POST) {
                                     throw 401;
                                 } else {
                                     return {
-                                        proposalUrl: resource.path
+                                        proposalUrl: version.path
                                     };
                                 }
                             });
                         });
                     }])
-                .default(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", [
-                    () => (resource : RIProposalVersion) => {
+                .specificVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "", [
+                    () => (item : RIProposal, version : RIProposalVersion) => {
                         return {
-                            proposalUrl: resource.path
+                            proposalUrl: version.path
                         };
                     }])
-                .default(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", {
+                .defaultVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", [
-                    () => (resource : RIProposalVersion) => {
+                .specificVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", [
+                    () => (item : RIProposal, version : RIProposalVersion) => {
                         return {
-                            commentableUrl: resource.path,
-                            proposalUrl: resource.path
+                            commentableUrl: version.path,
+                            proposalUrl: version.path
                         };
                     }])
-                .default(RICommentVersion, "", RIKiezkassenProcess.content_type, "", {
+                .defaultVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
+                .specificVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {
@@ -235,8 +237,8 @@ export var register = (angular) => {
                         }
                     };
 
-                    return (resource : RICommentVersion) => {
-                        return getCommentableUrl(resource).then((commentable) => {
+                    return (item : RIComment, version : RICommentVersion) => {
+                        return getCommentableUrl(version).then((commentable) => {
                             return {
                                 commentableUrl: commentable.path,
                                 proposalUrl: commentable.path

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -134,15 +134,15 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIKiezkassenProcess.content_type, "", RIKiezkassenProcess.content_type, "", {
+                .default(RIKiezkassenProcess, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .default(RIKiezkassenProcess.content_type, "edit_process", RIKiezkassenProcess.content_type, "", {
+                .default(RIKiezkassenProcess, "edit_process", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "edit_process", RIKiezkassenProcess.content_type, "", [
+                .specific(RIKiezkassenProcess, "edit_process", RIKiezkassenProcess.content_type, "", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
@@ -157,11 +157,11 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", {
+                .default(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIKiezkassenProcess.content_type, "create_proposal", RIKiezkassenProcess.content_type, "", [
+                .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
@@ -176,11 +176,11 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion.content_type, "edit", RIKiezkassenProcess.content_type, "", {
+                .default(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "edit", RIKiezkassenProcess.content_type, "", [
+                .specific(RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", [
                     "adhHttp", "adhUser", (
                         adhHttp : AdhHttp.Service<any>,
                         adhUser : AdhUser.Service
@@ -197,32 +197,32 @@ export var register = (angular) => {
                             });
                         });
                     }])
-                .default(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
+                .default(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", [
+                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", [
                     () => (resource : RIProposalVersion) => {
                         return {
                             proposalUrl: resource.path
                         };
                     }])
-                .default(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", {
+                .default(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "comments", RIKiezkassenProcess.content_type, "", [
+                .specific(RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", [
                     () => (resource : RIProposalVersion) => {
                         return {
                             commentableUrl: resource.path,
                             proposalUrl: resource.path
                         };
                     }])
-                .default(RICommentVersion.content_type, "", RIKiezkassenProcess.content_type, "", {
+                .default(RICommentVersion, "", RIKiezkassenProcess.content_type, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIProposalVersion.content_type, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
+                .specific(RIProposalVersion, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => {

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -1117,20 +1117,20 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIMercatorProposalVersion.content_type, "", "", "", {
+                .default(RIMercatorProposalVersion, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "", "", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion, "", "", "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path
                     };
                 })
-                .default(RIMercatorProposalVersion.content_type, "edit", "", "", {
+                .default(RIMercatorProposalVersion, "edit", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-hide"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "edit", "", "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
+                .specific(RIMercatorProposalVersion, "edit", "", "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
                     return (resource : RIMercatorProposalVersion) => {
                         var poolPath = AdhUtil.parentPath(resource.path);
 
@@ -1145,11 +1145,11 @@ export var register = (angular) => {
                         });
                     };
                 }])
-                .default(RIMercatorProposalVersion.content_type, "comments", "", "", {
+                .default(RIMercatorProposalVersion, "comments", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIMercatorProposalVersion.content_type, "comments", "", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion, "comments", "", "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         commentableUrl: resource.path
@@ -1158,11 +1158,11 @@ export var register = (angular) => {
 
             _(SIMercatorSubResources.Sheet._meta.readable).forEach((section : string) => {
                 adhResourceAreaProvider
-                    .default(RIMercatorProposalVersion.content_type, "comments:" + section, "", "", {
+                    .default(RIMercatorProposalVersion, "comments:" + section, "", "", {
                         space: "content",
                         movingColumns: "is-collapse-show-show"
                     })
-                    .specific(RIMercatorProposalVersion.content_type, "comments:" + section, "", "", () =>
+                    .specific(RIMercatorProposalVersion, "comments:" + section, "", "", () =>
                         (resource : RIMercatorProposalVersion) => {
                             return {
                                 proposalUrl: resource.path,

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -179,11 +179,11 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RICommentVersion.content_type, "", "", "", {
+                .default(RICommentVersion, "", "", "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RICommentVersion.content_type, "", "", "", ["adhHttp", "$q", (
+                .specific(RICommentVersion, "", "", "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => (resource : RICommentVersion) => {
@@ -214,17 +214,17 @@ export var register = (angular) => {
                     })
                     .then(() => specifics);
                 }])
-                .default(RIPoolWithAssets.content_type, "", "", "", {
+                .default(RIPoolWithAssets, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide",
                     proposalUrl: "",  // not used by default, but should be overridable
                     focus: "0"
                 })
-                .default(RIPoolWithAssets.content_type, "create_proposal", "", "", {
+                .default(RIPoolWithAssets, "create_proposal", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIPoolWithAssets.content_type, "create_proposal", "", "", ["adhHttp", "adhUser",
+                .specific(RIPoolWithAssets, "create_proposal", "", "", ["adhHttp", "adhUser",
                     (adhHttp : AdhHttp.Service<any>, adhUser) => {
                         return (resource : RIPoolWithAssets) => {
                             return adhUser.ready.then(() => {


### PR DESCRIPTION
this adds functionality to `adhResourceArea` to easily register routes for versionable resources.

The assumption is that we always need an item and a version for routing in these cases. If the URL points to an item, the newest version is used.

This does not yet implement any links to the newly created item routes. I will do that in a separate pull request.