### PR TITLE
make http requests wait for credentials

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -1,6 +1,7 @@
 import _ = require("lodash");
 
 import AdhConfig = require("../Config/Config");
+import AdhCredentials = require("../User/Credentials");
 import AdhDateTime = require("../DateTime/DateTime");
 import AdhDone = require("../Done/Done");
 import AdhEmbed = require("../Embed/Embed");
@@ -13,7 +14,6 @@ import AdhRate = require("../Rate/Rate");
 import AdhAngularHelpers = require("../AngularHelpers/AngularHelpers");
 import AdhResourceWidgets = require("../ResourceWidgets/ResourceWidgets");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
-import AdhUser = require("../User/User");
 import AdhUtil = require("../Util/Util");
 import AdhResourceUtil = require("../Util/ResourceUtil");
 
@@ -294,7 +294,7 @@ export var adhCreateOrShowCommentListing = (
     adhDone,
     adhHttp : AdhHttp.Service<any>,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
-    adhUser : AdhUser.Service
+    adhCredentials : AdhCredentials.Service
 ) => {
     return {
         restrict: "E",
@@ -321,7 +321,7 @@ export var adhCreateOrShowCommentListing = (
                     if (_.contains(result.data[SIPool.nick].elements, commentablePath)) {
                         setScope(commentablePath);
                     } else {
-                        var unwatch = scope.$watch(() => adhUser.loggedIn, (loggedIn) => {
+                        var unwatch = scope.$watch(() => adhCredentials.loggedIn, (loggedIn) => {
                             if (loggedIn) {
                                 var externalResource = new RIExternalResource({preliminaryNames: adhPreliminaryNames, name: scope.key});
                                 return adhHttp.post(scope.poolPath, externalResource).then((obj) => {
@@ -352,6 +352,7 @@ export var moduleName = "adhComment";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhCredentials.moduleName,
             AdhDateTime.moduleName,
             AdhDone.moduleName,
             AdhEmbed.moduleName,
@@ -362,15 +363,14 @@ export var register = (angular) => {
             AdhRate.moduleName,
             AdhAngularHelpers.moduleName,
             AdhResourceWidgets.moduleName,
-            AdhTopLevelState.moduleName,
-            AdhUser.moduleName
+            AdhTopLevelState.moduleName
         ])
         .directive("adhCommentListingPartial",
             ["adhConfig", "adhWebSocket", (adhConfig, adhWebSocket) =>
                 new AdhListing.Listing(new Adapter.ListingCommentableAdapter()).createDirective(adhConfig, adhWebSocket)])
         .directive("adhCommentListing", ["adhConfig", "adhTopLevelState", "$location", adhCommentListing])
         .directive("adhCreateOrShowCommentListing", [
-            "adhConfig", "adhDone", "adhHttp", "adhPreliminaryNames", "adhUser", adhCreateOrShowCommentListing])
+            "adhConfig", "adhDone", "adhHttp", "adhPreliminaryNames", "adhCredentials", adhCreateOrShowCommentListing])
         .directive("adhCommentResource", [
             "adhConfig", "adhHttp", "adhPermissions", "adhPreliminaryNames", "adhTopLevelState", "adhRecursionHelper", "$window", "$q",
             (adhConfig, adhHttp, adhPermissions, adhPreliminaryNames, adhTopLevelState, adhRecursionHelper, $window, $q) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -1,5 +1,6 @@
 import _ = require("lodash");
 
+import AdhAngularHelpers = require("../AngularHelpers/AngularHelpers");
 import AdhConfig = require("../Config/Config");
 import AdhCredentials = require("../User/Credentials");
 import AdhDateTime = require("../DateTime/DateTime");
@@ -11,11 +12,10 @@ import AdhMovingColumns = require("../MovingColumns/MovingColumns");
 import AdhPermissions = require("../Permissions/Permissions");
 import AdhPreliminaryNames = require("../PreliminaryNames/PreliminaryNames");
 import AdhRate = require("../Rate/Rate");
-import AdhAngularHelpers = require("../AngularHelpers/AngularHelpers");
+import AdhResourceUtil = require("../Util/ResourceUtil");
 import AdhResourceWidgets = require("../ResourceWidgets/ResourceWidgets");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
 import AdhUtil = require("../Util/Util");
-import AdhResourceUtil = require("../Util/ResourceUtil");
 
 import ResourcesBase = require("../../ResourcesBase");
 
@@ -352,6 +352,7 @@ export var moduleName = "adhComment";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhAngularHelpers.moduleName,
             AdhCredentials.moduleName,
             AdhDateTime.moduleName,
             AdhDone.moduleName,
@@ -361,7 +362,6 @@ export var register = (angular) => {
             AdhPermissions.moduleName,
             AdhPreliminaryNames.moduleName,
             AdhRate.moduleName,
-            AdhAngularHelpers.moduleName,
             AdhResourceWidgets.moduleName,
             AdhTopLevelState.moduleName
         ])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -228,6 +228,6 @@ export var register = (angular, trusted = false) => {
     if (trusted) {
         mod.factory("adhCrossWindowMessaging", ["adhConfig", "$location", "$window", "$rootScope", factory]);
     } else {
-        mod.factory("adhCrossWindowMessaging", ["adhConfig", "$location", "$window", "$rootScope", "adhUser", factory]);
+        mod.factory("adhCrossWindowMessaging", ["adhConfig", "$location", "$window", "$rootScope", factory]);
     }
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -73,7 +73,7 @@ export class Service implements IService {
         private $window : Window,
         private $rootScope,
         private trustedDomains : string[],
-        private adhUser ?: AdhUser.Service
+        private adhUser? : AdhUser.Service
     ) {
         var _self : Service = this;
 
@@ -144,8 +144,7 @@ export class Service implements IService {
         if (_self.embedderOrigin === "*") {
             _self.embedderOrigin = data.embedderOrigin;
 
-            _self.$rootScope.$watch(() => _self.adhUser.loggedIn, ((loggedIn) => _self.sendLoginState(loggedIn)));
-            _self.sendLoginState(_self.adhUser.loggedIn);
+            _self.$rootScope.$watch(() => _self.adhUser.loggedIn, (loggedIn) => _self.sendLoginState(loggedIn));
 
             _self.$rootScope.$watch(() => _self.$location.absUrl(), (absUrl) => {
                 _self.postMessage(
@@ -207,7 +206,7 @@ export var factory = (
     $location : angular.ILocationService,
     $window : Window,
     $rootScope,
-    adhUser ?: AdhUser.Service
+    adhUser? : AdhUser.Service
 ) : IService => {
     if (adhConfig.embedded) {
         var postMessageToParent = $window.parent.postMessage.bind($window.parent);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
@@ -10,13 +10,13 @@ export var register = () => {
         var locationMock;
         var windowMock;
         var rootScopeMock;
-        var adhUserMock;
+        var adhCredentialsMock;
 
         beforeEach(() => {
             locationMock = jasmine.createSpyObj("locationMock", ["absUrl"]);
             windowMock = jasmine.createSpyObj("windowMock", ["addEventListener"]);
             rootScopeMock = jasmine.createSpyObj("rootScopeMock", ["$watch"]);
-            adhUserMock = jasmine.createSpyObj("adhUserMock", ["loggedIn"]);
+            adhCredentialsMock = jasmine.createSpyObj("adhCredentialsMock", ["loggedIn"]);
         });
 
         describe("Service", () => {
@@ -26,7 +26,7 @@ export var register = () => {
             beforeEach(() => {
                 postMessageMock = jasmine.createSpy("postMessageMock");
                 service = new AdhCrossWindowMessaging.Service(
-                    postMessageMock, locationMock, windowMock, rootScopeMock, ["http://trusted.lan"], adhUserMock);
+                    postMessageMock, locationMock, windowMock, rootScopeMock, ["http://trusted.lan"], adhCredentialsMock, <any>true);
             });
 
             describe("registerMessageHandler", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -7,6 +7,7 @@
 import _ = require("lodash");
 
 import AdhConfig = require("../Config/Config");
+import AdhCredentials = require("../User/Credentials");
 import AdhPreliminaryNames = require("../PreliminaryNames/PreliminaryNames");
 import AdhResourceUtil = require("../Util/ResourceUtil");
 import AdhUtil = require("../Util/Util");
@@ -100,6 +101,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         private $http : angular.IHttpService,
         private $q : angular.IQService,
         private $timeout : angular.ITimeoutService,
+        private adhCredentials : AdhCredentials.Service,
         private adhMetaApi : AdhMetaApi.MetaApiQuery,
         private adhPreliminaryNames : AdhPreliminaryNames.Service,
         private adhConfig : AdhConfig.IService,
@@ -153,27 +155,28 @@ export class Service<Content extends ResourcesBase.Resource> {
         var headers = this.parseConfig(config);
 
         return this.adhCache.memoize(path, "OPTIONS",
-            () => this.$http({method: "OPTIONS", url: path, headers: headers})
-        ).then((response) => {
-            if (typeof config.importOptions === "undefined" || config.importOptions) {
-                return this.importOptions(response);
-            } else {
-                return response;
-            }
-        }, AdhError.logBackendError);
+            () => this.adhCredentials.ready.then(
+            () => this.$http({method: "OPTIONS", url: path, headers: headers}).then(
+            (response) => {
+                if (typeof config.importOptions === "undefined" || config.importOptions) {
+                    return this.importOptions(response);
+                } else {
+                    return response;
+                }
+            }, AdhError.logBackendError)));
     }
 
-    public getRaw(path : string, params?, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
+    public getRaw(path : string, params?, config : IHttpConfig = {}) : angular.IPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-get preliminary path: " + path;
         }
         path = this.formatUrl(path);
         var headers = this.parseConfig(config);
 
-        return this.$http.get(path, {
+        return this.adhCredentials.ready.then(() => this.$http.get(path, {
             params : params,
             headers : headers
-        });
+        }));
     }
 
     /**
@@ -207,7 +210,7 @@ export class Service<Content extends ResourcesBase.Resource> {
                 AdhError.logBackendError));
     }
 
-    public putRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
+    public putRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-put preliminary path: " + path;
         }
@@ -215,9 +218,9 @@ export class Service<Content extends ResourcesBase.Resource> {
         var headers = this.parseConfig(config);
         this.adhCache.invalidate(path);
 
-        return this.$http.put(path, obj, {
+        return this.adhCredentials.ready.then(() => this.$http.put(path, obj, {
             headers: headers
-        });
+        }));
     }
 
     public put(path : string, obj : Content, config : IHttpPutConfig = {}) : angular.IPromise<Content> {
@@ -244,7 +247,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
     }
 
-    public postRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IHttpPromise<any> {
+    public postRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<any> {
         var _self = this;
 
         if (_self.adhPreliminaryNames.isPreliminary(path)) {
@@ -253,19 +256,21 @@ export class Service<Content extends ResourcesBase.Resource> {
         path = this.formatUrl(path);
         var headers = this.parseConfig(config);
 
-        if (typeof FormData !== "undefined" && FormData.prototype.isPrototypeOf(obj)) {
-            return _self.$http({
-                method: "POST",
-                url: path,
-                data: obj,
-                headers: _.assign({"Content-Type": undefined}, headers),
-                transformRequest: undefined
-            });
-        } else {
-            return _self.$http.post(path, obj, {
-                headers: headers
-            });
-        }
+        return this.adhCredentials.ready.then(() => {
+            if (typeof FormData !== "undefined" && FormData.prototype.isPrototypeOf(obj)) {
+                return _self.$http({
+                    method: "POST",
+                    url: path,
+                    data: obj,
+                    headers: _.assign({"Content-Type": undefined}, headers),
+                    transformRequest: undefined
+                });
+            } else {
+                return _self.$http.post(path, obj, {
+                    headers: headers
+                });
+            }
+        });
     }
 
     public post(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<Content> {
@@ -562,6 +567,7 @@ export var moduleName = "adhHttp";
 export var register = (angular, config, metaApi) => {
     angular
         .module(moduleName, [
+            AdhCredentials.moduleName,
             AdhPreliminaryNames.moduleName,
             AdhWebSocket.moduleName,
             "angular-data.DSCacheFactory",
@@ -572,7 +578,7 @@ export var register = (angular, config, metaApi) => {
         .service("adhHttpBusy", ["$q", Busy])
         .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", busyDirective])
         .service("adhHttp", [
-            "$http", "$q", "$timeout", "adhMetaApi", "adhPreliminaryNames", "adhConfig", "adhCache", Service])
+            "$http", "$q", "$timeout", "adhCredentials", "adhMetaApi", "adhPreliminaryNames", "adhConfig", "adhCache", Service])
         .service("adhCache", ["$q", "adhConfig", "adhWebSocket", "DSCacheFactory", AdhCache.Service])
         .factory("adhMetaApi", () => new AdhMetaApi.MetaApiQuery(metaApi))
         .filter("adhFormatError", () => AdhError.formatError);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpIg.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpIg.ts
@@ -19,19 +19,23 @@ import AdhHttp = require("./Http");
 import AdhMetaApi = require("./MetaApi");
 
 export var register = (angular, config, meta_api) => {
+    var factory = ($http, $q, $timeout) => {
+        $http.defaults.headers.common["X-User-Token"] = "SECRET_GOD";
+        $http.defaults.headers.common["X-User-Path"] = "/principals/users/0000000";
+
+        var preliminaryNames = new AdhPreliminaryNames.Service();
+        var adhMetaApi = new AdhMetaApi.MetaApiQuery(meta_api);
+
+        var adhCredentialsMock = <any>{
+            ready: $q.when(true)
+        };
+
+        return (new AdhHttp.Service($http, $q, $timeout, adhCredentialsMock, adhMetaApi, preliminaryNames, config));
+    };
+    factory.$inject = ["$http", "$q", "$timeout"];
 
     describe("$http.get and AdhHttp.getRaw", () => {
-        var adhHttp : AdhHttp.Service<any> = (() => {
-            var factory = ($http, $q, $timeout) => {
-                $http.defaults.headers.common["X-User-Token"] = "SECRET_GOD";
-                $http.defaults.headers.common["X-User-Path"] = "/principals/users/0000000";
-
-                var preliminaryNames = new AdhPreliminaryNames.Service();
-                return (new AdhHttp.Service($http, $q, $timeout, new AdhMetaApi.MetaApiQuery(meta_api), preliminaryNames, config));
-            };
-            factory.$inject = ["$http", "$q", "$timeout"];
-            return angular.injector(["ng"]).invoke(factory);
-        })();
+        var adhHttp : AdhHttp.Service<any> = angular.injector(["ng"]).invoke(factory)();
 
         // FIXME: there is a work-around for this problem in Error.ts
         // in function logBackendError.  if this test is re-enabled
@@ -57,18 +61,7 @@ export var register = (angular, config, meta_api) => {
         // randomise.)
 
     describe("withTransaction", () => {
-        var adhHttp : AdhHttp.Service<any> = (() => {
-            var factory = ($http, $q, $timeout) => {
-                $http.defaults.headers.common["X-User-Token"] = "SECRET_GOD";
-                $http.defaults.headers.common["X-User-Path"] = "/principals/users/0000000";
-
-                var preliminaryNames = new AdhPreliminaryNames.Service();
-                return (new AdhHttp.Service($http, $q, $timeout, new AdhMetaApi.MetaApiQuery(meta_api), preliminaryNames, config));
-            };
-            factory.$inject = ["$http", "$q", "$timeout"];
-            return angular.injector(["ng"]).invoke(factory);
-        })();
-
+        var adhHttp : AdhHttp.Service<any> = angular.injector(["ng"]).invoke(factory)();
         var adhPreliminaryNames = new AdhPreliminaryNames.Service();
 
         it("Deep-rewrites preliminary resource paths.", (done) => {
@@ -119,18 +112,7 @@ export var register = (angular, config, meta_api) => {
     });
 
     describe("postNewVersionNoFork", () => {
-        var adhHttp : AdhHttp.Service<any> = (() => {
-            var factory = ($http, $q, $timeout) => {
-                $http.defaults.headers.common["X-User-Token"] = "SECRET_GOD";
-                $http.defaults.headers.common["X-User-Path"] = "/principals/users/0000000";
-
-                var preliminaryNames = new AdhPreliminaryNames.Service();
-                return (new AdhHttp.Service($http, $q, $timeout, new AdhMetaApi.MetaApiQuery(meta_api), preliminaryNames, config));
-            };
-            factory.$inject = ["$http", "$q", "$timeout"];
-            return angular.injector(["ng"]).invoke(factory);
-        })();
-
+        var adhHttp : AdhHttp.Service<any> = angular.injector(["ng"]).invoke(factory)();
         var adhPreliminaryNames = new AdhPreliminaryNames.Service();
 
         it("Identifies backend 'no fork allowed' error message properly.", (done) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -89,6 +89,7 @@ export var register = () => {
             var adhMetaApiMock;
             var adhConfigMock;
             var adhCacheMock;
+            var adhCredentialsMock;
             var adhHttp : AdhHttp.Service<any>;
 
             beforeEach(() => {
@@ -103,8 +104,11 @@ export var register = () => {
                     invalidateUpdated: (updated, posted) => undefined,
                     memoize: (path, subkey, closure) => closure()
                 };
+                adhCredentialsMock = {
+                    ready: q.when(true)
+                };
                 adhHttp = new AdhHttp.Service(
-                    $httpMock, <any>q, $timeoutMock, adhMetaApiMock, adhPreliminaryNames, adhConfigMock, adhCacheMock);
+                    $httpMock, <any>q, $timeoutMock, adhCredentialsMock, adhMetaApiMock, adhPreliminaryNames, adhConfigMock, adhCacheMock);
             });
 
             describe("options", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Permissions/Permissions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Permissions/Permissions.ts
@@ -1,11 +1,11 @@
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
 
+import AdhCredentials = require("../User/Credentials");
 import AdhHttp = require("../Http/Http");
-import AdhUser = require("../User/User");
 
 
 export class Service {
-    constructor(private adhHttp : AdhHttp.Service<any>, private adhUser : AdhUser.Service) {}
+    constructor(private adhHttp : AdhHttp.Service<any>, private adhCredentials : AdhCredentials.Service) {}
 
     /**
      * Set result of OPTIONS request to scope.key and keep it fresh.
@@ -31,8 +31,8 @@ export class Service {
             }
         };
 
-        // FIXME: It would be better if adhUser would notify us on change
-        scope.$watch(() => self.adhUser.userPath, update);
+        // FIXME: It would be better if adhCredentials would notify us on change
+        scope.$watch(() => self.adhCredentials.userPath, update);
         scope.$watch(pathFn, (p : string) => {
             pathString = p;
             update();
@@ -46,8 +46,8 @@ export var moduleName = "adhPermissions";
 export var register = (angular) => {
     angular
         .module(moduleName, [
-            AdhHttp.moduleName,
-            AdhUser.moduleName
+            AdhCredentials.moduleName,
+            AdhHttp.moduleName
         ])
-        .service("adhPermissions", ["adhHttp", "adhUser", Service]);
+        .service("adhPermissions", ["adhHttp", "adhCredentials", Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -2,13 +2,13 @@ import _ = require("lodash");
 
 import AdhAngularHelpers = require("../AngularHelpers/AngularHelpers");
 import AdhConfig = require("../Config/Config");
+import AdhCredentials = require("../User/Credentials");
 import AdhEventManager = require("../EventManager/EventManager");
 import AdhHttp = require("../Http/Http");
 import AdhPermissions = require("../Permissions/Permissions");
 import AdhPreliminaryNames = require("../PreliminaryNames/PreliminaryNames");
 import AdhResourceUtil = require("../Util/ResourceUtil");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
-import AdhUser = require("../User/User");
 import AdhUtil = require("../Util/Util");
 import AdhWebSocket = require("../WebSocket/WebSocket");
 
@@ -142,7 +142,7 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
     adhHttp : AdhHttp.Service<any>,
     adhWebSocket : AdhWebSocket.Service,
     adhPermissions : AdhPermissions.Service,
-    adhUser : AdhUser.Service,
+    adhCredentials : AdhCredentials.Service,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhDone
@@ -215,8 +215,8 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
             var storeMyRateResource : (resource : RIRateVersion) => void;
 
             var updateMyRate = () : angular.IPromise<void> => {
-                if (adhUser.loggedIn) {
-                    return adhRate.fetchRate(postPoolPath, scope.refersTo, adhUser.userPath).then((resource) => {
+                if (adhCredentials.loggedIn) {
+                    return adhRate.fetchRate(postPoolPath, scope.refersTo, adhCredentials.userPath).then((resource) => {
                         storeMyRateResource(resource);
                         scope.myRate = adapter.rate(resource);
                     }, () => undefined);
@@ -294,7 +294,7 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
                 }
 
                 if (!scope.optionsPostPool.POST) {
-                    if (!adhUser.loggedIn) {
+                    if (!adhCredentials.loggedIn) {
                         adhTopLevelState.redirectToLogin();
                     } else {
                         // FIXME
@@ -310,7 +310,7 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
 
                         adapter.rate(newVersion, rate);
                         adapter.object(newVersion, scope.refersTo);
-                        adapter.subject(newVersion, adhUser.userPath);
+                        adapter.subject(newVersion, adhCredentials.userPath);
 
                         return adhHttp.postNewVersionNoFork(version.path, newVersion)
                             .then(() => {
@@ -363,12 +363,12 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhAngularHelpers.moduleName,
+            AdhCredentials.moduleName,
             AdhEventManager.moduleName,
             AdhHttp.moduleName,
             AdhPermissions.moduleName,
             AdhPreliminaryNames.moduleName,
             AdhTopLevelState.moduleName,
-            AdhUser.moduleName,
             AdhWebSocket.moduleName
         ])
         .service("adhRateEventManager", ["adhEventManagerClass", (cls) => new cls()])
@@ -381,7 +381,7 @@ export var register = (angular) => {
             "adhHttp",
             "adhWebSocket",
             "adhPermissions",
-            "adhUser",
+            "adhCredentials",
             "adhPreliminaryNames",
             "adhTopLevelState",
             "adhDone",
@@ -394,7 +394,7 @@ export var register = (angular) => {
             "adhHttp",
             "adhWebSocket",
             "adhPermissions",
-            "adhUser",
+            "adhCredentials",
             "adhPreliminaryNames",
             "adhTopLevelState",
             "adhDone",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateIg.ts
@@ -54,7 +54,11 @@ export var register = (angular, config, meta_api) => {
                     $http.defaults.headers.common["X-Credentials-Token"] = "SECRET_GOD";
                     $http.defaults.headers.common["X-Credentials-Path"] = "/principals/users/0000000/";
 
-                    return (new AdhHttp.Service($http, $q, $timeout, adhMetaApi, adhPreliminaryNames, config));
+                    var adhCredentialsMock = <any>{
+                        ready: $q.when(true)
+                    };
+
+                    return (new AdhHttp.Service($http, $q, $timeout, adhCredentialsMock, adhMetaApi, adhPreliminaryNames, config));
                 };
                 factory.$inject = ["$http", "$q", "$timeout"];
                 return angular.injector(["ng"]).invoke(factory);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -97,10 +97,10 @@ export class Provider {
 
         this.$get = [
             "adhEventManagerClass", "adhTracking", "adhCredentials",
-            "$location", "$rootScope", "$http", "$q", "$injector", "$templateRequest",
-            (adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $http, $q, $injector, $templateRequest) => {
+            "$location", "$rootScope", "$q", "$injector", "$templateRequest",
+            (adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $q, $injector, $templateRequest) => {
                 return new Service(
-                    self, adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $http, $q, $injector, $templateRequest);
+                    self, adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $q, $injector, $templateRequest);
             }
         ];
     }
@@ -151,7 +151,6 @@ export class Service {
         private adhCredentials : AdhCredentials.Service,
         private $location : angular.ILocationService,
         private $rootScope : angular.IScope,
-        private $http : angular.IHttpService,
         private $q : angular.IQService,
         private $injector : angular.auto.IInjectorService,
         private $templateRequest : angular.ITemplateRequestService

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -26,9 +26,9 @@
 import _ = require("lodash");
 
 import AdhConfig = require("../Config/Config");
+import AdhCredentials = require("../User/Credentials");
 import AdhEventManager = require("../EventManager/EventManager");
 import AdhTracking = require("../Tracking/Tracking");
-import AdhUser = require("../User/User");
 
 var pkgLocation = "/TopLevelState";
 
@@ -96,11 +96,11 @@ export class Provider {
         this.spaceDefaults = {};
 
         this.$get = [
-            "adhEventManagerClass", "adhTracking", "adhUser",
+            "adhEventManagerClass", "adhTracking", "adhCredentials",
             "$location", "$rootScope", "$http", "$q", "$injector", "$templateRequest",
-            (adhEventManagerClass, adhTracking, adhUser, $location, $rootScope, $http, $q, $injector, $templateRequest) => {
+            (adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $http, $q, $injector, $templateRequest) => {
                 return new Service(
-                    self, adhEventManagerClass, adhTracking, adhUser, $location, $rootScope, $http, $q, $injector, $templateRequest);
+                    self, adhEventManagerClass, adhTracking, adhCredentials, $location, $rootScope, $http, $q, $injector, $templateRequest);
             }
         ];
     }
@@ -148,7 +148,7 @@ export class Service {
         private provider : Provider,
         adhEventManagerClass : typeof AdhEventManager.EventManager,
         private adhTracking : AdhTracking.Service,
-        private adhUser : AdhUser.Service,
+        private adhCredentials : AdhCredentials.Service,
         private $location : angular.ILocationService,
         private $rootScope : angular.IScope,
         private $http : angular.IHttpService,
@@ -285,7 +285,7 @@ export class Service {
 
         switch (error.code) {
             case 401:
-                if (this.adhUser.loggedIn) {
+                if (this.adhCredentials.loggedIn) {
                     return this.handleRoutingError({
                         code: 403,
                         message: error.message
@@ -549,9 +549,9 @@ export var moduleName = "adhTopLevelState";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhCredentials.moduleName,
             AdhEventManager.moduleName,
-            AdhTracking.moduleName,
-            AdhUser.moduleName
+            AdhTracking.moduleName
         ])
         .provider("adhTopLevelState", Provider)
         .directive("adhPageWrapper", ["adhConfig", pageWrapperDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
@@ -46,7 +46,7 @@ export var register = () => {
 
                 adhTopLevelState = <any>new AdhTopLevelState.Service(
                     providerMock, eventManagerMockClass, adhTrackingMock, null,
-                    locationMock, rootScopeMock, null, <any>q, injectorMock, null);
+                    locationMock, rootScopeMock, <any>q, injectorMock, null);
 
                 spyOn(adhTopLevelState, "toLocation");
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Credentials.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Credentials.ts
@@ -1,0 +1,139 @@
+/// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import AdhCache = require("../Http/Cache");
+import AdhConfig = require("../Config/Config");
+import AdhTracking = require("../Tracking/Tracking");
+
+
+export class Service {
+    public token : string;
+    public userPath : string;
+    public loggedIn : boolean;
+    public ready : angular.IPromise<boolean>;
+
+    constructor(
+        private adhConfig : AdhConfig.IService,
+        private adhCache : AdhCache.Service,
+        private adhTracking : AdhTracking.Service,
+        private Modernizr,
+        private ng : typeof angular,
+        private $q : angular.IQService,
+        private $http : angular.IHttpService,
+        private $timeout : angular.ITimeoutService,
+        private $rootScope : angular.IScope,
+        private $window
+    ) {
+        var _self : Service = this;
+
+        var deferred = $q.defer();
+        _self.ready = deferred.promise;
+        var unwatch = _self.$rootScope.$watch(() => _self.loggedIn, ((loggedIn) => {
+            if (typeof loggedIn !== "undefined") {
+                deferred.resolve(loggedIn);
+                unwatch();
+            }
+        }));
+
+        if (_self.Modernizr.localstorage) {
+            var sessionValue = _self.$window.localStorage.getItem("user-session");
+            _self.updateSessionFromStorage(sessionValue);
+
+            _self.ng.element(_self.$window).on("storage", (event) => {
+                var storageEvent = <any>event.originalEvent;
+                if (storageEvent.key === "user-session") {
+                    _self.updateSessionFromStorage(storageEvent.newValue);
+                }
+            });
+        } else {
+            _self.loggedIn = false;
+        }
+    }
+
+    private updateSessionFromStorage(sessionValue) : angular.IPromise<boolean> {
+        var _self : Service = this;
+
+        var deferred = _self.$q.defer();
+
+        if (sessionValue) {
+            try {
+                var session = JSON.parse(sessionValue);
+                var path = session["user-path"];
+                var token = session["user-token"];
+                _self.$http.head(_self.adhConfig.rest_url, {
+                    headers: {
+                        "X-User-Token": token,
+                        "X-User-Path": path
+                    }
+                }).then((response) => {
+                    _self.enableToken(token, path);
+                    deferred.resolve(true);
+                }, (msg) => {
+                    console.log("Expired or invalid session deleted");
+                    _self.deleteToken();
+                    deferred.resolve(false);
+                });
+            } catch (e) {
+                console.log("Invalid session deleted");
+                _self.deleteToken();
+                deferred.resolve(false);
+            }
+        } else {
+            _self.$timeout(() => {
+                _self.deleteToken();
+                deferred.resolve(false);
+            });
+        }
+
+        return deferred.promise;
+    }
+
+    private enableToken(token : string, userPath : string) : void {
+        this.token = token;
+        this.userPath = userPath;
+        this.loggedIn = true;
+        this.$http.defaults.headers.common["X-User-Token"] = token;
+        this.$http.defaults.headers.common["X-User-Path"] = userPath;
+        this.adhTracking.setLoginState(true);
+        this.adhTracking.setUserId(userPath);
+    }
+
+    public storeAndEnableToken(token : string, userPath : string) : void {
+        if (this.Modernizr.localstorage) {
+            this.$window.localStorage.setItem("user-session", JSON.stringify({
+                "user-path": userPath,
+                "user-token": token
+            }));
+        } else {
+            console.log("session could not be persisted");
+        }
+
+        return this.enableToken(token, userPath);
+    }
+
+    public deleteToken() : void {
+        if (this.Modernizr.localstorage) {
+            this.$window.localStorage.removeItem("user-session");
+        }
+        delete this.$http.defaults.headers.common["X-User-Token"];
+        delete this.$http.defaults.headers.common["X-User-Path"];
+        this.token = undefined;
+        this.userPath = undefined;
+        this.loggedIn = false;
+        this.adhTracking.setLoginState(false);
+        this.adhTracking.setUserId(null);
+
+        this.adhCache.invalidateAll();
+    }
+}
+
+
+export var moduleName = "adhCredentials";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhTracking.moduleName
+        ])
+        .service("adhCredentials", [
+            "adhConfig", "adhCache", "adhTracking", "Modernizr", "angular", "$q", "$http", "$timeout", "$rootScope", "$window", Service]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Indicator.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Indicator.html
@@ -1,10 +1,10 @@
-<div class="user-indicator" data-ng-switch="user.loggedIn">
-    <div ng-switch-when="true">
-        <a data-ng-if="!noLink" data-ng-href="{{ user.userPath | adhResourceUrl }}" class="user-indicator-name">{{user.data.name}}</a
+<div class="user-indicator" data-ng-switch="credentials.loggedIn">
+    <div data-ng-switch-when="true">
+        <a data-ng-if="!noLink" data-ng-href="{{ credentials.userPath | adhResourceUrl }}" class="user-indicator-name">{{user.data.name}}</a
         ><span data-ng-if="noLink" class="user-indicator-name">{{user.data.name}}</span>,
         <a class="user-indicator-logout" href="" data-ng-click="logOut()">{{ "TR__LOGOUT" | translate }}</a>
     </div>
-    <div ng-switch-default="">
+    <div data-ng-switch-default="">
         <div class="user-indicator-primary">
             <i class="icon-user user-indicator-login-icon"></i> <a class="user-indicator-login" href="/login">{{ "TR__LOGIN" | translate }}</a>
             {{ "TR__OR" | translate }}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -1,12 +1,8 @@
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
 
-import _ = require("lodash");
-
-import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
-import AdhCache = require("../Http/Cache");
-import AdhLocale = require("../Locale/Locale");
-import AdhTracking = require("../Tracking/Tracking");
+
+import AdhCredentials = require("./Credentials");
 
 import SIPasswordAuthentication = require("../../Resources_/adhocracy_core/sheets/principal/IPasswordAuthentication");
 import SIUserBasic = require("../../Resources_/adhocracy_core/sheets/principal/IUserBasic");
@@ -23,88 +19,22 @@ export interface IRegisterResponse {}
 
 
 export class Service {
-    public loggedIn : boolean;
-    public ready : angular.IPromise<any>;
     public data : IUserBasic;
-    public token : string;
-    public userPath : string;
 
     constructor(
-        private adhConfig : AdhConfig.IService,
         private adhHttp : AdhHttp.Service<any>,
-        private adhCache : AdhCache.Service,
-        private adhTracking : AdhTracking.Service,
-        private $q : angular.IQService,
-        private $http : angular.IHttpService,
-        private $rootScope : angular.IScope,
-        private $window : Window,
-        private ng : typeof angular,
-        private Modernizr
+        private adhCredentials : AdhCredentials.Service,
+        private $rootScope : angular.IScope
     ) {
         var _self : Service = this;
 
-        var deferred = $q.defer();
-        _self.ready = deferred.promise;
-        var unwatch = this.$rootScope.$watch(() => _self.loggedIn, ((loggedIn) => {
-            if (typeof loggedIn !== "undefined") {
-                deferred.resolve(null);
-                unwatch();
+        _self.$rootScope.$watch(() => adhCredentials.userPath, (userPath) => {
+            if (userPath) {
+                _self.loadUser(userPath);
+            } else {
+                _self.data = undefined;
             }
-        }));
-
-        if (_self.Modernizr.localstorage) {
-            var win = _self.ng.element(_self.$window);
-            win.on("storage", (event) => {
-                var storageEvent = <any>event.originalEvent;
-                if (storageEvent.key === "user-session") {
-                    _self.updateSessionFromStorage(storageEvent.newValue);
-                }
-            });
-            var sessionValue = _self.$window.localStorage.getItem("user-session");
-            _self.updateSessionFromStorage(sessionValue);
-        } else {
-            _self.loggedIn = false;
-        }
-    }
-
-    private updateSessionFromStorage(sessionValue) : angular.IPromise<boolean> {
-        var _self : Service = this;
-
-        var deferred = _self.$q.defer();
-
-        if (sessionValue) {
-            try {
-                var session = JSON.parse(sessionValue);
-                var path = session["user-path"];
-                var token = session["user-token"];
-                this.$http.head(this.adhConfig.rest_url, {
-                    headers: {
-                        "X-User-Token": token,
-                        "X-User-Path": path
-                    }
-                }).then((response) => {
-                    _self.enableToken(token, path);
-                    deferred.resolve(true);
-                }, (msg) => {
-                    console.log("Expired or invalid session deleted");
-                    _self.deleteToken();
-                    deferred.resolve(false);
-                });
-            } catch (e) {
-                console.log("Invalid session deleted");
-                _self.deleteToken();
-            }
-        } else {
-            // $apply is necessary here to trigger a UI
-            // update.  the need for _.defer is explained
-            // here: http://stackoverflow.com/a/17958847
-            _.defer(() => _self.$rootScope.$apply(() => {
-                _self.deleteToken();
-                deferred.resolve(false);
-            }));
-        }
-
-        return deferred.promise;
+        });
     }
 
     private loadUser(userPath) {
@@ -113,60 +43,12 @@ export class Service {
         return _self.adhHttp.get(userPath)
             .then((resource) => {
                 _self.data = resource.data[SIUserBasic.nick];
-                _self.loggedIn = true;
-                _self.adhCache.invalidateAll();
             }, (reason) => {
                 // The user resource that was returned by the server could not be accessed.
                 // This may happen e.g. with a network disconnect
-                _self.deleteToken();
+                _self.adhCredentials.deleteToken();
                 throw "failed to fetch user resource";
             });
-    }
-
-    private enableToken(token : string, userPath : string) : angular.IPromise<void> {
-        var _self : Service = this;
-
-        _self.token = token;
-        _self.userPath = userPath;
-        _self.$http.defaults.headers.common["X-User-Token"] = token;
-        _self.$http.defaults.headers.common["X-User-Path"] = userPath;
-        _self.adhTracking.setLoginState(true);
-        _self.adhTracking.setUserId(userPath);
-
-        return _self.loadUser(userPath);
-    }
-
-    private storeAndEnableToken(token : string, userPath : string) : angular.IPromise<void> {
-        var _self : Service = this;
-
-        if (_self.Modernizr.localstorage) {
-            _self.$window.localStorage.setItem("user-session", JSON.stringify({
-                "user-path": userPath,
-                "user-token": token
-            }));
-        } else {
-            console.log("session could not be persisted");
-        }
-
-        return _self.enableToken(token, userPath);
-    }
-
-    private deleteToken() : void {
-        var _self : Service = this;
-
-        if (_self.Modernizr.localstorage) {
-            _self.$window.localStorage.removeItem("user-session");
-        }
-        delete _self.$http.defaults.headers.common["X-User-Token"];
-        delete _self.$http.defaults.headers.common["X-User-Path"];
-        _self.token = undefined;
-        _self.userPath = undefined;
-        _self.data = undefined;
-        _self.loggedIn = false;
-        _self.adhTracking.setLoginState(false);
-        _self.adhTracking.setUserId(null);
-
-        _self.adhCache.invalidateAll();
     }
 
     public logIn(nameOrEmail : string, password : string) : angular.IPromise<void> {
@@ -186,7 +68,7 @@ export class Service {
         }
 
         var success = (response) => {
-            return _self.storeAndEnableToken(response.data.user_token, response.data.user_path);
+            return _self.adhCredentials.storeAndEnableToken(response.data.user_token, response.data.user_path);
         };
 
         return promise
@@ -194,10 +76,8 @@ export class Service {
     }
 
     public logOut() : void {
-        var _self : Service = this;
-
         // The server does not have a logout yet.
-        _self.deleteToken();
+        this.adhCredentials.deleteToken();
     }
 
     public register(username : string, email : string, password : string, passwordRepeat : string) : angular.IPromise<IRegisterResponse> {
@@ -224,7 +104,7 @@ export class Service {
         var _self : Service = this;
 
         var success = (response) => {
-            return _self.storeAndEnableToken(response.data.user_token, response.data.user_path);
+            return _self.adhCredentials.storeAndEnableToken(response.data.user_token, response.data.user_path);
         };
 
         return _self.adhHttp.postRaw("/activate_account", {path: path})
@@ -235,7 +115,7 @@ export class Service {
         var _self : Service = this;
 
         var success = (response) => {
-            return _self.storeAndEnableToken(response.data.user_token, response.data.user_path);
+            return _self.adhCredentials.storeAndEnableToken(response.data.user_token, response.data.user_path);
         };
 
         return _self.adhHttp.postRaw("/password_reset", {
@@ -249,12 +129,12 @@ export class Service {
 export var moduleName = "adhUser";
 
 export var register = (angular) => {
+    AdhCredentials.register(angular);
+
     angular
         .module(moduleName, [
-            AdhHttp.moduleName,
-            AdhLocale.moduleName,
+            AdhCredentials.moduleName,
+            AdhHttp.moduleName
         ])
-        .service("adhUser", [
-            "adhConfig", "adhHttp", "adhCache", "adhTracking",
-            "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", Service]);
+        .service("adhUser", ["adhHttp", "adhCredentials", "$rootScope", Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -136,7 +136,7 @@ export class Service {
         return _self.loadUser(userPath);
     }
 
-    public storeAndEnableToken(token : string, userPath : string) : angular.IPromise<void> {
+    private storeAndEnableToken(token : string, userPath : string) : angular.IPromise<void> {
         var _self : Service = this;
 
         if (_self.Modernizr.localstorage) {
@@ -229,6 +229,19 @@ export class Service {
 
         return _self.adhHttp.postRaw("/activate_account", {path: path})
             .then(success, AdhHttp.logBackendError);
+    }
+
+    public passwordReset(path : string, password : string) : angular.IPromise<any> {
+        var _self : Service = this;
+
+        var success = (response) => {
+            return _self.storeAndEnableToken(response.data.user_token, response.data.user_path);
+        };
+
+        return _self.adhHttp.postRaw("/password_reset", {
+            path: path,
+            password: password
+        }).then(success, AdhHttp.logBackendError);
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -292,8 +292,13 @@ export var indicatorDirective = (adhConfig : AdhConfig.IService, adhResourceArea
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Indicator.html",
         scope: {},
-        controller: ["adhUser", "$scope", (adhUser : AdhUser.Service, $scope) => {
+        controller: ["adhUser", "adhCredentials", "$scope", (
+            adhUser : AdhUser.Service,
+            adhCredentials : AdhCredentials.Service,
+            $scope
+        ) => {
             $scope.user = adhUser;
+            $scope.credentials = adhCredentials;
             $scope.noLink = !adhResourceArea.has(RIUser.content_type);
 
             $scope.logOut = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -231,14 +231,11 @@ export var passwordResetDirective = (
             scope.errors = [];
 
             scope.passwordReset = () => {
-                return adhHttp.postRaw(adhConfig.rest_url + "/password_reset", {
-                    path: adhTopLevelState.get("path"),
-                    password: scope.input.password
-                }).then((response) => {
-                    adhUser.storeAndEnableToken(response.data.user_token, response.data.user_path);
-                    scope.success = true;
-                }, AdhHttp.logBackendError)
-                .catch((errors) => bindServerErrors(scope, errors));
+                return adhUser.passwordReset(adhTopLevelState.get("path"), scope.input.password)
+                    .then(() => {
+                        scope.success = true;
+                    },
+                    (errors) => bindServerErrors(scope, errors));
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -6,6 +6,7 @@ import AdhPermissions = require("../Permissions/Permissions");
 import AdhResourceArea = require("../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
 
+import AdhCredentials = require("./Credentials");
 import AdhUser = require("./User");
 
 import RIUser = require("../../Resources_/adhocracy_core/resources/principal/IUser");
@@ -150,6 +151,7 @@ export var loginDirective = (
 
 export var registerDirective = (
     adhConfig : AdhConfig.IService,
+    adhCredentials : AdhCredentials.Service,
     adhUser : AdhUser.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhShowError
@@ -167,7 +169,7 @@ export var registerDirective = (
                 adhUser.logOut();
             };
 
-            scope.$watch(() => adhUser.loggedIn, (value) => {
+            scope.$watch(() => adhCredentials.loggedIn, (value) => {
                 scope.loggedIn = value;
             });
 
@@ -243,6 +245,7 @@ export var passwordResetDirective = (
 
 export var createPasswordResetDirective = (
     adhConfig : AdhConfig.IService,
+    adhCredentials : AdhCredentials.Service,
     adhHttp : AdhHttp.Service<any>,
     adhUser : AdhUser.Service,
     adhTopLevelState : AdhTopLevelState.Service,
@@ -257,7 +260,7 @@ export var createPasswordResetDirective = (
             scope.showError = adhShowError;
             scope.siteName = adhConfig.site_name;
 
-            scope.$watch(() => adhUser.loggedIn, (value) => {
+            scope.$watch(() => adhCredentials.loggedIn, (value) => {
                 scope.loggedIn = value;
             });
 
@@ -375,6 +378,7 @@ export var userListItemDirective = (adhConfig : AdhConfig.IService) => {
 
 export var userProfileDirective = (
     adhConfig : AdhConfig.IService,
+    adhCredentials : AdhCredentials.Service,
     adhHttp : AdhHttp.Service<any>,
     adhPermissions : AdhPermissions.Service,
     adhTopLevelState : AdhTopLevelState.Service,
@@ -394,7 +398,7 @@ export var userProfileDirective = (
             scope.showMessaging = () => {
                 if (scope.messageOptions.POST) {
                     column.showOverlay("messaging");
-                } else if (!adhUser.loggedIn) {
+                } else if (!adhCredentials.loggedIn) {
                     adhTopLevelState.redirectToLogin();
                 } else {
                     // FIXME
@@ -484,6 +488,7 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhAngularHelpers.moduleName,
+            AdhCredentials.moduleName,
             AdhMovingColumns.moduleName,
             AdhPermissions.moduleName,
             AdhTopLevelState.moduleName,
@@ -542,12 +547,13 @@ export var register = (angular) => {
         }])
         .directive("adhListUsers", ["adhUser", "adhConfig", userListDirective])
         .directive("adhUserListItem", ["adhConfig", userListItemDirective])
-        .directive("adhUserProfile", ["adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", "adhUser", userProfileDirective])
+        .directive("adhUserProfile", [
+            "adhConfig", "adhCredentials", "adhHttp", "adhPermissions", "adhTopLevelState", "adhUser", userProfileDirective])
         .directive("adhLogin", ["adhConfig", "adhUser", "adhTopLevelState", "adhShowError", loginDirective])
         .directive("adhPasswordReset", ["adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", passwordResetDirective])
         .directive("adhCreatePasswordReset", [
-            "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", createPasswordResetDirective])
-        .directive("adhRegister", ["adhConfig", "adhUser", "adhTopLevelState", "adhShowError", registerDirective])
+            "adhConfig", "adhCredentials", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", createPasswordResetDirective])
+        .directive("adhRegister", ["adhConfig", "adhCredentials", "adhUser", "adhTopLevelState", "adhShowError", registerDirective])
         .directive("adhUserIndicator", ["adhConfig", "adhResourceArea", indicatorDirective])
         .directive("adhUserMeta", ["adhConfig", "adhResourceArea", metaDirective])
         .directive("adhUserMessage", ["adhConfig", "adhHttp", userMessageDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
@@ -195,8 +195,8 @@ export var register = () => {
                 beforeEach(() => {
                     scopeMock = {};
                     adhUserMock = jasmine.createSpyObj("adhUserMock", ["logOut"]);
-                    controller = <any>(directive.controller[2]);
-                    controller(adhUserMock, scopeMock);
+                    controller = <any>(directive.controller[3]);
+                    controller(adhUserMock, null, scopeMock);
                 });
 
                 describe("logOut", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
@@ -105,7 +105,7 @@ export var register = () => {
                 adhUserMock.logIn.and.returnValue(q.when(undefined));
                 adhTopLevelStateMock = jasmine.createSpyObj("adhTopLevelStateMock", ["redirectToCameFrom"]);
 
-                directive = AdhUserViews.registerDirective(adhConfigMock, adhUserMock, adhTopLevelStateMock, "adhShowError");
+                directive = AdhUserViews.registerDirective(adhConfigMock, null, adhUserMock, adhTopLevelStateMock, "adhShowError");
             });
 
             describe("link", () => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -3,7 +3,6 @@ import AdhEmbed = require("../../../Embed/Embed");
 import AdhHttp = require("../../../Http/Http");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
-import AdhUser = require("../../../User/User");
 
 import AdhMeinBerlinWorkbench = require("../Workbench/Workbench");
 
@@ -38,8 +37,7 @@ export var register = (angular) => {
             AdhHttp.moduleName,
             AdhMeinBerlinWorkbench.moduleName,
             AdhResourceArea.moduleName,
-            AdhTopLevelState.moduleName,
-            AdhUser.moduleName
+            AdhTopLevelState.moduleName
         ])
         .directive("adhKiezkassenContextHeader", ["adhConfig", "adhTopLevelState", headerDirective])
         .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
@@ -62,18 +60,13 @@ export var register = (angular) => {
                     movingColumns: "is-show-show-hide"
                 })
                 .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    "adhHttp", "adhUser", (
-                        adhHttp : AdhHttp.Service<any>,
-                        adhUser : AdhUser.Service
-                    ) => (resource : RIKiezkassenProcess) => {
-                        return adhUser.ready.then(() => {
-                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                                if (!options.POST) {
-                                    throw 401;
-                                } else {
-                                    return {};
-                                }
-                            });
+                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
+                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                            if (!options.POST) {
+                                throw 401;
+                            } else {
+                                return {};
+                            }
                         });
                     }])
                 .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
@@ -81,20 +74,15 @@ export var register = (angular) => {
                     movingColumns: "is-show-show-hide"
                 })
                 .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    "adhHttp", "adhUser", (
-                        adhHttp : AdhHttp.Service<any>,
-                        adhUser : AdhUser.Service
-                    ) => (item : RIProposal, version : RIProposalVersion) => {
-                        return adhUser.ready.then(() => {
-                            return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
-                                if (!options.POST) {
-                                    throw 401;
-                                } else {
-                                    return {
-                                        proposalUrl: version.path
-                                    };
-                                }
-                            });
+                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
+                        return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
+                            if (!options.POST) {
+                                throw 401;
+                            } else {
+                                return {
+                                    proposalUrl: version.path
+                                };
+                            }
                         });
                     }])
                 .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -6,7 +6,6 @@ import AdhHttp = require("../../../Http/Http");
 import AdhMovingColumns = require("../../../MovingColumns/MovingColumns");
 import AdhProcess = require("../../../Process/Process");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
-import AdhUser = require("../../../User/User");
 import AdhUtil = require("../../../Util/Util");
 import AdhPermissions = require("../../../Permissions/Permissions");
 
@@ -157,8 +156,7 @@ export var register = (angular) => {
             AdhMeinBerlinKiezkassenProposal.moduleName,
             AdhMovingColumns.moduleName,
             AdhProcess.moduleName,
-            AdhResourceArea.moduleName,
-            AdhUser.moduleName
+            AdhResourceArea.moduleName
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
@@ -171,18 +169,13 @@ export var register = (angular) => {
                     movingColumns: "is-show-hide-hide"
                 })
                 .specific(RIKiezkassenProcess, "edit_process", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", "adhUser", (
-                        adhHttp : AdhHttp.Service<any>,
-                        adhUser : AdhUser.Service
-                    ) => (resource : RIKiezkassenProcess) => {
-                        return adhUser.ready.then(() => {
-                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                                if (!options.PUT) {
-                                    throw 401;
-                                } else {
-                                    return {};
-                                }
-                            });
+                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
+                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                            if (!options.PUT) {
+                                throw 401;
+                            } else {
+                                return {};
+                            }
                         });
                     }])
                 .default(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", {
@@ -190,18 +183,13 @@ export var register = (angular) => {
                     movingColumns: "is-show-show-hide"
                 })
                 .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", "adhUser", (
-                        adhHttp : AdhHttp.Service<any>,
-                        adhUser : AdhUser.Service
-                    ) => (resource : RIKiezkassenProcess) => {
-                        return adhUser.ready.then(() => {
-                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                                if (!options.POST) {
-                                    throw 401;
-                                } else {
-                                    return {};
-                                }
-                            });
+                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
+                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                            if (!options.POST) {
+                                throw 401;
+                            } else {
+                                return {};
+                            }
                         });
                     }])
                 .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", {
@@ -209,20 +197,15 @@ export var register = (angular) => {
                     movingColumns: "is-show-show-hide"
                 })
                 .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", "adhUser", (
-                        adhHttp : AdhHttp.Service<any>,
-                        adhUser : AdhUser.Service
-                    ) => (item : RIProposal, version : RIProposalVersion) => {
-                        return adhUser.ready.then(() => {
-                            return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
-                                if (!options.POST) {
-                                    throw 401;
-                                } else {
-                                    return {
-                                        proposalUrl: version.path
-                                    };
-                                }
-                            });
+                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
+                        return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
+                            if (!options.POST) {
+                                throw 401;
+                            } else {
+                                return {
+                                    proposalUrl: version.path
+                                };
+                            }
                         });
                     }])
                 .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "", {

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -224,17 +224,15 @@ export var register = (angular) => {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIPoolWithAssets, "create_proposal", "", "", ["adhHttp", "adhUser",
-                    (adhHttp : AdhHttp.Service<any>, adhUser) => {
+                .specific(RIPoolWithAssets, "create_proposal", "", "", ["adhHttp",
+                    (adhHttp : AdhHttp.Service<any>) => {
                         return (resource : RIPoolWithAssets) => {
-                            return adhUser.ready.then(() => {
-                                return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                                    if (!options.POST) {
-                                        throw 401;
-                                    } else {
-                                        return {};
-                                    }
-                                });
+                            return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                                if (!options.POST) {
+                                    throw 401;
+                                } else {
+                                    return {};
+                                }
                             });
                         };
                     }]


### PR DESCRIPTION
this makes sure that http requests are stalled until the credentials have been loaded from localStorage.

You may see some OPTIONS requests without the token headers. We think that these are preflight requests issued by the browser.