### PR TITLE
deny setCameFrom on paths that are likely to be redirected to

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -423,7 +423,8 @@ export class Service {
             "/activate"
         ];
 
-        if (!_.includes(denylist, path)) {
+        // FIXME: DefinitelyTyped
+        if (!(<any>_).includes(denylist, path)) {
             this.cameFrom = path;
             return true;
         } else {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -422,8 +422,21 @@ export class Service {
 
     private cameFrom : string;
 
-    public setCameFrom(path : string) : void {
-        this.cameFrom = path;
+    public setCameFrom(path : string) : boolean {
+        var denylist = [
+            "/login",
+            "/register",
+            "/password_reset",
+            "/create_password_reset",
+            "/activate"
+        ];
+
+        if (!_.includes(denylist, path)) {
+            this.cameFrom = path;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public getCameFrom() : string {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -410,15 +410,7 @@ export class Service {
         }, space);
     }
 
-    // FIXME: {set,get}CameFrom should be worked into the class
-    // doc-comment, but I don't feel I understand that comment well
-    // enough to edit it.  (also, the entire toplevelstate thingy will
-    // be refactored soon in order to get state mgmt with link support
-    // right.  see /docs/source/api/frontend-state.rst)
-    //
-    // Open problem: if the user navigates away from the, say, login,
-    // and the cameFrom stack will never be cleaned up...  how do we
-    // clean it up?
+    // FIXME: There currently is no real concept for cameFrom
 
     private cameFrom : string;
 


### PR DESCRIPTION
this fixes the following issue:

-   go to the login page
-   click on register in the user indicator
-   click on cancel

expected result: go back to the initial page

actual result: go back to login