### PR TITLE
Allow to sort by title

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
@@ -10,6 +10,7 @@ from adhocracy_core.sheets.metadata import IMetadata
 from adhocracy_core.sheets.rate import IRate
 from adhocracy_core.sheets.rate import IRateable
 from adhocracy_core.sheets.tags import TagElementsReference
+from adhocracy_core.sheets.title import ITitle
 from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.badge import IBadgeable
 from adhocracy_core.sheets.versions import IVersionable
@@ -33,6 +34,7 @@ class AdhocracyCatalogIndexes:
     tag = catalog.Keyword()
     private_visibility = catalog.Keyword()  # visible / deleted / hidden
     badge = catalog.Keyword()
+    title = catalog.Field()
     rate = catalog.Field()
     rates = catalog.Field()
     creator = catalog.Field()
@@ -71,6 +73,12 @@ def index_visibility(resource, default) -> [str]:
     if not result:
         result.append('visible')
     return result
+
+
+def index_title(resource, default) -> str:
+    """Return the value of field name ` title`."""
+    title = get_sheet_field(resource, ITitle, 'title')
+    return title
 
 
 def index_rate(resource, default) -> int:
@@ -143,6 +151,11 @@ def includeme(config):
                          catalog_name='adhocracy',
                          index_name='item_creation_date',
                          context=IMetadata,
+                         )
+    config.add_indexview(index_title,
+                         catalog_name='adhocracy',
+                         index_name='title',
+                         context=ITitle,
                          )
     config.add_indexview(index_rate,
                          catalog_name='adhocracy',

--- a/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
@@ -30,6 +30,7 @@ def test_create_adhocracy_catalog(pool_graph, registry):
     assert 'item_creation_date' in catalogs['adhocracy']
     assert 'private_visibility' in catalogs['adhocracy']
     assert 'badge' in catalogs['adhocracy']
+    assert 'title' in catalogs['adhocracy']
 
 
 class TestIndexMetadata:
@@ -249,4 +250,29 @@ def test_includeme_register_index_badge(registry):
     assert registry.adapters.lookup((IBadgeable,), IIndexView,
                                     name='adhocracy|badge')
 
+
+class TestIndexTitle:
+
+    @fixture
+    def registry(self, registry_with_content):
+        return registry_with_content
+
+    @fixture
+    def mock_sheet(self, mock_sheet, registry):
+        from adhocracy_core.sheets.title import ITitle
+        mock_sheet.meta = mock_sheet.meta._replace(isheet=ITitle)
+        registry.content.get_sheet.return_value = mock_sheet
+        return mock_sheet
+
+    def test_return_title(self, context, mock_sheet):
+        from .adhocracy import index_title
+        mock_sheet.get.return_value = {'title': 'Title'}
+        assert index_title(context, 'default') == 'Title'
+
+    @mark.usefixtures('integration')
+    def test_register(self, registry):
+        from adhocracy_core.sheets.title import ITitle
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((ITitle,), IIndexView,
+                                        name='adhocracy|title')
 

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1496,6 +1496,9 @@ custom filters:
 * *badge* the badge names of resources with :class:`adhocracy_core.sheets.badge.IBadgeable`
   sheet.
 
+* *title* the title of resources with :class:`adhocracy_core.sheets.title.ITitle`
+  sheet.
+
 *<package.sheets.sheet.ISheet:FieldName>* filters: you can add arbitrary custom
 filters that refer to sheet fields with references. The key is the name of
 the isheet plus the field name separated by ':' The value is the wanted

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Listing.html
@@ -2,6 +2,7 @@
     data-path="{{path}}"
     data-content-type="{{contentType}}"
     data-no-create-form="true"
+    data-sort="'title'"
     data-empty-text="{{ 'TR__DOCUMENT_EMPTY_TEXT' | translate }}">
     <div data-ng-switch="transclusionId">
         <adh-document-list-item


### PR DESCRIPTION
This adds a catalog index for `ITitle.title`.

@joka: As discssed, this doesn't work yet and yields something like:

    hypatia.exc.Unsortable: [-5337356932914536409]

Could you please check?

Also,

- tests are missing;
- maybe the sort request in the frontend needs to be in reverse.