### PR TITLE
BPlan UI

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_standalone_wrapper.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_standalone_wrapper.scss
@@ -36,14 +36,14 @@ branding.
     padding: (40px / $font-size-normal * 1em) (90px / $font-size-normal * 1em);
     position: relative;
 
-    .standalone-wrapper-title {
-        color: $color-text-normal;
-        font-size: $font-size-large;
-        font-weight: $font-weight-extrovert;
-        margin-bottom: 50px / $font-size-large * 1em;
-    }
-
     form {
         padding: 0;
     }
+}
+
+.standalone-wrapper-title {
+    color: $color-text-normal;
+    font-size: $font-size-plus;
+    font-weight: $font-weight-extrovert;
+    margin-bottom: 50px / $font-size-plus * 1em;
 }

--- a/src/meinberlin/meinberlin/static/i18n/meinberlin_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/meinberlin_de.json
@@ -27,7 +27,6 @@
     "TR__MEINBERLIN_ERROR_REQUIRED_TITLE": "Bitte einen Titel angeben",
     "TR__MEINBERLIN_I_WANT_TO_BE_PART": "Ich möchte selber an diesem Projekt mitwirken.",
     "TR__MEINBERLIN_LOCATION_TEXT": "Bitte geben Sie einen Ort für Ihr Projekt an, z.B. Grundschule XY",
-    "TR__MEINBERLIN_MEIN_BERLIN_BPLAENE_SIMPLE_PROPOSAL": "Stellungsnahmeformular",
     "TR__MEINBERLIN_NAME": "Ihr Name",
     "TR__MEINBERLIN_SEND": "Senden",
     "TR__MEINBERLIN_STATEMENT": "Stellungsnahme",

--- a/src/meinberlin/meinberlin/static/i18n/meinberlin_de_du.json
+++ b/src/meinberlin/meinberlin/static/i18n/meinberlin_de_du.json
@@ -27,7 +27,6 @@
     "TR__MEINBERLIN_ERROR_REQUIRED_TITLE": "Bitte einen Titel angeben",
     "TR__MEINBERLIN_I_WANT_TO_BE_PART": "Ich möchte selber an diesem Projekt mitwirken.",
     "TR__MEINBERLIN_LOCATION_TEXT": "Bitte gib einen Ort für Dein Projekt an, z.B. Grundschule XY",
-    "TR__MEINBERLIN_MEIN_BERLIN_BPLAENE_SIMPLE_PROPOSAL": "Stellungsnahmeformular",
     "TR__MEINBERLIN_NAME": "Dein Name",
     "TR__MEINBERLIN_SEND": "Senden",
     "TR__MEINBERLIN_STATEMENT": "Stellungsnahme",

--- a/src/meinberlin/meinberlin/static/i18n/meinberlin_en.json
+++ b/src/meinberlin/meinberlin/static/i18n/meinberlin_en.json
@@ -27,7 +27,6 @@
     "TR__MEINBERLIN_ERROR_REQUIRED_TITLE": "Please enter a proposal title",
     "TR__MEINBERLIN_I_WANT_TO_BE_PART": "I want to be a part",
     "TR__MEINBERLIN_LOCATION_TEXT": "Address",
-    "TR__MEINBERLIN_MEIN_BERLIN_BPLAENE_SIMPLE_PROPOSAL": "Statement",
     "TR__MEINBERLIN_NAME": "Your name",
     "TR__MEINBERLIN_SEND": "Send",
     "TR__MEINBERLIN_STATEMENT": "Statement",

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Create.html
@@ -4,88 +4,90 @@
     class="mein-berlin-bplaene-proposal-form"
     name="meinBerlinProposalForm">
 
