### PR TITLE
add templates for spd document create/detail

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -22,9 +22,6 @@ import moment = require("moment");
 import leaflet = require("leaflet");
 import webshim = require("polyfiller");
 
-// FIXME: just added here for testing
-import markdownit = require("markdownit");
-
 import AdhAbuse = require("./Packages/Abuse/Abuse");
 import AdhConfig = require("./Packages/Config/Config");
 import AdhComment = require("./Packages/Comment/Comment");
@@ -56,9 +53,6 @@ import AdhUser = require("./Packages/User/User");
 import AdhUserViews = require("./Packages/User/Views");
 import AdhWebSocket = require("./Packages/WebSocket/WebSocket");
 import AdhMapping = require("./Packages/Mapping/Mapping");
-
-// FIXME: Just added here for testing
-import AdhMarkdown = require("./Packages/Markdown/Markdown");
 
 import AdhTemplates = require("adhTemplates");  if (AdhTemplates) { ; };
 
@@ -94,8 +88,6 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhDone.moduleName,
         AdhMapping.moduleName,
 
-        // FIXME: Just added here for testing
-        AdhMarkdown.moduleName,
         AdhCrossWindowMessaging.moduleName,
         AdhEmbed.moduleName,
         AdhMeinBerlin.moduleName,
@@ -167,8 +159,6 @@ export var init = (config : AdhConfig.IService, meta_api) => {
 
     app.value("angular", angular);
 
-    // FIXME: Just added here for testing
-    app.value("markdownit", markdownit);
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
     app.value("leaflet", leaflet);
@@ -189,9 +179,6 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhLocalSocket.register(angular);
     AdhMeinBerlin.register(angular);
     AdhMapping.register(angular);
-
-    // FIXME: Just added here for testing
-    AdhMarkdown.register(angular);
     AdhMovingColumns.register(angular);
     AdhPermissions.register(angular);
     AdhPreliminaryNames.register(angular);

--- a/src/spd/spd/static/i18n/spd_de.json
+++ b/src/spd/spd/static/i18n/spd_de.json
@@ -1,1 +1,5 @@
-{}
+{
+
+	"TR__SPD_TITLE" : "Titel",
+	"TR__SPD_PARAGRAPH" : "Paragraph"
+}

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -21,6 +21,8 @@ import modernizr = require("modernizr");
 import moment = require("moment");
 import webshim = require("polyfiller");
 
+import markdownit = require("markdownit");
+
 import AdhAbuse = require("./Packages/Abuse/Abuse");
 import AdhConfig = require("./Packages/Config/Config");
 import AdhComment = require("./Packages/Comment/Comment");
@@ -53,6 +55,7 @@ import AdhUser = require("./Packages/User/User");
 import AdhUserViews = require("./Packages/User/Views");
 import AdhWebSocket = require("./Packages/WebSocket/WebSocket");
 import AdhTemplates = require("adhTemplates");  if (AdhTemplates) { ; };
+import AdhMarkdown = require("./Packages/Markdown/Markdown");
 
 webshim.setOptions("basePath", "/static/lib/webshim/js-webshim/minified/shims/");
 webshim.setOptions("forms-ext", {"replaceUI": true});
@@ -94,7 +97,8 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhProposal.moduleName,
         AdhSticky.moduleName,
         AdhTracking.moduleName,
-        AdhUserViews.moduleName
+        AdhUserViews.moduleName,
+        AdhMarkdown.moduleName
     ];
 
     if (config.cachebust) {
@@ -154,12 +158,14 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         });
     }]);
 
+    app.value("markdownit", markdownit);
     app.value("angular", angular);
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
 
     // register our modules
     app.value("adhConfig", config);
+    AdhMarkdown.register(angular);
     AdhAbuse.register(angular);
     AdhComment.register(angular);
     AdhCrossWindowMessaging.register(angular, config.trusted_domains === []);

