### PR TITLE
Fix code coverage for catalog/subscriber

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
@@ -51,8 +51,6 @@ def reindex_visibility(event):
 
 def _reindex_resource_and_descendants(resource: IResource):
     catalogs = find_service(resource, 'catalogs')
-    if catalogs is None:
-        return  # ease testing
     resource_and_descendants = list_resource_with_descendants(resource)
     for res in resource_and_descendants:
         catalogs.reindex_index(res, 'private_visibility')


### PR DESCRIPTION
@joka Here also it's not clear to me why you added these lines since they are not used by the tests. Maybe a later refactoring made them unnecessary.

Since this code is not executed, the code coverage is not 100% for this file.

Can you have a look and merge or just close the request if ther is a reason to have that?
