### PR TITLE
Change name of requirements depending on config

### DIFF
--- a/buildout-meinberlin.cfg
+++ b/buildout-meinberlin.cfg
@@ -24,3 +24,4 @@ wheels +=
        src/adhocracy_frontend
        src/adhocracy_meinberlin
        src/meinberlin
+style = meinberlin

--- a/buildout-mercator.cfg
+++ b/buildout-mercator.cfg
@@ -25,3 +25,4 @@ wheels +=
        src/adhocracy_frontend
        src/adhocracy_mercator
        src/mercator
+style = mercator

--- a/src/adhocracy_core/wheels.cfg
+++ b/src/adhocracy_core/wheels.cfg
@@ -4,7 +4,7 @@ target_dir = parts/wheels
 wheels =
        src/substanced
        src/adhocracy_core
-
+style = plain
 
 input = inline:
     #!/bin/bash
@@ -25,9 +25,9 @@ input = inline:
 
     # create requirements.txt
     if git describe --exact-match 2> /dev/null; then
-      REQUIREMENTS_FILE=${make_wheels:target_dir}/requirements/$(git describe --exact-match)-requirements.txt
+      REQUIREMENTS_FILE=${make_wheels:target_dir}/requirements/${make_wheels:style}-$(git describe --exact-match)-requirements.txt
     else
-      REQUIREMENTS_FILE=${make_wheels:target_dir}/requirements/requirements.txt
+      REQUIREMENTS_FILE=${make_wheels:target_dir}/requirements/${make_wheels:style}-$(git rev-parse --abbrev-ref HEAD)-requirements.txt
     fi
     mkdir -p ${make_wheels:target_dir}/requirements
     ${buildout:bin-directory}/pip freeze | grep -v $FILTER > $REQUIREMENTS_FILE


### PR DESCRIPTION
Needed to have different requirements for meinberlin and mercator.