### PR TITLE
Improve code coverage in authentification module

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -98,7 +98,8 @@ def get_tokenmanager(request: Request, **kwargs) -> ITokenManger:
 
     :returns: :class:'adhocracy_core.interfaces.ITokenManager or None.
     """
-    if getattr(request, 'root', None) is None:  # ease testing
+    # allow to run pyramid scripts without authentication
+    if getattr(request, 'root', None) is None:
         return None
     try:
         return ITokenManger(request.root)

--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -308,6 +308,14 @@ class GetTokenManagerUnitTest(unittest.TestCase):
         inst = self.call_fut(self.request)
         assert inst is None
 
+    def test_request_has_no_root(self):
+        """For pyramid scripts request.root is None and no authentication
+           is needed.
+        """
+        self.request.root = None
+        inst = self.call_fut(self.request)
+        assert inst is None
+
 
 class TokenHeaderAuthenticationPolicyIntegrationTest(unittest.TestCase):
 


### PR DESCRIPTION
@joka it's not clear to me why you added these lines since they are not used by the tests. Maybe a later refactoring made them unnecessary.

Since this code is not executed, the code coverage is not 100% for this file.

Can you have a look and merge or just close the request if ther is a reason to have that?