### PR TITLE
show description on bplan widget in announce/frozen phase

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Embed.html
@@ -1,8 +1,16 @@
-<div class="mein-berlin-bplaene-proposal-embed">
-    <adh-mein-berlin-bplaene-proposal-create data-ng-if="!success" data-path="{{path}}" data-on-success="showSuccess"></adh-mein-berlin-bplaene-proposal-create>
-    <div class="mein-berlin-bplaene-proposal-success" data-ng-if="success">
-        <h1 class="mein-berlin-bplaene-proposal-success-title">{{ "TR__MEINBERLIN_STATEMENT_THANKS" | translate }}</h1>
-        <p>{{ "TR__MEINBERLIN_STATEMENT_PRIVACY" | translate }}</p>
-        <a href="" class="mein-berlin-bplaene-proposal-success-show-form" data-ng-click="showForm()">{{ "TR__MEINBERLIN_STATEMENT_SHOW_FORM" | translate }}</a>
+<div class="mein-berlin-bplaene-proposal-embed" data-ng-switch="currentPhase">
+    <div data-ng-switch-when="announce">
+        {{ announceText }}
+    </div>
+    <div data-ng-switch-when="participate">
+        <adh-mein-berlin-bplaene-proposal-create data-ng-if="!success" data-path="{{path}}" data-on-success="showSuccess"></adh-mein-berlin-bplaene-proposal-create>
+        <div class="mein-berlin-bplaene-proposal-success" data-ng-if="success">
+            <h1 class="mein-berlin-bplaene-proposal-success-title">{{ "TR__MEINBERLIN_STATEMENT_THANKS" | translate }}</h1>
+            <p>{{ "TR__MEINBERLIN_STATEMENT_PRIVACY" | translate }}</p>
+            <a href="" class="mein-berlin-bplaene-proposal-success-show-form" data-ng-click="showForm()">{{ "TR__MEINBERLIN_STATEMENT_SHOW_FORM" | translate }}</a>
+        </div>
+    </div>
+    <div data-ng-switch-when="frozen">
+        {{ frozenText }}
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Bplaene/Proposal/Proposal.ts
@@ -11,6 +11,7 @@ import RIProposal = require("../../../../Resources_/adhocracy_meinberlin/resourc
 import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/bplan/IProposalVersion");
 import SIProposal = require("../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IProposal");
 import SIVersionable = require("../../../../Resources_/adhocracy_core/sheets/versions/IVersionable");
+import SIWorkflow = require("../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IWorkflowAssignment");
 
 var pkgLocation = "/MeinBerlin/Bplaene/Proposal";
 
@@ -101,7 +102,8 @@ export var createDirective = (
 
 
 export var embedDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>
 ) => {
     return {
         restrict: "E",
@@ -118,6 +120,12 @@ export var embedDirective = (
             scope.showForm = () => {
                 scope.success = false;
             };
+
+            adhHttp.get(scope.path).then((resource) => {
+                scope.currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                scope.announceText = resource.data[SIWorkflow.nick].announce.description;
+                scope.frozenText = resource.data[SIWorkflow.nick].frozen.description;
+            });
         }
     };
 };
@@ -139,5 +147,5 @@ export var register = (angular) => {
         }])
         .directive("adhMeinBerlinBplaeneProposalCreate", [
             "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", createDirective])
-        .directive("adhMeinBerlinBplaeneProposalEmbed", ["adhConfig", embedDirective]);
+        .directive("adhMeinBerlinBplaeneProposalEmbed", ["adhConfig", "adhHttp", embedDirective]);
 };


### PR DESCRIPTION
You can use the following script to change phases. First argument is the phase you want to go to (announce, participate, frozen) and second argument is god's user token.

curl 'http://localhost:6541/organisation/bplan/' -X PUT -H 'Content-Type: application/json;charset=UTF-8' -H 'X-User-Path: http://localhost:6541/principals/users/0000000/' -H 'Accept: application/json, text/plain, */*' -H 'X-User-Token: '$2 --data-binary '{"data" : {"adhocracy_meinberlin.sheets.bplan.IWorkflowAssignment" : {"workflow_state" : "'$1'"}},"content_type" : "adhocracy_meinberlin.resources.bplan.IProcess","root_versions" : []}'