### PR TITLE
http: noCredentials option

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -32,6 +32,7 @@ export var logBackendError : (response : angular.IHttpPromiseCallbackArg<IBacken
 
 
 export interface IHttpConfig {
+    noCredentials? : boolean;
 }
 
 export interface IHttpOptionsConfig extends IHttpConfig {
@@ -122,6 +123,12 @@ export class Service<Content extends ResourcesBase.Resource> {
 
     private parseConfig(config : IHttpConfig) {
         var headers = {};
+        if (config.noCredentials) {
+            _.assign(headers, {
+                "X-User-Token": undefined,
+                "X-User-Path": undefined
+            });
+        }
         return headers;
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -31,6 +31,22 @@ export interface IBackendErrorItem extends AdhError.IBackendErrorItem {};
 export var logBackendError : (response : angular.IHttpPromiseCallbackArg<IBackendError>) => void = AdhError.logBackendError;
 
 
+export interface IHttpConfig {
+}
+
+export interface IHttpOptionsConfig extends IHttpConfig {
+    importOptions? : boolean;
+}
+
+export interface IHttpGetConfig extends IHttpConfig {
+    warmupPoolCache? : boolean;
+}
+
+export interface IHttpPutConfig extends IHttpConfig {
+    keepMetadata? : boolean;
+}
+
+
 export interface IOptions {
     OPTIONS : boolean;
     PUT : boolean;
@@ -117,7 +133,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         };
     }
 
-    public options(path : string, importOptions : boolean = true) : angular.IPromise<IOptions> {
+    public options(path : string, config : IHttpOptionsConfig = {}) : angular.IPromise<IOptions> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-options preliminary path: " + path;
         }
@@ -126,7 +142,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         return this.adhCache.memoize(path, "OPTIONS",
             () => this.$http({method: "OPTIONS", url: path})
         ).then((response) => {
-            if (importOptions) {
+            if (typeof config.importOptions === "undefined" || config.importOptions) {
                 return this.importOptions(response);
             } else {
                 return response;
@@ -134,7 +150,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         }, AdhError.logBackendError);
     }
 
-    public getRaw(path : string, params?) : angular.IHttpPromise<any> {
+    public getRaw(path : string, params?, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-get preliminary path: " + path;
         }
@@ -155,11 +171,11 @@ export class Service<Content extends ResourcesBase.Resource> {
     public get(
         path : string,
         params?,
-        warmupPoolCache ?: boolean
+        config : IHttpGetConfig = {}
     ) : angular.IPromise<Content> {
         var query = (typeof params === "undefined") ? "" : "?" + $.param(params);
 
-        if (warmupPoolCache) {
+        if (config.warmupPoolCache) {
             if (_.has(params, "elements")) {
                 throw "cannot use warmupPoolCache when elements is set";
             } else {
@@ -168,13 +184,13 @@ export class Service<Content extends ResourcesBase.Resource> {
         }
 
         return this.adhCache.memoize(path, query,
-            () => this.getRaw(path, params).then(
+            () => this.getRaw(path, params, config).then(
                 (response) => AdhConvert.importContent(
-                    <any>response, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache, warmupPoolCache),
+                    <any>response, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache, config.warmupPoolCache),
                 AdhError.logBackendError));
     }
 
-    public putRaw(path : string, obj : Content) : angular.IHttpPromise<any> {
+    public putRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-put preliminary path: " + path;
         }
@@ -184,10 +200,10 @@ export class Service<Content extends ResourcesBase.Resource> {
             .put(path, obj);
     }
 
-    public put(path : string, obj : Content, keepMetadata : boolean = false) : angular.IPromise<Content> {
+    public put(path : string, obj : Content, config : IHttpPutConfig = {}) : angular.IPromise<Content> {
         var _self = this;
 
-        return this.putRaw(path, AdhConvert.exportContent(this.adhMetaApi, obj, keepMetadata))
+        return this.putRaw(path, AdhConvert.exportContent(this.adhMetaApi, obj, config.keepMetadata), config)
             .then(
                 (response) => {
                     _self.adhCache.invalidateUpdated(response.data.updated_resources);
@@ -196,7 +212,7 @@ export class Service<Content extends ResourcesBase.Resource> {
                 AdhError.logBackendError);
     }
 
-    public hide(path : string, contentType : string) : angular.IPromise<any> {
+    public hide(path : string, contentType : string, config : IHttpConfig = {}) : angular.IPromise<any> {
         var obj = {
             content_type: contentType,
             data: {}
@@ -205,10 +221,10 @@ export class Service<Content extends ResourcesBase.Resource> {
             hidden: true
         };
 
-        return this.put(path, <any>obj, true);
+        return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
     }
 
-    public postRaw(path : string, obj : Content) : angular.IHttpPromise<any> {
+    public postRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
         var _self = this;
 
         if (_self.adhPreliminaryNames.isPreliminary(path)) {
@@ -230,10 +246,10 @@ export class Service<Content extends ResourcesBase.Resource> {
         }
     }
 
-    public post(path : string, obj : Content) : angular.IPromise<Content> {
+    public post(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<Content> {
         var _self = this;
 
-        return _self.postRaw(path, AdhConvert.exportContent(_self.adhMetaApi, obj))
+        return _self.postRaw(path, AdhConvert.exportContent(_self.adhMetaApi, obj), config)
             .then(
                 (response) => {
                     this.adhCache.invalidateUpdated(response.data.updated_resources);
@@ -251,8 +267,8 @@ export class Service<Content extends ResourcesBase.Resource> {
      * LAST tag and adh-last-version directive.  (even though arguably
      * there is a difference between the LAST tag and this function.)
      */
-    public getNewestVersionPathNoFork(path : string) : angular.IPromise<string> {
-        return this.get(path + "LAST/")
+    public getNewestVersionPathNoFork(path : string, config : IHttpGetConfig = {}) : angular.IPromise<string> {
+        return this.get(path + "LAST/", undefined, config)
             .then((tag) => {
                 var heads = tag.data[SITag.nick].elements;
                 if (heads.length !== 1) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -120,6 +120,11 @@ export class Service<Content extends ResourcesBase.Resource> {
         }
     }
 
+    private parseConfig(config : IHttpConfig) {
+        var headers = {};
+        return headers;
+    }
+
     private importOptions(raw : angular.IHttpPromiseCallbackArg<any>) : IOptions {
         var metadata = AdhUtil.deepPluck(raw.data, ["PUT", "request_body", "data", SIMetadata.nick]);
         return {
@@ -138,9 +143,10 @@ export class Service<Content extends ResourcesBase.Resource> {
             throw "attempt to http-options preliminary path: " + path;
         }
         path = this.formatUrl(path);
+        var headers = this.parseConfig(config);
 
         return this.adhCache.memoize(path, "OPTIONS",
-            () => this.$http({method: "OPTIONS", url: path})
+            () => this.$http({method: "OPTIONS", url: path, headers: headers})
         ).then((response) => {
             if (typeof config.importOptions === "undefined" || config.importOptions) {
                 return this.importOptions(response);
@@ -155,8 +161,12 @@ export class Service<Content extends ResourcesBase.Resource> {
             throw "attempt to http-get preliminary path: " + path;
         }
         path = this.formatUrl(path);
+        var headers = this.parseConfig(config);
 
-        return this.$http.get(path, { params : params });
+        return this.$http.get(path, {
+            params : params,
+            headers : headers
+        });
     }
 
     /**
@@ -195,9 +205,12 @@ export class Service<Content extends ResourcesBase.Resource> {
             throw "attempt to http-put preliminary path: " + path;
         }
         path = this.formatUrl(path);
+        var headers = this.parseConfig(config);
         this.adhCache.invalidate(path);
-        return this.$http
-            .put(path, obj);
+
+        return this.$http.put(path, obj, {
+            headers: headers
+        });
     }
 
     public put(path : string, obj : Content, config : IHttpPutConfig = {}) : angular.IPromise<Content> {
@@ -231,18 +244,20 @@ export class Service<Content extends ResourcesBase.Resource> {
             throw "attempt to http-post preliminary path: " + path;
         }
         path = this.formatUrl(path);
+        var headers = this.parseConfig(config);
 
         if (typeof FormData !== "undefined" && FormData.prototype.isPrototypeOf(obj)) {
             return _self.$http({
                 method: "POST",
                 url: path,
                 data: obj,
-                headers: {"Content-Type": undefined},
+                headers: _.assign({"Content-Type": undefined}, headers),
                 transformRequest: undefined
             });
         } else {
-            return _self.$http
-                .post(path, obj);
+            return _self.$http.post(path, obj, {
+                headers: headers
+            });
         }
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -211,7 +211,10 @@ export var register = () => {
                     adhHttp.getNewestVersionPathNoFork(path).then(
                         (ret) => {
                             expect(ret).toBe(returnPath1);
-                            expect($httpMock.get).toHaveBeenCalledWith(path + "LAST/", { params: undefined });
+                            expect($httpMock.get).toHaveBeenCalledWith(path + "LAST/", {
+                                params: undefined,
+                                headers: {}
+                            });
                             done();
                         },
                         (msg) => {
@@ -267,6 +270,8 @@ export var register = () => {
                                         follows: ["/ome/path"]
                                     }
                                 }
+                            }, {
+                                headers: {}
                             });
                             done();
                         },
@@ -329,6 +334,8 @@ export var register = () => {
                                     }
                                 },
                                 root_versions: ["foo", "bar"]
+                            }, {
+                                headers: {}
                             });
                             done();
                         },

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -187,7 +187,9 @@ export class Listing<Container extends ResourcesBase.Resource> {
                     if (count) {
                         params["count"] = "true";
                     }
-                    return adhHttp.get($scope.path, params, warmup);
+                    return adhHttp.get($scope.path, params, {
+                        warmupPoolCache: warmup
+                    });
                 };
 
                 $scope.update = (warmup? : boolean) : angular.IPromise<void> => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -159,7 +159,7 @@ export var register = () => {
                         });
 
                         it("updates scope.container from server", () => {
-                            expect(adhHttpMock.get).toHaveBeenCalledWith(path, {count: "true"}, undefined);
+                            expect(adhHttpMock.get).toHaveBeenCalledWith(path, {count: "true"}, {warmupPoolCache: undefined});
                             expect(scope.container).toBe(container);
                         });
 
@@ -187,7 +187,7 @@ export var register = () => {
                             expect(adhHttpMock.get).toHaveBeenCalledWith(path, {
                                 content_type: "some_content_type",
                                 count: "true"
-                            }, undefined);
+                            }, {warmupPoolCache: undefined});
                             expect(scope.container).toBe(container);
                         });
                     });

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Process/Process.ts
@@ -136,7 +136,7 @@ export var editDirective = (
                 scope.data.title = process.data[SITitle.nick].title;
                 scope.data.currentWorkflowState = process.data[SIKiezkassenWorkflow.nick].workflow_state;
             });
-            adhHttp.options(scope.path, false).then((raw) => {
+            adhHttp.options(scope.path, {importOptions: false}).then((raw) => {
                 // extract available transitions
                 scope.data.availableWorkflowStates = AdhUtil.deepPluck(raw, [
                     "data", "PUT", "request_body", "data", SIKiezkassenWorkflow.nick, "workflow_state"]);


### PR DESCRIPTION
This adds an option `noCredentials` to (nearly) all http methods. This will overwrite the headers to not send authentication credentials on this request.

To avoid code duplication I refactored the http methods to take a generic `config` map similar to the one in `$http`. I hope that this will also be easy to extend in the future.