-    <div class="form-error" data-ng-repeat="error in errors track by $index">
-        <p>{{ error | adhFormatError | translate }}</p>
+    <div class="mein-berlin-bplaene-proposal-form-inner">
+        <div class="form-error" data-ng-repeat="error in errors track by $index">
+            <p>{{ error | adhFormatError | translate }}</p>
+        </div>
+
+        <!-- Name -->
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_NAME" | translate }}</span>
+            <input
+                type="text"
+                data-ng-model="data.name"
+                name="name"
+                minlength="3"
+                maxlength="100"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.name, 'required')">
+                {{ "TR__MEINBERLIN_ERROR_REQUIRED_NAME" | translate }}
+            </span>
+        </label>
+
+        <!-- Street and house number -->
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_STREET" | translate }}</span>
+            <input
+                type="text"
+                data-ng-model="data.street"
+                name="street"
+                minlength="3"
+                maxlength="100"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.street, 'required')">
+                {{ "TR__MEINBERLIN_ERROR_REQUIRED_STREET" | translate }}
+            </span>
+        </label>
+
+        <!-- city code and city -->
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_CITY" | translate }}</span>
+            <input
+                type="text"
+                data-ng-model="data.city"
+                name="city"
+                minlength="3"
+                maxlength="100"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.city, 'required')">
+                {{ "TR__MEINBERLIN_ERROR_REQUIRED_CITY" | translate }}
+            </span>
+        </label>
+
+        <!-- email -->
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_EMAIL" | translate }}</span>
+            <input
+                type="email"
+                data-ng-model="data.email"
+                name="email"
+                minlength="3"
+                maxlength="100"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.email, 'required')">
+                {{ "TR__MEINBERLIN_ERROR_REQUIRED_EMAIL" | translate }}
+            </span>
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.email, 'email')">
+                {{ "TR__ERROR_MUST_BE_A_VALID_EMAIL_STRING" | translate }}
+            </span>
+        </label>
+
+        <!--  statement -->
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_STATEMENT" | translate }}</span>
+
+            <textarea
+                data-msd-elastic=""
+                data-ng-model="data.statement"
+                name="statement"
+                maxlength="500"
+                required="required"></textarea>
+
+            <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.statement, 'required')">
+                {{ "TR__MEINBERLIN_ERROR_REQUIRED_STATEMENT" | translate }}
+            </span>
+        </label>
     </div>
-
-    <!-- Name -->
-    <label>
-        <span class="label-text">{{ "TR__MEINBERLIN_NAME" | translate }}</span>
-        <input
-            type="text"
-            data-ng-model="data.name"
-            name="name"
-            minlength="3"
-            maxlength="100"
-            required="required" />
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.name, 'required')">
-            {{ "TR__MEINBERLIN_ERROR_REQUIRED_NAME" | translate }}
-        </span>
-    </label>
-
-    <!-- Street and house number -->
-    <label>
-        <span class="label-text">{{ "TR__MEINBERLIN_STREET" | translate }}</span>
-        <input
-            type="text"
-            data-ng-model="data.street"
-            name="street"
-            minlength="3"
-            maxlength="100"
-            required="required" />
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.street, 'required')">
-            {{ "TR__MEINBERLIN_ERROR_REQUIRED_STREET" | translate }}
-        </span>
-    </label>
-
-    <!-- city code and city -->
-    <label>
-        <span class="label-text">{{ "TR__MEINBERLIN_CITY" | translate }}</span>
-        <input
-            type="text"
-            data-ng-model="data.city"
-            name="city"
-            minlength="3"
-            maxlength="100"
-            required="required" />
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.city, 'required')">
-            {{ "TR__MEINBERLIN_ERROR_REQUIRED_CITY" | translate }}
-        </span>
-    </label>
-
-    <!-- email -->
-    <label>
-        <span class="label-text">{{ "TR__MEINBERLIN_EMAIL" | translate }}</span>
-        <input
-            type="email"
-            data-ng-model="data.email"
-            name="email"
-            minlength="3"
-            maxlength="100"
-            required="required" />
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.email, 'required')">
-            {{ "TR__MEINBERLIN_ERROR_REQUIRED_EMAIL" | translate }}
-        </span>
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.email, 'email')">
-            {{ "TR__ERROR_MUST_BE_A_VALID_EMAIL_STRING" | translate }}
-        </span>
-    </label>
-
-    <!--  statement -->
-    <label>
-        <span class="label-text">{{ "TR__MEINBERLIN_STATEMENT" | translate }}</span>
-
-        <textarea
-            data-msd-elastic=""
-            data-ng-model="data.statement"
-            name="statement"
-            maxlength="500"
-            required="required"></textarea>
-
-        <span class="input-error" data-ng-show="showError(meinBerlinProposalForm, meinBerlinProposalForm.statement, 'required')">
-            {{ "TR__MEINBERLIN_ERROR_REQUIRED_STATEMENT" | translate }}
-        </span>
-    </label>
 
     <!-- DATA SUBMIT -->
     <footer class="form-footer mein-berlin-kiezkassen-proposal-form-footer">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Create.html
