### PR TITLE
fix redirect after form success

### DIFF
--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -40,9 +40,13 @@ var bindRedirectsToScope = (scope, adhConfig, adhResourceUrlFilter, $location) =
         // FIXME: use adhTopLevelState.redirectToCameFrom
         $location.url(adhResourceUrlFilter(resourcePath));
     };
-    scope.redirectAfterProposalSubmit = (result : {path : string }[]) => {
-        var proposalVersionPath = result.slice(-1)[0].path;
-        $location.url(adhResourceUrlFilter(proposalVersionPath));
+    scope.redirectAfterProposalSubmit = (result : any[]) => {
+        var proposalVersion = _.find(result, (r) => r.content_type === RIMercatorProposalVersion.content_type);
+        if (typeof proposalVersion !== "undefined") {
+            $location.url(adhResourceUrlFilter(proposalVersion.path));
+        } else {
+            throw 404;
+        }
     };
 };
 


### PR DESCRIPTION
The order in which resources are returned from `deepPost()` has been fixed in 223525ed. The redirect after creating/editing a MercatorProposal relied on the previous order. This should fix the regression.