### PR TITLE
Fix #1168, remove meinberlin evolution script to create sampel content,

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/evolution/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/evolution/__init__.py
@@ -1,10 +1,7 @@
 """Scripts to migrate legacy objects in existing databases."""
 import logging  # pragma: no cover
-from pyramid.threadlocal import get_current_registry
 from adhocracy_core.evolution import migrate_new_sheet
 from adhocracy_meinberlin.resources.kiezkassen import IProposalVersion
-from adhocracy_meinberlin.resources.root import\
-    create_initial_content_for_meinberlin
 import adhocracy_core.sheets
 import adhocracy_meinberlin.sheets
 
@@ -37,14 +34,7 @@ def use_adhocracy_core_description_sheet(root):  # pragma: no cover
                       fields_mapping=[('description', 'detail')])
 
 
-def add_sample_organisation(root):
-    """Add sample organisation and kiezkassen process."""
-    registry = get_current_registry(root)
-    create_initial_content_for_meinberlin(root, registry, {})
-
-
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_evolution_step(use_adhocracy_core_title_sheet)
     config.add_evolution_step(use_adhocracy_core_description_sheet)
-    config.add_evolution_step(add_sample_organisation)

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/evolution/test_init.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/evolution/test_init.py
@@ -5,14 +5,3 @@ from pytest import fixture
 @fixture
 def integration(config):
     config.include('adhocracy_meinberlin')
-
-
-@mark.usefixtures('integration')
-def test_add_sample_organisation(registry, pool):
-    from . import add_sample_organisation
-    add_sample_organisation(pool)
-    assert pool['organisation']
-    assert pool['organisation']['kiezkasse']
-
-
-


### PR DESCRIPTION
the sampe content objects are created twice, with the migration step and
with the after_create function for the root resource.