@@ -4,8 +4,6 @@
     class="mein-berlin-bplaene-proposal-form"
     name="meinBerlinProposalForm">
 
-    <h2 class="mein-berlin-kiezkassen-proposal-form-heading">{{ "TR__MEINBERLIN_MEIN_BERLIN_BPLAENE_SIMPLE_PROPOSAL" | translate }}</h2>
-
     <div class="form-error" data-ng-repeat="error in errors track by $index">
         <p>{{ error | adhFormatError | translate }}</p>
     </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
@@ -1,8 +1,8 @@
 <div class="mein-berlin-bplaene-proposal-embed">
     <adh-mein-berlin-bplaene-proposal-create data-ng-if="!success" data-path="{{path}}" data-on-success="showSuccess"></adh-mein-berlin-bplaene-proposal-create>
-    <div class="mein-berlin-bpleane-proposal-success" data-ng-if="success">
-        <h1>{{ "TR__MEINBERLIN_STATEMENT_THANKS" | translate }}</h1>
+    <div class="mein-berlin-bplaene-proposal-success" data-ng-if="success">
+        <h1 class="mein-berlin-bplaene-proposal-success-title">{{ "TR__MEINBERLIN_STATEMENT_THANKS" | translate }}</h1>
         <p>{{ "TR__MEINBERLIN_STATEMENT_PRIVACY" | translate }}</p>
-        <a href="" data-ng-click="showForm()">{{ "TR__MEINBERLIN_STATEMENT_SHOW_FORM" | translate }}</a>
+        <a href="" class="mein-berlin-bplaene-proposal-success-show-form" data-ng-click="showForm()">{{ "TR__MEINBERLIN_STATEMENT_SHOW_FORM" | translate }}</a>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
@@ -1,4 +1,4 @@
-<div class="mein-berlin-bplaene-proposal-widget">
+<div class="mein-berlin-bplaene-proposal-embed">
     <adh-mein-berlin-bplaene-proposal-create data-ng-if="!success" data-path="{{path}}" data-on-success="showSuccess"></adh-mein-berlin-bplaene-proposal-create>
     <div class="mein-berlin-bpleane-proposal-success" data-ng-if="success">
         <h1>{{ "TR__MEINBERLIN_STATEMENT_THANKS" | translate }}</h1>

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
@@ -60,6 +60,7 @@
 @import "components/error_pages_theme";
 @import "components/standalone_wrapper";
 @import "components/standalone_wrapper_theme";
+@import "components/bplan";
 
 @import "third_party/social_share";
 

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_bplan.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_bplan.scss
@@ -1,0 +1,22 @@
+// FIXME: This is very much like a moving column. Maybe we can share some code?
+
+.mein-berlin-bplaene-proposal-embed {
+    background: $color-background-base-introvert;
+    padding: 5px;
+}
+
+.mein-berlin-bplaene-proposal-form {
+    padding: 0;
+}
+
+.mein-berlin-bplaene-proposal-form-inner {
+    background: $color-background-base;
+    padding: 15px;
+}
+
+// HACK
+// scss-lint:disable QualifyingElement
+.mein-berlin-kiezkassen-proposal-form-footer input[type="submit"].m-call-to-action {
+    @include border-radius(0);
+}
+// scss-lint:enable QualifyingElement

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_bplan.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_bplan.scss
@@ -20,3 +20,16 @@
     @include border-radius(0);
 }
 // scss-lint:enable QualifyingElement
+
+.mein-berlin-bplaene-proposal-success {
+    @extend .standalone-wrapper;
+}
+
+.mein-berlin-bplaene-proposal-success-title {
+    @extend .standalone-wrapper-title;
+}
+
+.mein-berlin-bplaene-proposal-success-show-form {
+    @extend .button;
+    margin: 2em 0;
+}


### PR DESCRIPTION
This implements the UI for the embedded BPlan proposal. Some notes:

-   I am not too convinced of my SCSS code. I propose to merge this now, but @local-girl should still take a look when she is back.
-   I guess we should use the `nocenter` embed parameter with this
-   The button does not yet look like a button. This is because the buttons do not look like in the design in general. This will be taken care of separately.
-   AFAIK there is currently no way to get to the success screen because the request always fails. So you will have to hack around that when doing review.