### PR TITLE
2015 05 jk simplify process permissions add dummy mercator process

### DIFF
--- a/etc/frontend_test.ini.in
+++ b/etc/frontend_test.ini.in
@@ -34,7 +34,7 @@ adhocracy.frontend.rest_url = http://localhost:9080
 adhocracy.frontend.site_name = Adhocracy Test Site
 
 adhocracy.custom = mercator_platform_path
-adhocracy.custom.mercator_platform_path = /mercator/
+adhocracy.custom.mercator_platform_path = /mercator/advocate/
 
 [server:main]
 use = egg:gunicorn#main

--- a/src/adhocracy_core/adhocracy_core/resources/root.py
+++ b/src/adhocracy_core/adhocracy_core/resources/root.py
@@ -55,7 +55,7 @@ root_acm = ACM().deserialize(
                      ['create_user',                   Allow,       None,          None,         None,      None,        Allow],  # noqa
                      ['edit_userextended',             None,        None,          None,         Allow,     None,        Allow],  # noqa
                      ['view_userextended',             None,        None,          None,         Allow,     None,        Allow],  # noqa
-                     ['edit_sheet_permissions',        None,        None,          None,         None,      None,        Allow],  # noqa
+                     ['create_edit_sheet_permissions', None,        None,          None,         None,      None,        Allow],  # noqa
                      ['create_group',                  None,        None,          None,         None,      None,        Allow],  # noqa
                      ]})
 

--- a/src/adhocracy_core/adhocracy_core/sheets/principal.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/principal.py
@@ -205,8 +205,8 @@ permissions_meta = sheet_meta._replace(
     isheet=IPermissions,
     schema_class=PermissionsSchema,
     permission_view='view_userextended',
-    permission_create='edit_sheet_permissions',
-    permission_edit='edit_sheet_permissions',
+    permission_create='create_edit_sheet_permissions',
+    permission_edit='create_edit_sheet_permissions',
     sheet_class=PermissionsAttributeResourceSheet,
 )
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_principal.py
@@ -331,8 +331,8 @@ class TestPermissionsSheet:
         assert isinstance(inst, PermissionsAttributeResourceSheet)
         assert inst.meta.isheet == IPermissions
         assert inst.meta.schema_class == PermissionsSchema
-        assert inst.meta.permission_create == 'edit_sheet_permissions'
-        assert inst.meta.permission_edit == 'edit_sheet_permissions'
+        assert inst.meta.permission_create == 'create_edit_sheet_permissions'
+        assert inst.meta.permission_edit == 'create_edit_sheet_permissions'
         assert inst.meta.permission_view == 'view_userextended'
 
     def test_get_empty(self, meta, context):

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/kiezkassen.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/kiezkassen.py
@@ -31,7 +31,7 @@ proposal_version_meta = itemversion_meta._replace(
                      IPoint,
                      ICommentable,
                      IRateable],
-    permission_create='edit_kiezkassen_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -50,7 +50,7 @@ proposal_meta = item_meta._replace(
     ],
     item_type=IProposalVersion,
     is_implicit_addable=True,
-    permission_create='create_kiezkassen_proposal',
+    permission_create = 'create_proposal',
 )
 
 
@@ -70,7 +70,6 @@ process_meta = process.process_meta._replace(
         ILocationReference,
         IImageReference,
     ],
-    permission_create='create_kiezkassen_process',
 )
 
 

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/root.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/root.py
@@ -1,7 +1,6 @@
 """Root resource type."""
 from pyramid.registry import Registry
 from pyramid.threadlocal import get_current_registry
-from pyramid.security import Allow
 from substanced.util import find_service
 from adhocracy_core.resources.organisation import IOrganisation
 from adhocracy_core.interfaces import IPool
