### PR TITLE
2015 05 mn render markdown

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -20,6 +20,7 @@ import modernizr = require("modernizr");
 import moment = require("moment");
 import webshim = require("polyfiller");
 import leaflet = require("leaflet");
+import markdownit = require("markdownit");
 
 import AdhAbuse = require("./Packages/Abuse/Abuse");
 import AdhConfig = require("./Packages/Config/Config");
@@ -35,6 +36,7 @@ import AdhInject = require("./Packages/Inject/Inject");
 import AdhListing = require("./Packages/Listing/Listing");
 import AdhLocale = require("./Packages/Locale/Locale");
 import AdhLocalSocket = require("./Packages/LocalSocket/LocalSocket");
+import AdhMarkdown = require("./Packages/Markdown/Markdown");
 import AdhMapping = require("./Packages/Mapping/Mapping");
 import AdhMovingColumns = require("./Packages/MovingColumns/MovingColumns");
 import AdhPermissions = require("./Packages/Permissions/Permissions");
@@ -91,7 +93,8 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhProposal.moduleName,
         AdhSticky.moduleName,
         AdhTracking.moduleName,
-        AdhUserViews.moduleName
+        AdhUserViews.moduleName,
+        AdhMarkdown.moduleName
     ];
 
     if (config.cachebust) {
@@ -148,6 +151,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
     app.value("leaflet", leaflet);
+    app.value("markdownit", markdownit);
 
     // register our modules
     app.value("adhConfig", config);
@@ -165,6 +169,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhLocale.register(angular);
     AdhLocalSocket.register(angular);
     AdhMapping.register(angular);
+    AdhMarkdwon.register(angular);
     AdhMovingColumns.register(angular);
     AdhPermissions.register(angular);
     AdhPreliminaryNames.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
@@ -3,30 +3,24 @@
 import AdhConfig = require("../Config/Config");
 import AdhEmbed = require("../Embed/Embed");
 
-export var parsemarkdown = (adhConfig : AdhConfig.IService, markdownit : any) => {
+export var parseMarkdown = (adhConfig : AdhConfig.IService, markdownit) => {
     return {
         scope: {
             parsetext: "="
         },
         restrict: "E",
         link: (scope, element) => {
+            var md = new markdownit();
 
-            var parseMarkdown = (markdown: string): string => {
-                var markdownit = require("markdownit");
-                    md = new markdownit();
-                var result = md.render(markdown);
-                return result;
-            };
-
-			scope.$watch("parsetext", function(newValue) {
-				element.children().remove();
-				element.append(parseMarkdown(newValue));
-			});
+            scope.$watch("parsetext", (newValue) => {
+                element.children().remove();
+                element.append(md.render(newValue));
+            });
         }
     };
 };
 
-export var testmarkdown = (adhConfig: AdhConfig.IService) => {
+export var testMarkdown = (adhConfig: AdhConfig.IService) => {
     return {
         restrict: "E",
         template: "<textarea ng-model=\"data.parsetext\" cols=\"50\" rows=\"10\"></textarea>" +
@@ -47,6 +41,6 @@ export var register = (angular) => {
         .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
             adhEmbedProvider.registerEmbeddableDirectives(["test-parse-markdown"]);
         }])
-        .directive("adhParseMarkdown", ["adhConfig", "markdownit", parsemarkdown])
-        .directive("adhTestParseMarkdown", ["adhConfig", testmarkdown]);
+        .directive("adhParseMarkdown", ["adhConfig", "markdownit", parseMarkdown])
+        .directive("adhTestParseMarkdown", ["adhConfig", testMarkdown]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
@@ -1,0 +1,52 @@
+/// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import AdhConfig = require("../Config/Config");
+import AdhEmbed = require("../Embed/Embed");
+
+export var parsemarkdown = (adhConfig : AdhConfig.IService, markdownit : any) => {
+    return {
+        scope: {
+            parsetext: "="
+        },
+        restrict: "E",
+        link: (scope, element) => {
+
+            var parseMarkdown = (markdown: string): string => {
+                var markdownit = require("markdownit");
+                    md = new markdownit();
+                var result = md.render(markdown);
+                return result;
+            };
+
+			scope.$watch("parsetext", function(newValue) {
+				element.children().remove();
+				element.append(parseMarkdown(newValue));
+			});
+        }
+    };
+};
+
+export var testmarkdown = (adhConfig: AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        template: "<textarea ng-model=\"data.parsetext\" cols=\"50\" rows=\"10\"></textarea>" +
+        "<adh-parse-markdown ng-if=\"data.parsetext\" parsetext=\"data.parsetext\"></adh-parse-markdown>",
+        link: (scope) => {
+            scope.data = {};
+        }
+    };
+};
+
+export var moduleName = "adhMarkdown";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhEmbed.moduleName
+        ])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider.registerEmbeddableDirectives(["test-parse-markdown"]);
+        }])
+        .directive("adhParseMarkdown", ["adhConfig", "markdownit", parsemarkdown])
+        .directive("adhTestParseMarkdown", ["adhConfig", testmarkdown]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/MarkdownSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/MarkdownSpec.ts
@@ -1,0 +1,12 @@
+/// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
+
+import AdhMarkdown = require("./Markdown");
+
+
+export var register = () => {
+    describe("Markdown", () => {
+        xit("exists", () => {
+            expect(AdhMarkdown).toBeDefined();
+        });
+    });
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/_all.d.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/_all.d.ts
@@ -111,6 +111,7 @@ declare class FlowOpts {
     acceptedFileTypes : string[];
 }
 
+declare module "markdownit" {}
 declare module "socialSharePrivacy" {}
 declare module "adhTemplates" {}
 declare module "polyfiller" {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
@@ -35,6 +35,7 @@ require.config({
         angularScroll: "../lib/angular-scroll/angular-scroll.min",
         angularFlow: "../lib/ng-flow/dist/ng-flow.min",
         angularMessages: "../lib/angular-messages/angular-messages.min",
+        markdownit: "../lib/markdown-it/dist/markdown-it.min",
         flow: "../lib/flow.js/dist/flow.min",
         leaflet: "../lib/leaflet/dist/leaflet",
         lodash: "../lib/lodash/lodash.min",

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -208,6 +208,7 @@ packages =
     angular-scroll#0.6.5
     angular-translate#2.6.1
     angular-translate-loader-static-files#2.6.1
+    markdown-it#4.2.1
     leaflet#0.7.3
     lodash#3.6.0
     requirejs#2.1.17
@@ -336,6 +337,7 @@ input = inline:
                             modernizr: "empty:",
                             moment: "empty:",
                             leaflet: "empty:",
+                            markdown-it: "empty",
                             sticky: "empty:",
                             socialSharePrivacy: "empty:",
                             polyfiller: "empty:",

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -22,6 +22,9 @@ import moment = require("moment");
 import leaflet = require("leaflet");
 import webshim = require("polyfiller");
 
+// FIXME: just added here for testing
+import markdownit = require("markdownit");
+
 import AdhAbuse = require("./Packages/Abuse/Abuse");
 import AdhConfig = require("./Packages/Config/Config");
 import AdhComment = require("./Packages/Comment/Comment");
@@ -53,6 +56,9 @@ import AdhUser = require("./Packages/User/User");
 import AdhUserViews = require("./Packages/User/Views");
 import AdhWebSocket = require("./Packages/WebSocket/WebSocket");
 import AdhMapping = require("./Packages/Mapping/Mapping");
+
+// FIXME: Just added here for testing
+import AdhMarkdown = require("./Packages/Markdown/Markdown");
 
 import AdhTemplates = require("adhTemplates");  if (AdhTemplates) { ; };
 
@@ -87,6 +93,9 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhComment.moduleName,
         AdhDone.moduleName,
         AdhMapping.moduleName,
+
+        // FIXME: Just added here for testing
+        AdhMarkdown.moduleName,
         AdhCrossWindowMessaging.moduleName,
         AdhEmbed.moduleName,
         AdhMeinBerlin.moduleName,
@@ -157,6 +166,9 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     }]);
 
     app.value("angular", angular);
+
+    // FIXME: Just added here for testing
+    app.value("markdownit", markdownit);
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
     app.value("leaflet", leaflet);
@@ -177,6 +189,9 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhLocalSocket.register(angular);
     AdhMeinBerlin.register(angular);
     AdhMapping.register(angular);
+
+    // FIXME: Just added here for testing
+    AdhMarkdown.register(angular);
     AdhMovingColumns.register(angular);
     AdhPermissions.register(angular);
     AdhPreliminaryNames.register(angular);


### PR DESCRIPTION
This code adds a directive that renders markdown to html and I also added a directive for you to test it. Use buildout for meinberlin and then go to http://localhost:6551/embed/test-parse-markdown and start typing to the textfield. 

I used this library https://github.com/markdown-it/markdown-it#usage-examples it does not render script tags to html. 