### PR TITLE
fix angular boostrap

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -187,7 +187,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhWebSocket.register(angular);
 
     // force-load some services
-    var injector = angular.bootstrap(document, ["a3"], {strictDi: true});
+    var injector = angular.bootstrap(document.body, ["a3"], {strictDi: true});
     injector.get("adhCrossWindowMessaging");
 
     loadComplete();

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -197,7 +197,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhWebSocket.register(angular);
 
     // force-load some services
-    var injector = angular.bootstrap(document, ["a3"], {strictDi: true});
+    var injector = angular.bootstrap(document.body, ["a3"], {strictDi: true});
     injector.get("adhCrossWindowMessaging");
 
     loadComplete();

--- a/src/mercator/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/mercator/static/js/Adhocracy.ts
@@ -194,7 +194,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhWebSocket.register(angular);
 
     // force-load some services
-    var injector = angular.bootstrap(document, ["a3Mercator"], {strictDi: true});
+    var injector = angular.bootstrap(document.body, ["a3Mercator"], {strictDi: true});
     injector.get("adhCrossWindowMessaging");
 
     loadComplete();

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -197,7 +197,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhWebSocket.register(angular);
 
     // force-load some services
-    var injector = angular.bootstrap(document, ["a3spd"], {strictDi: true});
+    var injector = angular.bootstrap(document.body, ["a3spd"], {strictDi: true});
     injector.get("adhCrossWindowMessaging");
 
     loadComplete();


### PR DESCRIPTION
in an effort to increase acceptance test stability I did a bit of reading on the `angular never provided resumeBootstrap` error.

I found https://github.com/angular/protractor/issues/1124 which was interesting but did not really provide a solution.

However, I noticed that we passed `document` as a first parameter to `angular.bootstrap()`.  This is invalid because a DOMElement is required there.

I changed it to `document.body` because this is also the default value for [rootElement](https://github.com/angular/protractor/blob/master/docs/referenceConf.js) in the protractor config. This will probably not make much of a difference but does not hurt either.