--- a/src/spd/spd/static/js/Packages/spdDocument/Create.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Create.html
@@ -1,1 +1,56 @@
-<div>Create</div>
+<form
+    novalidate="novalidate"
+    data-ng-submit="submit()"
+    class="spd-document-form"
+    name="spdDocumentForm">
+
+    <div class="">
+    	<div class="form-error" data-ng-repeat="error in errors track by $index">
+            <p>{{ error | adhFormatError | translate }}</p>
+        </div>
+
+        <!-- Title -->
+        <label>
+            <span class="label-text">{{ "TR__SPD_TITLE" | translate }}</span>
+            <input
+                type="text"
+                data-ng-model="data.title"
+                name="title"
+                minlength="3"
+                maxlength="100"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(spdDocumentForm, spdDocumentForm.title, 'required')">
+                {{ "TR__SPD_ERROR_REQUIRED_TITLE" | translate }}
+            </span>
+        </label>
+
+        <!-- 1. Parapraph -->
+        <label>
+            <span class="label-text">{{ "TR__SPD_PARAGRAPH" | translate }}</span>
+
+            <textarea
+                data-msd-elastic=""
+                data-ng-model="data.detail"
+                name="detail"
+                maxlength="500"
+                required="required"></textarea>
+
+            <span class="input-error" data-ng-show="showError(spdDocumentForm, spdDocumentForm.detail, 'required')">
+                {{ "TR__SPD_ERROR_REQUIRED_PARAGRAPH" | translate }}
+            </span>
+        </label>
+
+    <!-- DATA SUBMIT -->
+    <footer class="form-footer">
+        <input
+            type="submit"
+            name="submit"
+            value="{{ 'TR__PUBLISH' | translate }}"
+            class="m-call-to-action form-footer-button-cta" />
+
+        <a data-ng-show="create" href="{{ processUrl | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
+        {{ "TR__CANCEL" | translate }}</a>
+        <a data-ng-show="!create" href="{{ path | adhParentPath | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
+        {{ "TR__CANCEL" | translate }}</a>
+    </footer>
+</form>

--- a/src/spd/spd/static/js/Packages/spdDocument/Create.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Create.html
@@ -48,6 +48,8 @@
             value="{{ 'TR__PUBLISH' | translate }}"
             class="m-call-to-action form-footer-button-cta" />
 
+        <a href="" class="button m-call-to-action-secondary" data-ng-click="addParagraph()">{{ "TR__ADD_PARAGRAPH" | translate }}</a>
+
         <a data-ng-show="create" href="{{ processUrl | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">
         {{ "TR__CANCEL" | translate }}</a>
         <a data-ng-show="!create" href="{{ path | adhParentPath | adhResourceUrl }}" data-ng-click="cancel()" class="button form-footer-button">

--- a/src/spd/spd/static/js/Packages/spdDocument/Create.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Create.html
@@ -4,8 +4,8 @@
     class="spd-document-form"
     name="spdDocumentForm">
 
-    <div class="">
-    	<div class="form-error" data-ng-repeat="error in errors track by $index">
+    <div>
+        <div class="form-error" data-ng-repeat="error in errors track by $index">
             <p>{{ error | adhFormatError | translate }}</p>
         </div>
 
@@ -39,6 +39,7 @@
                 {{ "TR__SPD_ERROR_REQUIRED_PARAGRAPH" | translate }}
             </span>
         </label>
+    </div>
 
     <!-- DATA SUBMIT -->
     <footer class="form-footer">

--- a/src/spd/spd/static/js/Packages/spdDocument/Create.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Create.html
@@ -24,18 +24,17 @@
             </span>
         </label>
 
-        <!-- 1. Parapraph -->
-        <label>
+        <label data-ng-repeat="paragraph in data.paragraphs">
             <span class="label-text">{{ "TR__SPD_PARAGRAPH" | translate }}</span>
 
             <textarea
                 data-msd-elastic=""
