### PR TITLE
Add migration script for the mercator process

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -7,11 +7,15 @@ from pyramid.security import Allow
 from zope.interface.interfaces import IInterface
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
+from zope.interface import directlyProvides
 from substanced.evolution import add_evolution_step
 from substanced.util import get_acl
+from substanced.util import find_service
 from adhocracy_core.utils import get_sheet
 from adhocracy_core.authorization import set_acl
 from adhocracy_core.interfaces import IResource
+from adhocracy_core.interfaces import search_query
+from adhocracy_core.interfaces import ResourceMetadata
 from adhocracy_core.sheets.pool import IPool
 from adhocracy_core.sheets.title import ITitle
 from adhocracy_core.resources.pool import IBasicPool
@@ -59,6 +63,36 @@ def migrate_new_sheet(context: IPool,
         if remove_isheet_old:
             logger.info('Remove {0} sheet'.format(isheet_old))
             noLongerProvides(resource, isheet_old)
+
+
+def migrate_new_iresource(context: IResource,
+                          old_iresource: IInterface,
+                          new_iresource: IInterface):
+    """Migrate resources with `old_iresource` interface to `new_iresource`."""
+    meta = _get_resource_meta(context, new_iresource)
+    catalogs = find_service(context, 'catalogs')
+    resources = _search_for_interfaces(catalogs, old_iresource)
+    for resource in resources:
+        logger.info('Migrate iresource of {0}'.format(resource))
+        noLongerProvides(resource, old_iresource)
+        directlyProvides(resource, new_iresource)
+        for sheet in meta.basic_sheets + meta.extended_sheets:
+            alsoProvides(resource, sheet)
+        catalogs.reindex_index(resource, 'interfaces')
+
+
+def _get_resource_meta(context: IResource,
+                       iresource: IInterface) -> ResourceMetadata:
+    registry = get_current_registry(context)
+    meta = registry.content.resources_meta[iresource]
+    return meta
+
+
+def _search_for_interfaces(catalogs: ICatalogsService,
+                           interfaces: (IInterface)) -> [IResource]:
+    query = search_query._replace(interfaces=interfaces)
+    resources = catalogs.search(query).elements
+    return resources
 
 
 def log_migration(func):

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -320,6 +320,8 @@ def mock_catalogs(search_result) -> Mock:
     search_mock = Mock(spec=CatalogsServiceAdhocracy.search)
     search_mock.return_value = search_result
     catalogs.search = search_mock
+    reindex_index_mock = Mock(spec=CatalogsServiceAdhocracy.reindex_index)
+    catalogs.reindex_index = reindex_index_mock
     return catalogs
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
@@ -4,14 +4,12 @@ from pyramid.threadlocal import get_current_registry
 from substanced.util import get_acl
 from pyramid.security import Deny
 from substanced.util import find_catalog  # pragma: no cover
-from substanced.util import find_service
 from adhocracy_core.authorization import set_acl
 from adhocracy_core.evolution import migrate_new_sheet
+from adhocracy_core.evolution import migrate_new_iresource
 from adhocracy_core.evolution import log_migration
 from adhocracy_core.utils import get_sheet_field
 from zope.interface import alsoProvides
-from zope.interface import directlyProvides
-from zope.interface import noLongerProvides
 
 logger = logging.getLogger(__name__)  # pragma: no cover
 
@@ -86,20 +84,11 @@ def change_mercator_type_to_iprocess(root):
     """Change mercator type from IBasicPoolWithAssets to IProcess."""
     from adhocracy_mercator.resources.mercator import IProcess
     from adhocracy_core.resources.asset import IPoolWithAssets
-    from adhocracy_mercator.resources.mercator import process_meta
     from adhocracy_core.resources.badge import add_badges_service
-
-    mercator = root['mercator']
-    noLongerProvides(mercator, IPoolWithAssets)
-    directlyProvides(mercator, IProcess)
-
-    for sheet in process_meta.basic_sheets + process_meta.extended_sheets:
-        alsoProvides(mercator, sheet)
-
+    migrate_new_iresource(root, IPoolWithAssets, IProcess)
     registry = get_current_registry()
-    add_badges_service(mercator, registry, {})
-    catalogs = find_service(root, 'catalogs')
-    catalogs.reindex_index(mercator, 'interfaces')
+    add_badges_service(root['mercator'], registry, {})
+
 
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""


### PR DESCRIPTION
I get this stacktrace when trying to evolve an old db:

```
Executing evolution step adhocracy_core.evolution.evolve1_add_title_sheet_to_pools
Traceback (most recent call last):
  File "./bin/sd_evolve", line 112, in <module>
    sys.exit(substanced.scripts.evolve.main())
  File "/home/alphonse/projects/adhocracy3.mercator/src/substanced/substanced/scripts/evolve.py", line 83, in main
    complete = manager.evolve(latest)
  File "/home/alphonse/projects/adhocracy3.mercator/src/substanced/substanced/evolution/__init__.py", line 75, in evolve
    func(self.context)
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/evolution/__init__.py", line 79, in evolve1_add_title_sheet_to_pools
    migrate_new_sheet(root, IBasicPool, ITitle, IPool,
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/evolution/__init__.py", line 46, in migrate_new_sheet
    resources = pool.get(query)['elements']
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/sheets/pool.py", line 38, in get
    return super().get(params)
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/sheets/__init__.py", line 97, in get
    appstruct.update(self._get_reference_appstruct(query))
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/sheets/pool.py", line 66, in _get_reference_appstruct
    result = self._catalogs.search(query)
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/catalog/__init__.py", line 48, in search
    elements = self._search_elements(query)
  File "/home/alphonse/projects/adhocracy3.mercator/src/adhocracy_core/adhocracy_core/catalog/__init__.py", line 91, in _search_elements
    elements = index_query.execute(resolver=None)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/query/__init__.py", line 448, in execute
    resolver=resolver
  File "/home/alphonse/projects/adhocracy3.mercator/src/substanced/substanced/catalog/indexes.py", line 65, in resultset_from_query
    docids = query._apply(names)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/query/__init__.py", line 568, in _apply
    result = queries[0]._apply(names)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/query/__init__.py", line 268, in _apply
    return self.index.applyAll(self._get_value(names))
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/keyword/__init__.py", line 110, in applyAll
    return self.apply({'query': values, 'operator': 'and'})
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/keyword/__init__.py", line 284, in apply
    return self.search(query, operator=operator)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/hypatia-0.3-py3.4-linux-x86_64.egg/hypatia/keyword/__init__.py", line 255, in search
    docids = self._fwd_index.get(word, self.family.IF.Set())
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/ZODB-4.1.0-py3.4.egg/ZODB/Connection.py", line 871, in setstate
    self._setstate(obj)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/ZODB-4.1.0-py3.4.egg/ZODB/Connection.py", line 925, in _setstate
    self._reader.setGhostState(obj, p)
  File "/home/alphonse/projects/adhocracy3.mercator/eggs/ZODB-4.1.0-py3.4.egg/ZODB/serialize.py", line 635, in setGhostState
    obj.__setstate__(state)
TypeError: Object has default comparison

```