### PR TITLE
Do not set any permissions in the evolution script

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -3,16 +3,13 @@ import logging
 from functools import wraps
 from pyramid.registry import Registry
 from pyramid.threadlocal import get_current_registry
-from pyramid.security import Allow
 from zope.interface.interfaces import IInterface
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
 from zope.interface import directlyProvides
 from substanced.evolution import add_evolution_step
-from substanced.util import get_acl
 from substanced.util import find_service
 from adhocracy_core.utils import get_sheet
-from adhocracy_core.authorization import set_acl
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import search_query
 from adhocracy_core.interfaces import ResourceMetadata
@@ -132,15 +129,7 @@ def evolve1_add_title_sheet_to_pools(root: IPool):  # pragma: no cover
 
 @log_migration
 def add_kiezkassen_permissions(root):
-    """Add permission to use the kiezkassen process."""
-    registry = get_current_registry()
-    acl = get_acl(root)
-    new_acl = [(Allow, 'role:contributor', 'add_kiezkassen_proposal'),
-               (Allow, 'role:creator', 'edit_kiezkassen_proposal'),
-               (Allow, 'role:admin', 'add_kiezkassen_process'),
-               (Allow, 'role:admin', 'add_process')]
-    updated_acl = acl + new_acl
-    set_acl(root, updated_acl, registry=registry)
+    """(disabled) Add permission to use the kiezkassen process."""
 
 
 @log_migration

--- a/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/evolution/__init__.py
@@ -1,10 +1,7 @@
 """Scripts to migrate legacy objects in existing databases."""
 import logging  # pragma: no cover
 from pyramid.threadlocal import get_current_registry
-from pyramid.security import Deny
-from substanced.util import get_acl
 from substanced.util import find_catalog  # pragma: no cover
-from adhocracy_core.authorization import set_acl
 from adhocracy_core.evolution import migrate_new_sheet
 from adhocracy_core.evolution import migrate_new_iresource
 from adhocracy_core.evolution import log_migration
@@ -51,13 +48,7 @@ def evolve1_add_ititle_sheet_to_proposals(root):  # pragma: no cover
 
 @log_migration
 def evolve2_disable_add_proposal_permission(root):  # pragma: no cover
-    """Disable add_proposal permissions."""
-    registry = get_current_registry()
-    acl = get_acl(root)
-    deny_acl = [(Deny, 'role:contributor', 'add_proposal'),
-                (Deny, 'role:creator', 'edit_mercator_proposal')]
-    updated_acl = deny_acl + acl
-    set_acl(root, updated_acl, registry=registry)
+    """(disabled) Disable add_proposal permissions."""
 
 
 @log_migration
@@ -72,15 +63,7 @@ def evolve3_use_adhocracy_core_title_sheet(root):  # pragma: no cover
 
 @log_migration
 def evolve4_disable_voting_and_commenting(root):
-    """Disable rate and comment permissions."""
-    registry = get_current_registry()
-    acl = get_acl(root)
-    deny_acl = [(Deny, 'role:annotator', 'add_comment'),
-                (Deny, 'role:annotator', 'add_rate'),
-                (Deny, 'role:creator', 'edit_comment'),
-                (Deny, 'role:creator', 'edit_rate')]
-    updated_acl = deny_acl + acl
-    set_acl(root, updated_acl, registry=registry)
+    """(disabled) Disable rate and comment permissions."""
 
 
 @log_migration


### PR DESCRIPTION
Permissions are set with ACM on resources or with workflows. Setting
permissions in evolution script is not necessary. The evolution
scripts cannot be removed yet because they are referenced by
substanced in the database itself to keep track of which scripts have
been executed.