-                data-ng-model="data.detail"
-                name="detail"
+                data-ng-model="paragraph.body"
+                name="paragraph-{{ $index }}"
                 maxlength="500"
                 required="required"></textarea>
 
-            <span class="input-error" data-ng-show="showError(spdDocumentForm, spdDocumentForm.detail, 'required')">
+            <span class="input-error" data-ng-show="showError(spdDocumentForm, spdDocumentForm['paragraph-' + $index], 'required')">
                 {{ "TR__SPD_ERROR_REQUIRED_PARAGRAPH" | translate }}
             </span>
         </label>

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -1,5 +1,5 @@
 <h1>{{ data.title }}</h1>
 
 <div data-ng-repeat="paragraph in data.paragraphs">
-	<adh-parse-markdown parsetext="paragraph"></adh-parse-markdown>
+    <adh-parse-markdown data-parsetext="paragraph"></adh-parse-markdown>
 </div>

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -1,5 +1,36 @@
-<h1>{{ data.title }}</h1>
+<div class="mercator-proposal-detail-view proposal" id="mercator-detail-view-top">
+    <h2 class="print-only mercator-proposal-cover-header" data-aria-hidden="true">{{ data.title }}</h2>
 
-<div data-ng-repeat="paragraph in data.paragraphs">
-    <adh-parse-markdown data-parsetext="paragraph"></adh-parse-markdown>
-</div>
+    <div class="mercator-proposal-detail-cover">
+        <h1 class="mercator-proposal-cover-header screen-only">{{ data.title }}</h1>
+        <ul class="mercator-proposal-detail-meta">
+            <li class="mercator-propsal-detail-meta-item mercator-propsal-detail-meta-item-total-comments">
+                <i class="icon-speechbubbles"></i>
+                {{ data.commentCountTotal }} {{ "TR__COMMENTS_TOTAL" | translate }}
+            </li>
+        </ul>
+    </div><!-- /.cover -->
+
+    <div class="mercator-proposal-detail-container">
+
+        <nav class="mercator-proposal-detail-nav m-unnumbered" data-adh-sticky="">
+            <ol>
+                <li data-ng-repeat="paragraph in data.paragraphs">
+                    <a
+                        href="#mercator-proposal-chapter-{{ $index }}"
+                        data-du-smooth-scroll=""
+                        data-du-scrollspy="">{{ $index }}.</a>
+                </li>
+            </ol>
+        </nav>
+
+        <div class="mercator-proposal-chapters" data-du-spy-context="">
+            <section class="commentable-section" data-ng-repeat="paragraph in data.paragraphs" id="mercator-proposal-chapter-{{$index}}">
+                <adh-parse-markdown data-parsetext="paragraph"></adh-parse-markdown>
+                <a class="commentable-section-show-comments" href="">
+                    <i class="icon-speechbubble"></i> {{ paragraph.commentCount }}
+                </a>
+            </section>
+        </div><!-- /.mercator-detail-body -->
+    </div><!-- /.mercator-proposal-detail-container -->
+</div><!-- /.mercator-proposal-detail-view -->

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -1,1 +1,5 @@
-<div>Detail</div>
+<h1>{{ data.title }}</h1>
+
+<div data-ng-repeat="paragraph in data.paragraphs">
+	<adh-parse-markdown parsetext="paragraph"></adh-parse-markdown>
+</div>

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -26,7 +26,7 @@
 
         <div class="mercator-proposal-chapters" data-du-spy-context="">
             <section class="commentable-section" data-ng-repeat="paragraph in data.paragraphs" id="mercator-proposal-chapter-{{$index}}">
-                <adh-parse-markdown data-parsetext="paragraph"></adh-parse-markdown>
+                <adh-parse-markdown data-parsetext="paragraph.body"></adh-parse-markdown>
                 <a class="commentable-section-show-comments" href="">
                     <i class="icon-speechbubble"></i> {{ paragraph.commentCount }}
                 </a>

