### PR TITLE
Make IRootPool an organisation

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/root.py
+++ b/src/adhocracy_core/adhocracy_core/resources/root.py
@@ -9,6 +9,7 @@ from substanced.util import find_service
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IPool
 from adhocracy_core.resources import add_resource_type_to_registry
+from adhocracy_core.resources.organisation import IOrganisation
 from adhocracy_core.resources.pool import pool_meta
 from adhocracy_core.resources.pool import IBasicPool
 from adhocracy_core.resources.principal import IPrincipalsService
@@ -62,7 +63,7 @@ root_acm = ACM().deserialize(
 # fixme: remove edit_xx_permission
 
 
-class IRootPool(IPool, IRoot):
+class IRootPool(IOrganisation, IRoot):
 
     """The application root object."""
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/root.py
@@ -4,20 +4,17 @@ from pyramid.security import Allow
 
 from adhocracy_core.interfaces import IPool
 from adhocracy_core.resources import add_resource_type_to_registry
-from adhocracy_core.resources.organisation import IOrganisation
 from adhocracy_core.resources.process import IProcess
 from adhocracy_core.resources.root import root_meta
-from adhocracy_core.resources.root import add_platform
 from adhocracy_core.schema import ACM
 from adhocracy_core import sheets
 
 
 def _create_initial_content(context: IPool, registry: Registry, options: dict):
     """Add mercator specific content."""
-    add_platform(context, registry, 'mercator', resource_type=IOrganisation)
-    appstructs = {sheets.name.IName.__identifier__: {'name': 'advocate'}}
+    appstructs = {sheets.name.IName.__identifier__: {'name': 'mercator'}}
     registry.content.create(IProcess.__identifier__,
-                            parent=context['mercator'],
+                            parent=context,
                             appstructs=appstructs)
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_root.py
@@ -26,6 +26,6 @@ def test_create_root_with_initial_content(registry):
         from adhocracy_core.resources.process import IProcess
         inst = registry.content.create(IRootPool.__identifier__)
         assert IRootPool.providedBy(inst)
-        assert IOrganisation.providedBy(inst['mercator'])
-        assert IProcess.providedBy(inst['mercator']['advocate'])
+        assert IOrganisation.providedBy(inst)
+        assert IProcess.providedBy(inst['mercator'])
 

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -15,7 +15,7 @@ import AdhUtil = require("../Util/Util");
 
 import RICommentVersion = require("../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
 import RIMercatorProposalVersion = require("../../Resources_/adhocracy_mercator/resources/mercator/IMercatorProposalVersion");
-import RIOrganisation = require("../../Resources_/adhocracy_core/resources/organisation/IOrganisation");
+import RIProcess = require("../../Resources_/adhocracy_core/resources/process/IProcess");
 import SIComment = require("../../Resources_/adhocracy_core/sheets/comment/IComment");
 
 var pkgLocation = "/MercatorWorkbench";
@@ -215,19 +215,19 @@ export var register = (angular) => {
                     })
                     .then(() => specifics);
                 }])
-                .default(RIOrganisation, "", "", "", {
+                .default(RIProcess, "", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide",
                     proposalUrl: "",  // not used by default, but should be overridable
                     focus: "0"
                 })
-                .default(RIOrganisation, "create_proposal", "", "", {
+                .default(RIProcess, "create_proposal", "", "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIOrganisation, "create_proposal", "", "", ["adhHttp",
+                .specific(RIProcess, "create_proposal", "", "", ["adhHttp",
                     (adhHttp : AdhHttp.Service<any>) => {
-                        return (resource : RIOrganisation) => {
+                        return (resource : RIProcess) => {
                             return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                                 if (!options.POST) {
                                     throw 401;


### PR DESCRIPTION
This makes the root object an organisation, which allows to add processes directly below the root pool.

The latter is done for the MercatorWorkbench, which now works again under the old paths.

Note that migrations are pending:

- Root objects also need to provide the `IOrganisation` interface
- Mercator workbench needs to be migrated to a process