### PR TITLE
add missing abuse dependency

### DIFF
--- a/src/spd/spd/static/js/Packages/spdWorkbench/spdWorkbench.ts
+++ b/src/spd/spd/static/js/Packages/spdWorkbench/spdWorkbench.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
 
+import AdhAbuse = require("../Abuse/Abuse");
 import AdhComment = require("../Comment/Comment");
 import AdhConfig = require("../Config/Config");
 import AdhHttp = require("../Http/Http");
@@ -124,6 +125,7 @@ export var register = (angular) => {
 
     angular
         .module(moduleName, [
+            AdhAbuse.moduleName,
             AdhComment.moduleName,
             AdhHttp.moduleName,
             AdhMovingColumns.moduleName,


### PR DESCRIPTION
due to a missing angular dependency, the report form for comments was not rendered.