### PR TITLE
2015 06 cc spd core badges

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/a3.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/a3.scss
@@ -20,6 +20,7 @@
 @import "layout";
 
 @import "components/type";
+@import "components/badges";
 @import "components/forms";
 @import "components/button";
 @import "components/login";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -1,6 +1,6 @@
 /*doc
 ---
-title: badges
+title: Badges
 name: badges
 category: Type
 ---
@@ -8,12 +8,12 @@ category: Type
 Badges for labeling things
 
 ```html_example
-I am a normal user <span class="has-badge">Normal User</span>
+I am a normal user <span class="badge">Normal User</span>
 ```
 
 */
 
-.has-badge {
+.badge {
     @include inline-block;
     background: $color-structure-normal;
     color: $color-text-normal;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -1,8 +1,23 @@
+/*doc
+---
+title: badges
+name: badges
+category: Type
+---
+
+Badges for labeling things
+
+```html_example
+I am a normal user <span class="has-badge">Normal User</span>
+```
+
+*/
+
 .has-badge {
     @include inline-block;
     background: $color-structure-normal;
     color: $color-text-normal;
     font-size: $font-size-smaller;
-    padding: 0 5px;
+    padding: 3px 5px 2px;
     text-transform: uppercase;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -18,6 +18,6 @@ I am a normal user <span class="badge">Normal User</span>
     background: $color-structure-normal;
     color: $color-text-normal;
     font-size: $font-size-smaller;
-    padding: 3px 5px 2px;
+    padding: 2px 5px;
     text-transform: uppercase;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -18,6 +18,6 @@ I am a normal user <span class="badge">Normal User</span>
     background: $color-structure-normal;
     color: $color-text-normal;
     font-size: $font-size-smaller;
-    padding: 2px 5px;
+    padding: 3px 5px 2px;
     text-transform: uppercase;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -1,0 +1,8 @@
+.has-badge {
+    @include inline-block;
+    background: $color-structure-normal;
+    color: $color-text-normal;
+    font-size: $font-size-smaller;
+    padding: 0 5px;
+    text-transform: uppercase;
+}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -1,7 +1,7 @@
 /*doc
 ---
 title: Badges
-name: badges
+name: badge
 category: Type
 ---
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_list.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_list.scss
@@ -44,7 +44,7 @@ A user list item within a listing widget
         color: $color-text-normal;
         font-size: $font-size-large;
 
-        + .has-badge {
+        + .badge {
             margin-left: 10px / $font-size-small * 1em;
         }
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_list.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_list.scss
@@ -43,6 +43,10 @@ A user list item within a listing widget
     .user-list-item-name {
         color: $color-text-normal;
         font-size: $font-size-large;
+
+        + .has-badge {
+            margin-left: 10px / $font-size-small * 1em;
+        }
     }
 
     .user-list-item-button {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
@@ -2,7 +2,7 @@
     <header class="mein-berlin-kiezkassen-proposal-detail-header">
         <span
                 data-ng-if="data.assignments.length > 0"
-                class="has-badge"
+                class="badge"
                 data-ng-class="{
                     'is-realized': data.assignments[0].name === 'going_to_be_realized',
                     'is-not-realized': data.assignments[0].name === 'not_realizeable'

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/Detail.html
@@ -4,8 +4,8 @@
                 data-ng-if="data.assignments.length > 0"
                 class="badge"
                 data-ng-class="{
-                    'is-realized': data.assignments[0].name === 'going_to_be_realized',
-                    'is-not-realized': data.assignments[0].name === 'not_realizeable'
+                    'm-is-realized': data.assignments[0].name === 'going_to_be_realized',
+                    'm-is-not-realized': data.assignments[0].name === 'not_realizeable'
             }">{{ data.assignments[0].title }}</span>
         <ul class="mein-berlin-kiezkassen-proposal-detail-meta">
             <li class="mein-berlin-kiezkassen-proposal-detail-meta-item mein-berlin-kiezkassen-proposal-detail-meta-item-location">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
@@ -8,7 +8,7 @@
         <adh-time data-datetime="data.creationDate" data-format="L"></adh-time>
         <span
             data-ng-if="data.assignments.length > 0"
-            class="has-badge"
+            class="badge"
             data-ng-class="{
                 'is-realized': data.assignments[0].name === 'going_to_be_realized',
                 'is-not-realized': data.assignments[0].name === 'not_realizeable'

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Proposal/ListItem.html
@@ -10,8 +10,8 @@
             data-ng-if="data.assignments.length > 0"
             class="badge"
             data-ng-class="{
-                'is-realized': data.assignments[0].name === 'going_to_be_realized',
-                'is-not-realized': data.assignments[0].name === 'not_realizeable'
+                'm-is-realized': data.assignments[0].name === 'going_to_be_realized',
+                'm-is-not-realized': data.assignments[0].name === 'not_realizeable'
         }">{{ data.assignments[0].title }}</span>
     </div>
     <div class="meinberlin-kiezkassen-proposal-list-item-col-right">

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
@@ -63,6 +63,7 @@
 @import "components/standalone_wrapper";
 @import "components/standalone_wrapper_theme";
 @import "components/bplan";
+@import "components/badges";
 @import "components/badges_theme";
 @import "components/proposal_list";
 

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -1,7 +1,7 @@
 /*doc
 ---
-title: badges
-name: badges
+title: badges MeinBerlin
+name: badges-mainberlin
 category: Type
 ---
 

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -13,12 +13,11 @@ Badges for labeling if a proposal has been realized or not.
 ```
 
 */
+
 .has-badge {
-    @include inline-block;
-    color: $color-text-inverted;
-    font-size: $font-size-smaller;
-    padding: 0 5px;
-    text-transform: uppercase;
+    &.is-realized, &.is-not-realized {
+        color: $color-text-inverted;
+    }
 
     &.is-realized {
         background-color: $color-brand-two-normal;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -8,22 +8,22 @@ category: Type
 Badge modifiers for labeling if a proposal has been realized or not.
 
 ```html_example
-<span class="badge is-realized">Is Realized</span>
-<span class="badge is-not-realized">Is Not Realized</span>
+<span class="badge m-is-realized">Is Realized</span>
+<span class="badge m-is-not-realized">Is Not Realized</span>
 ```
 
 */
 
 .badge {
-    &.is-realized, &.is-not-realized {
+    &.m-is-realized, &.m-is-not-realized {
         color: $color-text-inverted;
     }
 
-    &.is-realized {
+    &.m-is-realized {
         background-color: $color-brand-two-normal;
     }
 
-    &.is-not-realized {
+    &.m-is-not-realized {
         background-color: $color-text-introvert;
     }
 }

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -8,13 +8,13 @@ category: Type
 Badge modifiers for labeling if a proposal has been realized or not.
 
 ```html_example
-<span class="has-badge is-realized">Is Realized</span>
-<span class="has-badge is-not-realized">Is Not Realized</span>
+<span class="badge is-realized">Is Realized</span>
+<span class="badge is-not-realized">Is Not Realized</span>
 ```
 
 */
 
-.has-badge {
+.badge {
     &.is-realized, &.is-not-realized {
         color: $color-text-inverted;
     }

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -1,7 +1,7 @@
 /*doc
 ---
-title: badges MeinBerlin
-name: badges-mainberlin
+title: Badges MeinBerlin
+name: badges-meinberlin
 category: Type
 ---
 

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -1,8 +1,8 @@
 /*doc
 ---
 title: Badges MeinBerlin
-name: badges-meinberlin
-category: Type
+name: badge-meinberlin
+parent: badge
 ---
 
 Badge modifiers for labeling if a proposal has been realized or not.

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -5,7 +5,7 @@ name: badges-mainberlin
 category: Type
 ---
 
-Badges for labeling if a proposal has been realized or not.
+Badge modifiers for labeling if a proposal has been realized or not.
 
 ```html_example
 <span class="has-badge is-realized">Is Realized</span>

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_meinberlin_proposal.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_meinberlin_proposal.scss
@@ -66,7 +66,7 @@
         margin: 0 0 (30px / $font-size-normal * 1em);
     }
 
-    .has-badge {
+    .badge {
         position: relative;
         top: -20px / $font-size-small * 1em;
     }
@@ -187,7 +187,7 @@ as metadata.  It serves as an entry to a detail view.
         }
     }
 
-    .has-badge {
+    .badge {
         margin-left: 20px / $font-size-small * 1em;
     }
 }

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/Detail.html
@@ -1,7 +1,7 @@
 <div
     class="section-jump" id="section-jump-top"
     data-ng-class="{
-        'has-badge': data.winnerBadgeAssignment,
+        'has-rosette': data.winnerBadgeAssignment,
         'm-winner': data.winnerBadgeAssignment.name === 'winning',
         'm-community-award': data.winnerBadgeAssignment.name === 'community'
     }">

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/ListItem.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/ListItem.html
@@ -1,7 +1,7 @@
 <a
     data-ng-href="{{ path | adhResourceUrl }}"
     data-ng-class="{
-        'has-badge': data.winnerBadgeAssignment,
+        'has-rosette': data.winnerBadgeAssignment,
         'm-winner': data.winnerBadgeAssignment.name === 'winning',
         'm-community-award': data.winnerBadgeAssignment.name === 'community'
     }"

--- a/src/mercator/mercator/static/stylesheets/scss/a3.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/a3.scss
@@ -57,7 +57,7 @@
 @import "components/error_pages_theme";
 @import "components/standalone_wrapper";
 @import "components/proposal_list";
-@import "components/rosettes_theme";
+@import "components/rosette_theme";
 @import "components/jury_decision_theme";
 
 @import "third_party/social_share";

--- a/src/mercator/mercator/static/stylesheets/scss/a3.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/a3.scss
@@ -23,6 +23,7 @@
 @import "components/presentation_theme";
 
 @import "components/type";
+@import "components/badges";
 @import "components/forms";
 @import "components/forms_theme";
 @import "components/button";

--- a/src/mercator/mercator/static/stylesheets/scss/a3.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/a3.scss
@@ -57,8 +57,7 @@
 @import "components/error_pages_theme";
 @import "components/standalone_wrapper";
 @import "components/proposal_list";
-
-@import "components/badges_theme";
+@import "components/rosettes_theme";
 @import "components/jury_decision_theme";
 
 @import "third_party/social_share";

--- a/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
@@ -1,8 +1,8 @@
 /*doc
 ---
 title: Rosettes
-name: Rosettes
-category: Widgets
+name: has-rosette
+parent: badges
 ---
 
 Add a winning rosette or similar to an element. Must have a position:relative or absolute container.

--- a/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
@@ -13,7 +13,7 @@ Add a winning rosette or similar to an element. Must have a position:relative or
     <li class="listing-element debug-placeholder has-rosette m-community-award" style="min-height:75px; position: relative">Community Winner</li>
 </ol>
 
-<div class="debug-placeholder has-badge m-winner" style="position: relative; height:100px; width: 200px">Winner</div>
+<div class="debug-placeholder has-rosette m-winner" style="position: relative; height:100px; width: 200px">Winner</div>
 ```
 */
 

--- a/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
@@ -2,7 +2,7 @@
 ---
 title: Rosettes
 name: has-rosette
-parent: badges
+parent: badge
 ---
 
 Add a winning rosette or similar to an element. Must have a position:relative or absolute container.

--- a/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_rosette_theme.scss
@@ -1,23 +1,23 @@
 /*doc
 ---
-title: Badges
-name: badges
+title: Rosettes
+name: Rosettes
 category: Widgets
 ---
 
-Add a winning badge or similar to an element. Must have a position:relative or absolute container.
+Add a winning rosette or similar to an element. Must have a position:relative or absolute container.
 
 ```html_example
 <ol class="listing-elements">
-    <li class="listing-element debug-placeholder has-badge m-winner" style="min-height:75px; position: relative">Winner</li>
-    <li class="listing-element debug-placeholder has-badge m-community-award" style="min-height:75px; position: relative">Community Winner</li>
+    <li class="listing-element debug-placeholder has-rosette m-winner" style="min-height:75px; position: relative">Winner</li>
+    <li class="listing-element debug-placeholder has-rosette m-community-award" style="min-height:75px; position: relative">Community Winner</li>
 </ol>
 
 <div class="debug-placeholder has-badge m-winner" style="position: relative; height:100px; width: 200px">Winner</div>
 ```
 */
 
-.has-badge {
+.has-rosette {
     &:after, &:before {
         font-size: $font-size-normal;
     }

--- a/src/spd/spd/static/stylesheets/scss/a3.scss
+++ b/src/spd/spd/static/stylesheets/scss/a3.scss
@@ -46,6 +46,7 @@
 @import "components/space_switch";
 @import "components/user_list";
 @import "components/user_profile";
+@import "components/user_profile_theme";
 @import "components/rate";
 @import "components/facets";
 @import "components/unsupported_browser";

--- a/src/spd/spd/static/stylesheets/scss/a3.scss
+++ b/src/spd/spd/static/stylesheets/scss/a3.scss
@@ -21,6 +21,7 @@
 @import "layout";
 
 @import "components/type";
+@import "components/badges";
 @import "components/forms";
 @import "components/forms_theme";
 @import "components/button";

--- a/src/spd/spd/static/stylesheets/scss/components/_user_profile_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_user_profile_theme.scss
@@ -1,0 +1,7 @@
+.user-profile-info-name-text {
+    display: block;
+}
+
+.user-profile-info-name .has-badge {
+    margin-top: 20px / $font-size-small * 1em;
+}

--- a/src/spd/spd/static/stylesheets/scss/components/_user_profile_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_user_profile_theme.scss
@@ -2,6 +2,6 @@
     display: block;
 }
 
-.user-profile-info-name .has-badge {
+.user-profile-info-name .badge {
     margin-top: 20px / $font-size-small * 1em;
 }


### PR DESCRIPTION
Hey there, so I renamed mercators style winners badges to 'Rosettes' 
![rosette](https://cloud.githubusercontent.com/assets/701632/8306993/681e9dc4-19bc-11e5-8ae8-1ffabf81ce99.jpg) to disinguish them from plain old badges

## adding to user list
```
        <span class="user-list-item-name">{{userBasic.name}}</span>
        <span class="has-badge">Hi there</span>
        <span class="user-list-item-button">{{"TR__VIEW_PROFILE" | translate }}</span>
```
badge must be placed directly after .user-list-item-name for correct spacing

## adding to user profile
In the user profile page place the badge inside the h1 like so
```<h1 data-itemprop="name" class="user-profile-info-name"><span class="user-profile-info-name-text">{{userBasic.name}}</span><span class="has-badge">Hi there</span></h1>```