### PR TITLE
Fix documentUrl on @comments route

### DIFF
--- a/src/spd/spd/static/js/Packages/spdWorkbench/spdWorkbench.ts
+++ b/src/spd/spd/static/js/Packages/spdWorkbench/spdWorkbench.ts
@@ -192,7 +192,7 @@ export var register = (angular) => {
                     () => (item : RIParagraph, version : RIParagraphVersion) => {
                         return {
                             commentableUrl: version.path,
-                            documentUrl: version.data[SIParagraph.nick].documents[0]
+                            documentUrl: _.last(_.sortBy(version.data[SIParagraph.nick].documents))
                         };
                     }])
                 .defaultVersionable(RIComment, RICommentVersion, "", processType, "", {
@@ -216,7 +216,7 @@ export var register = (angular) => {
                         return getCommentableUrl(version).then((commentable) => {
                             return {
                                 commentableUrl: commentable.path,
-                                documentUrl: commentable.path
+                                documentUrl: _.last(_.sortBy(commentable.data[SIParagraph.nick].documents))
                             };
                         });
                     };


### PR DESCRIPTION
-   create a document
-   edit the document and only add one paragraph
-   go to the comments of one of the initial paragraphs

the new paragraph is displayed

the new paragraph is not displayed

during routing, the wrong document version was selected

I also fixed a similar issue for the comment route in the same commit.