@@ -42,11 +41,8 @@ def create_initial_content_for_meinberlin(context: IPool, registry: Registry,
                             appstructs=appstructs)
 
 meinberlin_acm = ACM().deserialize(
-    {'principals':                                   ['anonymous', 'participant', 'moderator',  'creator', 'initiator', 'admin'],  # noqa
-     'permissions': [['edit_kiezkassen_proposal',      None,        None,          None,         None,      None,        Allow],  # noqa
-                     ['create_kiezkassen_proposal',    None,        None,          None,         None,      None,        Allow],  # noqa
-                     ['create_kiezkassen_process',     None,        None,          None,         None,      Allow,       Allow],  # noqa
-                     ]})
+    {'principals': ['anonymous', 'participant', 'moderator',  'creator', 'initiator', 'admin'],  # noqa
+     'permissions': []})
 
 meinberlin_root_meta = root_meta._replace(
     after_creation=root_meta.after_creation +

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_kiezkassen.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_kiezkassen.py
@@ -21,7 +21,7 @@ def test_proposal_meta():
     from .kiezkassen import IProposalVersion
     assert proposal_meta.element_types == [IProposalVersion]
     assert proposal_meta.item_type == IProposalVersion
-    assert proposal_meta.permission_create == 'create_kiezkassen_proposal'
+    assert proposal_meta.permission_create == 'create_proposal'
 
 
 @mark.usefixtures('integration')
@@ -45,7 +45,7 @@ def test_kiezkassenversion_meta():
                                     ICommentable,
                                     IRateable,
                                     ]
-    assert meta.permission_create == 'edit_kiezkassen_proposal'
+    assert meta.permission_create == 'edit_proposal'
 
 @mark.usefixtures('integration')
 def test_kiezkassenversion_create(registry):
@@ -70,7 +70,7 @@ class TestProcess:
         assert meta.iresource is IProcess
         assert IProcess.isOrExtends(adhocracy_core.resources.process.IProcess)
         assert meta.is_implicit_addable is True
-        assert meta.permission_create == 'create_kiezkassen_process'
+        assert meta.permission_create == 'create_process'
         assert meta.extended_sheets == [
             adhocracy_core.sheets.description.IDescription,
             adhocracy_meinberlin.sheets.kiezkassen.IWorkflowAssignment,
@@ -78,7 +78,7 @@ class TestProcess:
             adhocracy_core.sheets.image.IImageReference,
         ]
         assert add_assets_service in meta.after_creation
-        assert meta.permission_create == 'create_kiezkassen_process'
+        assert meta.permission_create == 'create_process'
 
 
     @mark.usefixtures('integration')

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_subscriber.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_subscriber.py
@@ -10,10 +10,10 @@ def test_application_created_subscriber(monkeypatch):
     event = Mock()
     # avoid substanced querying the real registry when the commit occurs
     monkeypatch.setattr(transaction, 'commit', lambda: None)
-    event.app.registry.content.permissions = ['edit_kiezkassen_proposal',
-                                              'create_kiezkassen_proposal'
-                                              'create_kiezkassen_process']
+    event.app.registry.content.permissions = ['edit_proposal',
+                                              'create_proposal'
+                                              'create_process']
     root = testing.DummyResource(__acl__=[(Allow, 'role:creator', 'view')])
     event.app.root_factory.return_value = root
     _application_created_subscriber(event)