--- a/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
+++ b/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
@@ -14,9 +14,35 @@ import AdhRate = require("../Rate/Rate");
 import AdhSticky = require("../Sticky/Sticky");
 import AdhEmbed = require("../Embed/Embed");
 
-
-
 var pkgLocation = "/spdDocument";
+
+// FIXME: Can be removed when we work with real data
+export var dummydata = [
+    "## Hallo \n Lorem ipsum dolor sit amet, " +
+     "consectetur adipiscing elit. Phasellus quis " +
+     "lectus metus, at posuere neque. Sed pharetra " +
+     "nibh eget orci convallis at posuere leo convallis. " +
+     "Sed blandit augue vitae augue scelerisque bibendum. " +
+     "Vivamus sit amet libero turpis, non venenatis urna. " +
+     "In blandit, odio convallis suscipit venenatis, ante " +
+     "ipsum cursus augue.",
+     "## Toll \n Lorem ipsum dolor sit amet, " +
+     "consectetur adipiscing elit. Phasellus quis " +
+     "lectus metus, at posuere neque. Sed pharetra " +
+     "nibh eget orci convallis at posuere leo convallis. " +
+     "Sed blandit augue vitae augue scelerisque bibendum. " +
+     "Vivamus sit amet libero turpis, non venenatis urna. " +
+     "In blandit, odio convallis suscipit venenatis, ante " +
+     "ipsum cursus augue.",
+     "## Klasse! \n Lorem ipsum dolor sit amet," +
+     "consectetur adipiscing elit. Phasellus quis " +
+     "lectus metus, at posuere neque. Sed pharetra " +
+     "nibh eget orci convallis at posuere leo convallis. " +
+     "Sed blandit augue vitae augue scelerisque bibendum. " +
+     "Vivamus sit amet libero turpis, non venenatis urna. " +
+     "In blandit, odio convallis suscipit venenatis, ante " +
+     "ipsum cursus augue."
+];
 
 export interface IScope extends angular.IScope {
     path? : string;
@@ -26,7 +52,7 @@ export interface IScope extends angular.IScope {
 
         // FIXME: not final
         title : string;
-        detail : string;
+        paragraphs : string[][];
     };
     selectedState? : string;
     resource: any;
@@ -45,8 +71,10 @@ export var detailDirective = (
         scope: {
             path: "@"
         },
-        link: (scope : IScope) => {
-            console.log("here comes the stuff");
+        link: (scope : any) => {
+            scope.data = {};
+            scope.data.title = "Toller Titel";
+            scope.data.paragraphs = dummydata;
         }
     };
 };
@@ -75,16 +103,18 @@ export var createDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
-    adhTopLevelState : AdhTopLevelState.Service
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhShowError,
+    adhSubmitIfValid
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
-        scope: {
-            path: "@"
-        },
-        link: (scope : IScope) => {
-            console.log("here comes the stuff");
+        link: (scope, element) => {
+            scope.errors = [];
+            scope.data = {};
+            scope.create = true;
+            scope.showError = adhShowError;
         }
     };
 };
