### PR TITLE
reflect resource inheritance in frontend

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/MetaApi.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/MetaApi.ts
@@ -26,6 +26,7 @@ export interface IResource {
     sheets : string[];
     item_type ?: string;
     element_types : string[];
+    super_types : string[];
 
     // generated after import
     nick ?: string;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/MetaApiSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/MetaApiSpec.ts
@@ -12,7 +12,8 @@ var sampleMetaApi : AdhMetaApi.IMetaApi = {
             ],
             "element_types" : [
                 "adhocracy_core.interfaces.IPool"
-            ]
+            ],
+            "super_types" : []
         }
     },
     "sheets" : {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -9,7 +9,7 @@ import AdhProcess = require("../Process/Process");
 import AdhTopLevelState = require("../TopLevelState/TopLevelState");
 import AdhUtil = require("../Util/Util");
 
-import RIOrganisation = require("../../Resources_/adhocracy_core/resources/organisation/IOrganisation");
+import RIProcess = require("../../Resources_/adhocracy_core/resources/process/IProcess");
 import SIVersionable = require("../../Resources_/adhocracy_core/sheets/versions/IVersionable");
 
 var pkgLocation = "/ResourceArea";
@@ -243,11 +243,9 @@ export class Service implements AdhTopLevelState.IAreaInput {
                 return _.map(requests, (request) => responses[request.index]);
             });
         }).then((resources) => {
-            // FIXME: a process can not be identified directly. Instead, we look
-            // for resources that are directly below an organisation.
-            for (var i = 1; i < resources.length; i++) {
-                if (resources[i].content_type === RIOrganisation.content_type) {
-                    return resources[i - 1];
+            for (var i = 0; i < resources.length; i++) {
+                if (resources[i].isInstanceOf(RIProcess.content_type)) {
+                    return resources[i];
                 }
             }
             if (fail) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -35,6 +35,7 @@ export class Resource {
     public parent : string;
     public first_version_path : string;
     public root_versions : string[];
+    public static super_types : string[];
     /* tslint:enable:variable-name */
 
     constructor(public content_type : string) {
@@ -56,7 +57,11 @@ export class Resource {
     }
 
     public isInstanceOf(resourceType : string) : boolean {
+        var _class = <any>this.constructor;
+
         if (resourceType === this.content_type) {
+            return true;
+        } else if ((<any>_).includes(_class.super_types, resourceType)) {  // FIXME: DefinitelyTyped
             return true;
         } else {
             return false;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -54,4 +54,12 @@ export class Resource {
 
         return result;
     }
+
+    public isInstanceOf(resourceType : string) : boolean {
+        if (resourceType === this.content_type) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -140,6 +140,7 @@ var mkResourceClassName : (resource : string) => string;
 var mkModuleName : (module : string, metaApi : MetaApi.IMetaApi) => string;
 var mkImportStatement : (modulePath : string, relativeRoot : string, metaApi : MetaApi.IMetaApi) => string;
 var mkNick : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
+var mkSuperTypes : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
 var mkFieldType : (field : MetaApi.ISheetField) => FieldType;
 var mkFlags : (field : MetaApi.ISheetField, comment ?: boolean) => string;
 var isReadableField : (field : MetaApi.ISheetField) => boolean;
@@ -717,7 +718,8 @@ renderResource = (modulePath : string, resource : MetaApi.IResource, modules : M
     };
 
     resourceC += "class " + mkResourceClassName(mkNick(modulePath, metaApi)) + " extends Base.Resource {\n";
-    resourceC += "    public static content_type = \"" + modulePath + "\";\n\n";
+    resourceC += "    public static content_type = \"" + modulePath + "\";\n";
+    resourceC += "    public static super_types = " + mkSuperTypes(modulePath, metaApi) + ";\n\n";
     resourceC += mkConstructor("    ") + "\n\n";
     resourceC += mkDataDeclaration("    ") + "\n\n";
     resourceC += mkGettersSetters("    ") + "\n";
@@ -762,6 +764,11 @@ mkNick = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
     } else {
         throw "mkNick: " + modulePath;
     }
+};
+
+mkSuperTypes = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
+    var superTypes = metaApi.resources[modulePath].super_types;
+    return JSON.stringify(superTypes);
 };
 
 mkFieldType = (field : MetaApi.ISheetField) : FieldType => {


### PR DESCRIPTION
This adds the `super_types` from the meta api to the generated frontend types. It also uses them in `adhResourceArea.getProcess()`.