### PR TITLE
2015 06 cc spd chapter styles

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_chapter.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_chapter.scss
@@ -29,20 +29,6 @@ A high-level section of a document with its own heading.
 }
 
 .chapter {
-    .chapter-header {
-        color: $color-text-introvert;
-        margin: 0 0 1em;
-
-        &.active {
-            color: $color-text-highlight-normal;
-        }
-
-        &.m-counted:before {
-            content: counter(chapter-counter) ". ";
-            counter-increment: chapter-counter;
-        }
-    }
-
     @media print {
         border: 0;
         margin: 0;
@@ -50,5 +36,19 @@ A high-level section of a document with its own heading.
         .chapter-header:before {
             display: none;
         }
+    }
+}
+
+.chapter-header {
+    color: $color-text-introvert;
+    margin: 0 0 1em;
+
+    &.active {
+        color: $color-text-highlight-normal;
+    }
+
+    &.m-counted:before {
+        content: counter(chapter-counter) ". ";
+        counter-increment: chapter-counter;
     }
 }

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -23,7 +23,7 @@
             </ol>
         </nav>
 
-        <div class="section-jump-main" data-du-spy-context="">
+        <div class="section-jump-main chapter-wrapper" data-du-spy-context="">
             <section class="commentable-section chapter" data-ng-repeat="paragraph in data.paragraphs" id="section-jump-chapter-{{$index}}">
                 <adh-parse-markdown data-parsetext="paragraph.body"></adh-parse-markdown>
                 <a class="commentable-section-show-comments" href="">

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -24,7 +24,7 @@
         </nav>
 
         <div class="section-jump-main" data-du-spy-context="">
-            <section class="commentable-section" data-ng-repeat="paragraph in data.paragraphs" id="section-jump-chapter-{{$index}}">
+            <section class="commentable-section chapter" data-ng-repeat="paragraph in data.paragraphs" id="section-jump-chapter-{{$index}}">
                 <adh-parse-markdown data-parsetext="paragraph.body"></adh-parse-markdown>
                 <a class="commentable-section-show-comments" href="">
                     <i class="icon-speechbubble"></i> {{ paragraph.commentCount }}

--- a/src/spd/spd/static/js/Packages/spdDocument/Detail.html
+++ b/src/spd/spd/static/js/Packages/spdDocument/Detail.html
@@ -18,7 +18,7 @@
                     <a
                         href="#section-jump-chapter-{{$index}}"
                         data-du-smooth-scroll=""
-                        data-du-scrollspy="">{{ $index }}.</a>
+                        data-du-scrollspy="">{{ $index + 1}}</a>
                 </li>
             </ol>
         </nav>

--- a/src/spd/spd/static/stylesheets/scss/a3.scss
+++ b/src/spd/spd/static/stylesheets/scss/a3.scss
@@ -37,6 +37,7 @@
 @import "components/annotated_section";
 @import "components/commentable_section";
 @import "components/chapter";
+@import "components/chapter_theme";
 @import "components/jump_navigation";
 @import "components/section_jump";
 @import "components/space_switch";

--- a/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
@@ -1,4 +1,3 @@
 .chapter h2 {
     @extend .chapter-header;
-    @extend .m-counted.chapter-header;
 }

--- a/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
@@ -1,0 +1,3 @@
+.chapter h2 {
+    @extend .chapter-header;
+}

--- a/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_chapter_theme.scss
@@ -1,3 +1,4 @@
 .chapter h2 {
     @extend .chapter-header;
+    @extend .m-counted.chapter-header;
 }


### PR DESCRIPTION
Markdown H2 headers in SPD detail form will be styled exactly as chapter headers, this involved de-nesting a core style. Also tidied up jump nav