@@ -133,7 +163,8 @@ export var register = (angular) => {
         .directive("adhSpdDocumentDetail", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", detailDirective])
         .directive("adhSpdDocumentCreate", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", createDirective])
+            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhShowError",
+            "adhSubmitIfValid", createDirective])
         .directive("adhSpdDocumentEdit", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", editDirective])
         .directive("adhSpdDocumentListItem", [

--- a/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
+++ b/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
@@ -17,42 +17,47 @@ import AdhEmbed = require("../Embed/Embed");
 var pkgLocation = "/spdDocument";
 
 // FIXME: Can be removed when we work with real data
-export var dummydata = [
-    "## Hallo \n\n Lorem ipsum dolor sit amet, " +
-     "consectetur adipiscing elit. Phasellus quis " +
-     "lectus metus, at posuere neque. Sed pharetra " +
-     "nibh eget orci convallis at posuere leo convallis. " +
-     "Sed blandit augue vitae augue scelerisque bibendum. " +
-     "Vivamus sit amet libero turpis, non venenatis urna. " +
-     "In blandit, odio convallis suscipit venenatis, ante " +
-     "ipsum cursus augue.",
-     "## Toll \n\n Lorem ipsum dolor sit amet, " +
-     "consectetur adipiscing elit. Phasellus quis " +
-     "lectus metus, at posuere neque. Sed pharetra " +
-     "nibh eget orci convallis at posuere leo convallis. " +
-     "Sed blandit augue vitae augue scelerisque bibendum. " +
-     "Vivamus sit amet libero turpis, non venenatis urna. " +
-     "In blandit, odio convallis suscipit venenatis, ante " +
-     "ipsum cursus augue.",
-     "## Klasse! \n\n Lorem ipsum dolor sit amet," +
-     "consectetur adipiscing elit. Phasellus quis " +
-     "lectus metus, at posuere neque. Sed pharetra " +
-     "nibh eget orci convallis at posuere leo convallis. " +
-     "Sed blandit augue vitae augue scelerisque bibendum. " +
-     "Vivamus sit amet libero turpis, non venenatis urna. " +
-     "In blandit, odio convallis suscipit venenatis, ante " +
-     "ipsum cursus augue."
-];
+export var dummydata : IParagraph[] = [{
+   body: "## Hallo \n\n Lorem ipsum dolor sit amet, " +
+       "consectetur adipiscing elit. Phasellus quis " +
+       "lectus metus, at posuere neque. Sed pharetra " +
+       "nibh eget orci convallis at posuere leo convallis. " +
+       "Sed blandit augue vitae augue scelerisque bibendum. " +
+       "Vivamus sit amet libero turpis, non venenatis urna. " +
+       "In blandit, odio convallis suscipit venenatis, ante " +
+       "ipsum cursus augue."
+}, {
+    body: "## Toll \n\n Lorem ipsum dolor sit amet, " +
+       "consectetur adipiscing elit. Phasellus quis " +
+       "lectus metus, at posuere neque. Sed pharetra " +
+       "nibh eget orci convallis at posuere leo convallis. " +
+       "Sed blandit augue vitae augue scelerisque bibendum. " +
+       "Vivamus sit amet libero turpis, non venenatis urna. " +
+       "In blandit, odio convallis suscipit venenatis, ante " +
+       "ipsum cursus augue."
+}, {
+    body: "## Klasse! \n\n Lorem ipsum dolor sit amet," +
+       "consectetur adipiscing elit. Phasellus quis " +
+       "lectus metus, at posuere neque. Sed pharetra " +
+       "nibh eget orci convallis at posuere leo convallis. " +
+       "Sed blandit augue vitae augue scelerisque bibendum. " +
+       "Vivamus sit amet libero turpis, non venenatis urna. " +
+       "In blandit, odio convallis suscipit venenatis, ante " +
+       "ipsum cursus augue."
+}];
+
+export interface IParagraph {
+    body : string;
+}
 
 export interface IScope extends angular.IScope {
     path? : string;
     options : AdhHttp.IOptions;
     errors? : AdhHttp.IBackendErrorItem[];
     data : {
-
         // FIXME: not final
         title : string;
-        paragraphs : string[];
+        paragraphs : IParagraph[];
     };
     selectedState? : string;
     resource: any;

--- a/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
+++ b/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
@@ -18,7 +18,7 @@ var pkgLocation = "/spdDocument";
 
 // FIXME: Can be removed when we work with real data
 export var dummydata = [
-    "## Hallo \n Lorem ipsum dolor sit amet, " +
+    "## Hallo \n\n Lorem ipsum dolor sit amet, " +
      "consectetur adipiscing elit. Phasellus quis " +
      "lectus metus, at posuere neque. Sed pharetra " +
      "nibh eget orci convallis at posuere leo convallis. " +
@@ -26,7 +26,7 @@ export var dummydata = [
      "Vivamus sit amet libero turpis, non venenatis urna. " +
      "In blandit, odio convallis suscipit venenatis, ante " +
      "ipsum cursus augue.",
-     "## Toll \n Lorem ipsum dolor sit amet, " +
+     "## Toll \n\n Lorem ipsum dolor sit amet, " +
      "consectetur adipiscing elit. Phasellus quis " +
      "lectus metus, at posuere neque. Sed pharetra " +
      "nibh eget orci convallis at posuere leo convallis. " +
@@ -34,7 +34,7 @@ export var dummydata = [
      "Vivamus sit amet libero turpis, non venenatis urna. " +
      "In blandit, odio convallis suscipit venenatis, ante " +
      "ipsum cursus augue.",
-     "## Klasse! \n Lorem ipsum dolor sit amet," +
+     "## Klasse! \n\n Lorem ipsum dolor sit amet," +
      "consectetur adipiscing elit. Phasellus quis " +
      "lectus metus, at posuere neque. Sed pharetra " +
      "nibh eget orci convallis at posuere leo convallis. " +
@@ -52,7 +52,7 @@ export interface IScope extends angular.IScope {
 
         // FIXME: not final
         title : string;
-        paragraphs : string[][];
+        paragraphs : string[];
     };
     selectedState? : string;
     resource: any;
@@ -71,10 +71,11 @@ export var detailDirective = (
         scope: {
             path: "@"
         },
-        link: (scope : any) => {
-            scope.data = {};
-            scope.data.title = "Toller Titel";
-            scope.data.paragraphs = dummydata;
+        link: (scope : IScope) => {
+            scope.data = {
+                title: "Toller Titel",
+                paragraphs: dummydata
+            };
         }
     };
 };
@@ -163,8 +164,7 @@ export var register = (angular) => {
         .directive("adhSpdDocumentDetail", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", detailDirective])
         .directive("adhSpdDocumentCreate", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhShowError",
-            "adhSubmitIfValid", createDirective])
+            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhShowError", "adhSubmitIfValid", createDirective])
         .directive("adhSpdDocumentEdit", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", editDirective])
         .directive("adhSpdDocumentListItem", [

--- a/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
+++ b/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
@@ -63,6 +63,11 @@ export interface IScope extends angular.IScope {
     resource: any;
 }
 
+export interface IFormScope extends IScope {
+    create : boolean;
+    showError;
+}
+
 export var detailDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
@@ -116,9 +121,12 @@ export var createDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
-        link: (scope, element) => {
+        link: (scope : IFormScope) => {
             scope.errors = [];
-            scope.data = {};
+            scope.data = {
+                title: "Toller Titel",
+                paragraphs: dummydata
+            };
             scope.create = true;
             scope.showError = adhShowError;
         }
@@ -138,7 +146,7 @@ export var editDirective = (
         scope: {
             path: "@"
         },
-        link: (scope : IScope) => {
+        link: (scope : IFormScope) => {
             console.log("here comes the stuff");
         }
     };

--- a/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
+++ b/src/spd/spd/static/js/Packages/spdDocument/spdDocument.ts
@@ -66,6 +66,7 @@ export interface IScope extends angular.IScope {
 export interface IFormScope extends IScope {
     create : boolean;
     showError;
+    addParagraph() : void;
 }
 
 export var detailDirective = (
@@ -129,6 +130,12 @@ export var createDirective = (
             };
             scope.create = true;
             scope.showError = adhShowError;
+
+            scope.addParagraph = () => {
+                scope.data.paragraphs.push({
+                    body: ""
+                });
+            };
         }
     };
 };


### PR DESCRIPTION
This adds mostly boilerplate code for the spd document.

For the Detail view, a lot of code from mercator proposal was reused. We will have to either move some CSS code to core and  make it more abstract or duplicate it. But that will be done separately.