-    assert (Allow, 'role:admin', 'create_kiezkassen_proposal') in root.__acl__
+    assert (Allow, 'role:admin', 'create_proposal') in root.__acl__

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/kiezkassen.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/kiezkassen.py
@@ -19,8 +19,8 @@ kiezkassen_meta = {
                         'description': '',
                         'acm': {'principals': [                   'participant', 'moderator', 'creator', 'initiator'],  # noqa
                                 'permissions':
-                                  [['create_kiezkassen_proposal', 'Allow',        None,        None,     'Allow'],  # noqa
-                                   ['edit_kiezkassen_proposal',    None,          None,       'Allow',   'Allow'],  # noqa
+                                  [['create_proposal',            'Allow',        None,        None,     'Allow'],  # noqa
+                                   ['edit_proposal',               None,          None,       'Allow',   'Allow'],  # noqa
                                    ['create_comment',             'Allow',       'Allow',      None,     'Allow'],  # noqa
                                    ['edit_comment',                None,          None,       'Allow',    None],  # noqa
                                    ['create_rate',                'Allow',        None,        None,      None],  # noqa
@@ -31,8 +31,8 @@ kiezkassen_meta = {
                    'description': '',
                    'acm': {'principals': [                    'participant', 'moderator', 'creator', 'initiator'],  # noqa
                            'permissions':
-                              [['create_kiezkassen_proposal',  None,         None,        None,     'Allow'],  # noqa
-                               ['edit_kiezkassen_proposal',    None,          None,        None,     'Allow'],  # noqa
+                              [['create_proposal',             None,          None,        None,     'Allow'],  # noqa
+                               ['edit_proposal',               None,          None,        None,     'Allow'],  # noqa
                                ]},
                    },
         'result': {'title': 'Result',

--- a/src/adhocracy_mercator/adhocracy_mercator/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/__init__.py
@@ -14,6 +14,7 @@ def includeme(config):
     config.include('adhocracy_core.resources.sample_proposal')
     config.include('.catalog')
     config.include('.sheets.mercator')
+    config.include('.resources.root')
     config.include('.resources.mercator')
     config.include('.resources.subscriber')
     config.include('.evolution')

--- a/src/adhocracy_mercator/adhocracy_mercator/conftest.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/conftest.py
@@ -2,3 +2,16 @@
 from pytest import fixture
 
 
+@fixture(scope='class')
+def app(app_settings):
+    """Return the adhocracy_mercator test wsgi application."""
+    from pyramid.config import Configurator
+    from adhocracy_core.testing import add_create_test_users_subscriber
+    import adhocracy_mercator
+    configurator = Configurator(settings=app_settings,
+                                root_factory=adhocracy_mercator.root_factory)
+    configurator.include(adhocracy_mercator)
+    configurator.commit()
+    add_create_test_users_subscriber(configurator)
+    app = configurator.make_wsgi_app()
+    return app

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
@@ -1,14 +1,10 @@
 """Mercator proposal."""
-from pyramid.registry import Registry
-from pyramid.security import Allow
-
 from adhocracy_core.interfaces import IItemVersion
 from adhocracy_core.interfaces import IItem
-from adhocracy_core.interfaces import IPool
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources.asset import asset_meta
 from adhocracy_core.resources.asset import IAsset
-from adhocracy_core.resources.asset import IPoolWithAssets
+
 from adhocracy_core.resources.itemversion import itemversion_meta
 from adhocracy_core.resources.item import item_meta
 from adhocracy_core.resources.comment import add_commentsservice
@@ -16,9 +12,7 @@ from adhocracy_core.resources.rate import add_ratesservice
 from adhocracy_core.sheets.asset import IAssetMetadata
 from adhocracy_core.sheets.rate import ILikeable
 from adhocracy_core.sheets.comment import ICommentable
-from adhocracy_core.resources.root import root_meta
-from adhocracy_core.resources.root import add_platform
-from adhocracy_core.schema import ACM
+
 import adhocracy_core.sheets.title
 import adhocracy_mercator.sheets.mercator
 
@@ -451,23 +445,6 @@ mercator_proposal_meta = item_meta._replace(
 )
 
 
-def _create_initial_content(context: IPool, registry: Registry, options: dict):
-    """Add mercator specific content."""
-    add_platform(context, registry, 'mercator', resource_type=IPoolWithAssets)
-
-
-mercator_acm = ACM().deserialize(
-    {'principals':                                   ['anonymous', 'participant', 'moderator',  'creator', 'initiator', 'admin'],  # noqa
-     'permissions': [['create_mercator_proposal',      None,        None,          None,          None,      None,        Allow],  # noqa
-                     ['edit_mercator_proposal',        None,        None,          None,          None,      None,        Allow],  # noqa
-                     ['view_sheet_heardfrom',          None,        None,          None,          Allow,     Allow,       Allow],  # noqa
-                     ]})
-
-
-mercator_root_meta = root_meta._replace(after_creation=root_meta.after_creation
-                                        + [_create_initial_content])
-
-
 def includeme(config):
     """Add resource type to content."""
     add_resource_type_to_registry(mercator_proposal_meta, config)
@@ -495,6 +472,3 @@ def includeme(config):
     add_resource_type_to_registry(finance_version_meta, config)
     add_resource_type_to_registry(experience_meta, config)
     add_resource_type_to_registry(experience_version_meta, config)
-    # overrides adhocracy root
-    config.commit()
-    add_resource_type_to_registry(mercator_root_meta, config)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
@@ -4,11 +4,11 @@ from adhocracy_core.interfaces import IItem
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources.asset import asset_meta
 from adhocracy_core.resources.asset import IAsset
-
 from adhocracy_core.resources.itemversion import itemversion_meta
 from adhocracy_core.resources.item import item_meta
 from adhocracy_core.resources.comment import add_commentsservice
 from adhocracy_core.resources.rate import add_ratesservice
+from adhocracy_core.resources import process
 from adhocracy_core.sheets.asset import IAssetMetadata
 from adhocracy_core.sheets.rate import ILikeable
 from adhocracy_core.sheets.comment import ICommentable
@@ -445,6 +445,20 @@ mercator_proposal_meta = item_meta._replace(
 )
 
 
+class IProcess(process.IProcess):
+
+    """Mercator participation process."""
+
+
+process_meta = process.process_meta._replace(
+    iresource=IProcess,
+    element_types=[IMercatorProposal,
+                   ],
+    is_implicit_addable=True,
+)
+
+
+
 def includeme(config):
     """Add resource type to content."""
     add_resource_type_to_registry(mercator_proposal_meta, config)
@@ -472,3 +486,4 @@ def includeme(config):
     add_resource_type_to_registry(finance_version_meta, config)
     add_resource_type_to_registry(experience_meta, config)
     add_resource_type_to_registry(experience_version_meta, config)
+    add_resource_type_to_registry(process_meta, config)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator.py
@@ -28,7 +28,7 @@ organization_info_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IOrganizationInfo,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -46,7 +46,7 @@ organization_info_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IOrganizationInfoVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -77,7 +77,7 @@ introduction_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IIntroduction,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -95,7 +95,7 @@ introduction_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IIntroductionVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -110,7 +110,7 @@ description_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IDescription,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -128,7 +128,7 @@ description_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IDescriptionVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -143,7 +143,7 @@ location_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.ILocation,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -161,7 +161,7 @@ location_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=ILocationVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -176,7 +176,7 @@ story_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IStory,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -194,7 +194,7 @@ story_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IStoryVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -209,7 +209,7 @@ outcome_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IOutcome,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -227,7 +227,7 @@ outcome_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IOutcomeVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -242,7 +242,7 @@ steps_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.ISteps,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -260,7 +260,7 @@ steps_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IStepsVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -275,7 +275,7 @@ value_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IValue,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -293,7 +293,7 @@ value_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IValueVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -308,7 +308,7 @@ partners_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IPartners,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -326,7 +326,7 @@ partners_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IPartnersVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -341,7 +341,7 @@ finance_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IFinance,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -359,7 +359,7 @@ finance_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IFinanceVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -374,7 +374,7 @@ experience_version_meta = itemversion_meta._replace(
     extended_sheets=[
         adhocracy_mercator.sheets.mercator.IExperience,
         ICommentable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -392,7 +392,7 @@ experience_meta = item_meta._replace(
         add_commentsservice,
     ],
     item_type=IExperienceVersion,
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -410,7 +410,7 @@ mercator_proposal_version_meta = itemversion_meta._replace(
                      adhocracy_mercator.sheets.mercator.IMercatorSubResources,
                      ICommentable,
                      ILikeable],
-    permission_create='edit_mercator_proposal',
+    permission_create='edit_proposal',
 )
 
 
@@ -441,7 +441,7 @@ mercator_proposal_meta = item_meta._replace(
     ],
     item_type=IMercatorProposalVersion,
     is_implicit_addable=True,
-    permission_create='create_mercator_proposal',
+    permission_create='create_proposal',
 )
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
@@ -4,15 +4,21 @@ from pyramid.security import Allow
 
 from adhocracy_core.interfaces import IPool
 from adhocracy_core.resources import add_resource_type_to_registry
-from adhocracy_core.resources.asset import IPoolWithAssets
+from adhocracy_core.resources.organisation import IOrganisation
+from adhocracy_core.resources.process import IProcess
 from adhocracy_core.resources.root import root_meta
 from adhocracy_core.resources.root import add_platform
 from adhocracy_core.schema import ACM
+from adhocracy_core import sheets
 
 
 def _create_initial_content(context: IPool, registry: Registry, options: dict):
     """Add mercator specific content."""
-    add_platform(context, registry, 'mercator', resource_type=IPoolWithAssets)
+    add_platform(context, registry, 'mercator', resource_type=IOrganisation)
+    appstructs = {sheets.name.IName.__identifier__: {'name': 'advocate'}}
+    registry.content.create(IProcess.__identifier__,
+                            parent=context['mercator'],
+                            appstructs=appstructs)
 
 
 mercator_acm = ACM().deserialize(

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
@@ -17,9 +17,7 @@ def _create_initial_content(context: IPool, registry: Registry, options: dict):
 
 mercator_acm = ACM().deserialize(
     {'principals':                                   ['anonymous', 'participant', 'moderator',  'creator', 'initiator', 'admin'],  # noqa
-     'permissions': [['create_mercator_proposal',      None,        None,          None,          None,      None,        Allow],  # noqa
-                     ['edit_mercator_proposal',        None,        None,          None,          None,      None,        Allow],  # noqa
-                     ['view_sheet_heardfrom',          None,        None,          None,          Allow,     Allow,       Allow],  # noqa
+     'permissions': [['view_sheet_heardfrom',          None,        None,          None,          Allow,     Allow,       Allow],  # noqa
                      ]})
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
@@ -1,0 +1,34 @@
+"""Root resource type."""
+from pyramid.registry import Registry
+from pyramid.security import Allow
+
+from adhocracy_core.interfaces import IPool
+from adhocracy_core.resources import add_resource_type_to_registry
+from adhocracy_core.resources.asset import IPoolWithAssets
+from adhocracy_core.resources.root import root_meta
+from adhocracy_core.resources.root import add_platform
+from adhocracy_core.schema import ACM
+
+
+def _create_initial_content(context: IPool, registry: Registry, options: dict):
+    """Add mercator specific content."""
+    add_platform(context, registry, 'mercator', resource_type=IPoolWithAssets)
+
+
+mercator_acm = ACM().deserialize(
+    {'principals':                                   ['anonymous', 'participant', 'moderator',  'creator', 'initiator', 'admin'],  # noqa
+     'permissions': [['create_mercator_proposal',      None,        None,          None,          None,      None,        Allow],  # noqa
+                     ['edit_mercator_proposal',        None,        None,          None,          None,      None,        Allow],  # noqa
+                     ['view_sheet_heardfrom',          None,        None,          None,          Allow,     Allow,       Allow],  # noqa
+                     ]})
+
+
+mercator_root_meta = root_meta._replace(after_creation=root_meta.after_creation
+                                        + [_create_initial_content])
+
+
+def includeme(config):
+    """Add resource type to content."""
+    # overrides adhocracy root
+    config.commit()
+    add_resource_type_to_registry(mercator_root_meta, config)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/subscriber.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/subscriber.py
@@ -5,7 +5,7 @@ from adhocracy_core.authorization import add_acm
 from adhocracy_core.authorization import clean_acl
 from adhocracy_core.authorization import set_god_all_permissions
 from adhocracy_core.resources.root import root_acm
-from adhocracy_mercator.resources.mercator import mercator_acm
+from adhocracy_mercator.resources.root import mercator_acm
 import transaction
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
@@ -47,7 +47,7 @@ def test_mercator_proposal_meta():
     assert meta.item_type == IMercatorProposalVersion
     assert add_ratesservice in meta.after_creation
     assert add_commentsservice in meta.after_creation
-    assert meta.permission_create == 'create_mercator_proposal'
+    assert meta.permission_create == 'create_proposal'
 
 
 def test_mercator_proposal_version_meta():
@@ -55,7 +55,7 @@ def test_mercator_proposal_version_meta():
     from .mercator import IMercatorProposalVersion
     meta = mercator_proposal_version_meta
     assert meta.iresource == IMercatorProposalVersion
-    assert meta.permission_create == 'edit_mercator_proposal'
+    assert meta.permission_create == 'edit_proposal'
  
 
 @fixture

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
@@ -11,18 +11,6 @@ from mercator.tests.fixtures.fixturesMercatorProposals1 import create_proposal_b
 from mercator.tests.fixtures.fixturesMercatorProposals1 import update_proposal_batch
 
 
-def test_root_meta():
-    from adhocracy_core.resources.root import root_meta
-    from adhocracy_core.resources.root import \
-        create_initial_content_for_app_root
-    from .mercator import _create_initial_content
-    from .mercator import mercator_root_meta
-    assert _create_initial_content not in root_meta.after_creation
-    assert _create_initial_content in mercator_root_meta.after_creation
-    assert create_initial_content_for_app_root in \
-        mercator_root_meta.after_creation
-
-
 def test_mercator_proposal_meta():
     from .mercator import mercator_proposal_meta
     from .mercator import IMercatorProposal
@@ -77,20 +65,13 @@ def integration(config):
     config.include('adhocracy_core.catalog')
     config.include('adhocracy_core.sheets')
     config.include('adhocracy_core.graph')
-    config.include('adhocracy_core.rest')
-    config.include('adhocracy_core.authentication')
     config.include('adhocracy_core.resources.geo')
     config.include('adhocracy_core.resources.tag')
-    config.include('adhocracy_core.resources.comment')
-    config.include('adhocracy_core.resources.rate')
-    config.include('adhocracy_core.resources.principal')
     config.include('adhocracy_core.resources.pool')
     config.include('adhocracy_core.resources.asset')
     config.include('adhocracy_core.resources.item')
-    config.include('adhocracy_core.resources.sample_paragraph')
-    config.include('adhocracy_core.resources.sample_proposal')
-    config.include('adhocracy_core.resources.sample_section')
-    config.include('adhocracy_core.resources.external_resource')
+    config.include('adhocracy_core.resources.comment')
+    config.include('adhocracy_core.resources.rate')
     config.include('adhocracy_mercator.sheets.mercator')
     config.include('adhocracy_mercator.resources.mercator')
     config.include('adhocracy_mercator.resources.subscriber')
@@ -123,12 +104,7 @@ class TestIncludemeIntegration:
                                       )
         assert IMercatorProposalVersion.providedBy(res)
 
-    def test_create_mercator_root_with_initial_content(self, registry):
-        from adhocracy_core.resources.root import IRootPool
-        from adhocracy_core.resources.asset import IPoolWithAssets
-        inst = registry.content.create(IRootPool.__identifier__)
-        assert IRootPool.providedBy(inst)
-        assert IPoolWithAssets.providedBy(inst['mercator'])
+
 
 @fixture(scope='class')
 def app_anonymous(app_anonymous):

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator.py
@@ -105,21 +105,49 @@ class TestIncludemeIntegration:
         assert IMercatorProposalVersion.providedBy(res)
 
 
+class TestProcess:
+
+    @fixture
+    def meta(self):
+        from .mercator import process_meta
+        return process_meta
+
+    def test_meta(self, meta):
+        import adhocracy_core.resources.process
+        from adhocracy_core.resources.asset import add_assets_service
+        from .mercator import IProcess
+        from .mercator import IMercatorProposal
+        assert meta.iresource is IProcess
+        assert IProcess.isOrExtends(adhocracy_core.resources.process.IProcess)
+        assert meta.is_implicit_addable is True
+        assert meta.permission_create == 'create_process'
+        assert meta.extended_sheets == [
+            adhocracy_core.sheets.workflow.ISample
+        ]
+        assert meta.element_types == [IMercatorProposal]
+        assert add_assets_service in meta.after_creation
+
+
+    @mark.usefixtures('integration')
+    def test_create(self, registry, meta):
+        res = registry.content.create(meta.iresource.__identifier__)
+        assert meta.iresource.providedBy(res)
+
 
 @fixture(scope='class')
 def app_anonymous(app_anonymous):
-    app_anonymous.base_path = '/mercator'
+    app_anonymous.base_path = '/mercator/advocate'
     return app_anonymous
 
 @fixture(scope='class')
 def app_participant(app_participant):
-    app_participant.base_path = '/mercator'
+    app_participant.base_path = '/mercator/advocate'
     return app_participant
 
 
 @fixture(scope='class')
 def app_god(app_god):
-    app_god.base_path = '/mercator'
+    app_god.base_path = '/mercator/advocate'
     return app_god
 
 
@@ -141,18 +169,14 @@ def _batch_post_full_sample_proposal(app_user) -> TestResponse:
 @mark.functional
 class TestMercatorProposalPermissionsAnonymous:
 
-    # FIXME add organisation/process/workflow for mercator
-    @mark.xfail(reason='migration to organisation/process needed')
     def test_cannot_create_proposal_item(self, app_anonymous):
         resp = _post_proposal_item(app_anonymous, path='/', name='proposal1')
         assert resp.status_code == 403
 
-    @mark.xfail(reason='migration to organisation/process needed')
     def test_cannot_create_proposal_per_batch(self, app_anonymous):
         resp = _batch_post_full_sample_proposal(app_anonymous)
         assert resp.status_code == 403
 
-    @mark.xfail(reason='migration to organisation/process needed')
     def test_cannot_create_proposal_per_batch_broken_token(
             self, app_broken_token):
         resp = _batch_post_full_sample_proposal(app_broken_token)
@@ -162,19 +186,16 @@ class TestMercatorProposalPermissionsAnonymous:
 @mark.functional
 class TestMercatorProposalPermissionsParticipant:
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_can_create_proposal_item(self, app_participant):
         resp = _post_proposal_item(app_participant, path='/', name='proposal1')
         assert resp.status_code == 200
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_can_create_proposal_version(self, app_participant):
         from adhocracy_mercator.resources import mercator
         possible_types = mercator.mercator_proposal_meta.element_types
         postable_types = app_participant.get_postable_types('/proposal1')
         assert set(postable_types) == set(possible_types)
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_can_create_and_update_proposal_per_batch(self, app_participant):
         """Create full proposal then do batch request that first
          creates a new subresource Version (IOrganisationInfo) and then
@@ -187,28 +208,24 @@ class TestMercatorProposalPermissionsParticipant:
         assert app_participant.get('/proposal2/VERSION_0000002').json_body['data']['adhocracy_mercator.sheets.mercator.IUserInfo']['personal_name'] == 'pita Updated'
         assert "VERSION_0000002" in  app_participant.get('/proposal2/VERSION_0000002').json_body['data']['adhocracy_mercator.sheets.mercator.IMercatorSubResources']['organization_info']
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_cannot_create_other_users_proposal_version(self, app_participant,
                                                         app_god):
         _post_proposal_item(app_god, path='/', name='proposal_other')
         postable_types = app_participant.get_postable_types('/proposal_other')
         assert postable_types == []
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_non_god_creator_is_set(self, app_participant):
         """Regression test issue #362"""
         from adhocracy_core.sheets.metadata import IMetadata
         resp = app_participant.get('/proposal1')
         creator = resp.json['data'][IMetadata.__identifier__]['creator']
-        assert '0000003' in creator
+        assert '0000001' in creator
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_god_can_create_proposal_item(self, app_god):
         """Regression test issue #362"""
         resp = _post_proposal_item(app_god, path='/', name='god1')
         assert resp.status_code == 200
 
-    @mark.xfail(reason='current process phase does not allow creating proposal')
     def test_god_creator_is_set(self, app_god):
         """Regression test issue #362"""
         from adhocracy_core.sheets.metadata import IMetadata

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
@@ -1,0 +1,29 @@
+from pytest import fixture
+from pytest import mark
+
+
+@fixture
+def integration(config, pool_graph_catalog):
+    config.include('adhocracy_mercator')
+
+
+def test_root_meta():
+    from adhocracy_core.resources.root import root_meta
+    from adhocracy_core.resources.root import \
+        create_initial_content_for_app_root
+    from .root import _create_initial_content
+    from .root import mercator_root_meta
+    assert _create_initial_content not in root_meta.after_creation
+    assert _create_initial_content in mercator_root_meta.after_creation
+    assert create_initial_content_for_app_root in \
+        mercator_root_meta.after_creation
+
+
+@mark.usefixtures('integration')
+def test_create_root_with_initial_content(registry):
+        from adhocracy_core.resources.root import IRootPool
+        from adhocracy_core.resources.asset import IPoolWithAssets
+        inst = registry.content.create(IRootPool.__identifier__)
+        assert IRootPool.providedBy(inst)
+        assert IPoolWithAssets.providedBy(inst['mercator'])
+

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
@@ -22,8 +22,10 @@ def test_root_meta():
 @mark.usefixtures('integration')
 def test_create_root_with_initial_content(registry):
         from adhocracy_core.resources.root import IRootPool
-        from adhocracy_core.resources.asset import IPoolWithAssets
+        from adhocracy_core.resources.organisation import IOrganisation
+        from adhocracy_core.resources.process import IProcess
         inst = registry.content.create(IRootPool.__identifier__)
         assert IRootPool.providedBy(inst)
-        assert IPoolWithAssets.providedBy(inst['mercator'])
+        assert IOrganisation.providedBy(inst['mercator'])
+        assert IProcess.providedBy(inst['mercator']['advocate'])
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_subscriber.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_subscriber.py
@@ -11,9 +11,9 @@ def test_application_created_subscriber(monkeypatch):
     event = Mock()
     # avoid substanced querying the real registry when the commit occurs
     monkeypatch.setattr(transaction, 'commit', lambda: None)
-    event.app.registry.content.permissions = ['edit_mercator_proposal']
+    event.app.registry.content.permissions = ['edit_proposal']
     root = testing.DummyResource(__acl__=[])
     event.app.root_factory.return_value = root
     _application_created_subscriber(event)
-    assert (Allow, 'role:admin', 'edit_mercator_proposal') in root.__acl__
+    assert (Allow, 'role:admin', 'edit_proposal') in root.__acl__
     assert (Allow, 'role:god', ALL_PERMISSIONS) == root.__acl__[0]

--- a/src/mercator/mercator/tests/fixtures/fixturesMercatorProposals1.py
+++ b/src/mercator/mercator/tests/fixtures/fixturesMercatorProposals1.py
@@ -45,7 +45,7 @@ def login():
 
 
 create_proposal_batch = \
-    [{"method": "POST", "path": "http://localhost/mercator", "body": {
+    [{"method": "POST", "path": "http://localhost/mercator/advocate", "body": {
         "content_type": "adhocracy_mercator.resources.mercator.IMercatorProposal",
         "data": {"adhocracy_core.sheets.name.IName": {"name": "proposal2"}},
         "first_version_path": "@pn2", "root_versions": [],
@@ -272,11 +272,11 @@ create_proposal_batch = \
 
 update_proposal_batch = \
     [{"method": "POST",
-      "path": "http://localhost/mercator/proposal2/organization_info/", "body": {
+      "path": "http://localhost/mercator/advocate/proposal2/organization_info/", "body": {
         "content_type": "adhocracy_mercator.resources.mercator"
                         ".IOrganizationInfoVersion",
         "data": {"adhocracy_core.sheets.versions.IVersionable": {"follows": [
-            "http://localhost/mercator/proposal2/organization_info"
+            "http://localhost/mercator/advocate/proposal2/organization_info"
             "/VERSION_0000001/"]},
                  "adhocracy_core.sheets.metadata.IMetadata": {"deleted": false,
                                                               "preliminaryNames":
@@ -285,9 +285,9 @@ update_proposal_batch = \
                      "name": "organization name Updated", "country": "CL",
                      "status": "registered_nonprofit",
                      "website": "http://example.org"}}, "root_versions": [],
-        "parent": "http://localhost/mercator/proposal2/organization_info/"},
+        "parent": "http://localhost/mercator/advocate/proposal2/organization_info/"},
       "result_path": "@pn65", "result_first_version_path": "@pn77"},
-     {"method": "POST", "path": "http://localhost/mercator/proposal2/", "body": {
+     {"method": "POST", "path": "http://localhost/mercator/advocate/proposal2/", "body": {
          "content_type": "adhocracy_mercator.resources.mercator"
                          ".IMercatorProposalVersion",
          "data": {
@@ -295,11 +295,11 @@ update_proposal_batch = \
                                                           "preliminaryNames":
                                                               {"state": 78}},
              "adhocracy_core.sheets.versions.IVersionable": {"follows": [
-                 "http://localhost/mercator/proposal2/VERSION_0000001/"]},
+                 "http://localhost/mercator/advocate/proposal2/VERSION_0000001/"]},
              "adhocracy_mercator.sheets.mercator.IUserInfo": {
                  "personal_name": "pita Updated", "family_name": "pasta",
                  "country": "AR"}}, "root_versions": [],
-         "parent": "http://localhost/mercator/proposal2/"}, "result_path": "@pn64",
+         "parent": "http://localhost/mercator/advocate/proposal2/"}, "result_path": "@pn64",
       "result_first_version_path": "@pn78"}]
 
 


### PR DESCRIPTION
 Note: we don't have to care about migration the mercator production server now, creating proposals/comments is disabled anyway.