### PR TITLE
Fix mercator workbench processType

### DIFF
--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -47,6 +47,7 @@ import RIMercatorStory = require("../../Resources_/adhocracy_mercator/resources/
 import RIMercatorStoryVersion = require("../../Resources_/adhocracy_mercator/resources/mercator/IStoryVersion");
 import RIMercatorValue = require("../../Resources_/adhocracy_mercator/resources/mercator/IValue");
 import RIMercatorValueVersion = require("../../Resources_/adhocracy_mercator/resources/mercator/IValueVersion");
+import RIProcess = require("../../Resources_/adhocracy_mercator/resources/mercator/IProcess");
 import RIRateVersion = require("../../Resources_/adhocracy_core/resources/rate/IRateVersion");
 import SIBadgeable = require("../../Resources_/adhocracy_core/sheets/badge/IBadgeable");
 import SIBadgeAssignment = require("../../Resources_/adhocracy_core/sheets/badge/IBadgeAssignment");
@@ -1134,6 +1135,8 @@ export var mercatorProposalFormController = ($scope : IControllerScope, $element
 export var moduleName = "adhMercatorProposal";
 
 export var register = (angular) => {
+    var processType = RIProcess.content_type;
+
     angular
         .module(moduleName, [
             "duScroll",
@@ -1151,20 +1154,20 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RIMercatorProposalVersion, "", "", "", {
+                .default(RIMercatorProposalVersion, "", processType, "", {
                     space: "content",
                     movingColumns: "is-show-show-hide"
                 })
-                .specific(RIMercatorProposalVersion, "", "", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion, "", processType, "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path
                     };
                 })
-                .default(RIMercatorProposalVersion, "edit", "", "", {
+                .default(RIMercatorProposalVersion, "edit", processType, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-hide"
                 })
-                .specific(RIMercatorProposalVersion, "edit", "", "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
+                .specific(RIMercatorProposalVersion, "edit", processType, "", ["adhHttp", (adhHttp : AdhHttp.Service<any>) => {
                     return (resource : RIMercatorProposalVersion) => {
                         var poolPath = AdhUtil.parentPath(resource.path);
 
@@ -1179,11 +1182,11 @@ export var register = (angular) => {
                         });
                     };
                 }])
-                .default(RIMercatorProposalVersion, "comments", "", "", {
+                .default(RIMercatorProposalVersion, "comments", processType, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RIMercatorProposalVersion, "comments", "", "", () => (resource : RIMercatorProposalVersion) => {
+                .specific(RIMercatorProposalVersion, "comments", processType, "", () => (resource : RIMercatorProposalVersion) => {
                     return {
                         proposalUrl: resource.path,
                         commentableUrl: resource.path
@@ -1192,11 +1195,11 @@ export var register = (angular) => {
 
             _(SIMercatorSubResources.Sheet._meta.readable).forEach((section : string) => {
                 adhResourceAreaProvider
-                    .default(RIMercatorProposalVersion, "comments:" + section, "", "", {
+                    .default(RIMercatorProposalVersion, "comments:" + section, processType, "", {
                         space: "content",
                         movingColumns: "is-collapse-show-show"
                     })
-                    .specific(RIMercatorProposalVersion, "comments:" + section, "", "", () =>
+                    .specific(RIMercatorProposalVersion, "comments:" + section, processType, "", () =>
                         (resource : RIMercatorProposalVersion) => {
                             return {
                                 proposalUrl: resource.path,

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -165,6 +165,8 @@ export var mercatorProposalListingColumnDirective = (
 export var moduleName = "adhMercatorWorkbench";
 
 export var register = (angular) => {
+    var processType = RIProcess.content_type;
+
     angular
         .module(moduleName, [
             AdhAbuse.moduleName,
@@ -180,11 +182,11 @@ export var register = (angular) => {
         ])
         .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
             adhResourceAreaProvider
-                .default(RICommentVersion, "", "", "", {
+                .default(RICommentVersion, "", processType, "", {
                     space: "content",
                     movingColumns: "is-collapse-show-show"
                 })
-                .specific(RICommentVersion, "", "", "", ["adhHttp", "$q", (
+                .specific(RICommentVersion, "", processType, "", ["adhHttp", "$q", (
                     adhHttp : AdhHttp.Service<any>,
                     $q : angular.IQService
                 ) => (resource : RICommentVersion) => {
@@ -215,17 +217,17 @@ export var register = (angular) => {
                     })
                     .then(() => specifics);
                 }])
-                .default(RIProcess, "", "", "", {
+                .default(RIProcess, "", processType, "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide",
                     proposalUrl: "",  // not used by default, but should be overridable
                     focus: "0"
                 })
-                .default(RIProcess, "create_proposal", "", "", {
+                .default(RIProcess, "create_proposal", processType, "", {
                     space: "content",
                     movingColumns: "is-show-hide-hide"
                 })
-                .specific(RIProcess, "create_proposal", "", "", ["adhHttp",
+                .specific(RIProcess, "create_proposal", processType, "", ["adhHttp",
                     (adhHttp : AdhHttp.Service<any>) => {
                         return (resource : RIProcess) => {
                             return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
@@ -240,7 +242,7 @@ export var register = (angular) => {
                 );
         }])
         .config(["adhProcessProvider", (adhProcessProvider) => {
-            adhProcessProvider.templateFactories[""] = ["$q", ($q : angular.IQService) => {
+            adhProcessProvider.templateFactories[processType] = ["$q", ($q : angular.IQService) => {
                 return $q.when("<adh-mercator-workbench></adh-mercator-workbench>");
             }];
         }])


### PR DESCRIPTION
With the merge of #1292 `/mercator` is recognized as a process by the frontend. So now it is required to define the routes in the context of this process.

I checked and I think this is the only process where this change is required.