### PR TITLE
refactore assign badges script; new json file format API CHANGE

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scripts/assign_badges.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/assign_badges.py
@@ -32,7 +32,7 @@ def assign_badges():  # pragma: no cover
     env = bootstrap(args.ini_file)
     root = env['root']
     registry = env['registry']
-    _import_assignments(root, registry, args.filename)
+    _import_assignments(root, registry, args.jsonfile)
     transaction.commit()
     env['closer']()
 

--- a/src/adhocracy_core/adhocracy_core/scripts/assign_badges.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/assign_badges.py
@@ -11,10 +11,14 @@ import argparse
 import transaction
 from pyramid.paster import bootstrap
 from pyramid.traversal import find_resource
+from pyramid.registry import Registry
 from substanced.util import find_service
 
-from adhocracy_core import resources
+from adhocracy_core.resources.principal import IUser
+from adhocracy_core.resources.badge import IBadge
+from adhocracy_core.resources.badge import IBadgeAssignment
 from adhocracy_core import sheets
+from adhocracy_core.interfaces import IResource
 from adhocracy_core.utils import load_json
 
 
@@ -28,12 +32,7 @@ def assign_badges():  # pragma: no cover
     env = bootstrap(args.ini_file)
     root = env['root']
     registry = env['registry']
-
-    entries = load_json(args.jsonfile)
-
-    for entry in entries:
-        _create_badge_assignment(entry, root, registry)
-
+    _import_assignments(root, registry, args.filename)
     transaction.commit()
     env['closer']()
 
@@ -50,40 +49,41 @@ def _parse_args():  # pragma: no cover
     return parser.parse_args()
 
 
-def _create_badge_assignment(entry, root, registry):
-
-    user = entry['user']
-    badge = entry['badge']
-    proposalversion = entry['proposalversion']
-    proposalitem = entry['proposalitem']
-    user, badge, proposal_version, parent = _get_resources(
-        root, user, badge, proposalversion, proposalitem)
-
-    description = entry['description']
-    service = find_service(parent, 'badge_assignments')
-    appstructs = _create_appstructs(user, badge, proposal_version, description)
-
-    registry.content.create(resources.badge.IBadgeAssignment.__identifier__,
-                            parent=service,
-                            appstructs=appstructs)
+def _import_assignments(root: IResource, registry: Registry, filename: str):
+    entries = load_json(filename)
+    for entry in entries:
+        user, badge, badgeable = _find_resources(root, entry)
+        description = entry['description']
+        create_badge_assignment(user, badge, badgeable, description, registry)
 
 
-def _create_appstructs(subject, badge, object, description):
-    appstructs = {sheets.badge.IBadgeAssignment.__identifier__:
-                  {'subject': subject,
-                   'badge': badge,
-                   'object': object
-                   },
-                  sheets.description.IDescription.__identifier__:
-                  {'description': description}
-                  }
-    return appstructs
-
-
-def _get_resources(root, userpath, badgepath, proposalversionpath,
-                   proposalitempath):
+def _find_resources(root,
+                    entry: dict) -> (IUser, IBadge, sheets.badge.IBadgeable):
+    userpath = entry.get('user')
     user = find_resource(root, userpath)
+    badgepath = entry.get('badge')
     badge = find_resource(root, badgepath)
-    proposal_version = find_resource(root, proposalversionpath)
-    proposal_item = find_resource(root, proposalitempath)
-    return user, badge, proposal_version, proposal_item
+    badgeablepath = entry.get('badgeable')
+    badgeable = find_resource(root, badgeablepath)
+    return user, badge, badgeable
+
+
+def create_badge_assignment(user: IUser,
+                            badge: IBadge,
+                            badgeable: sheets.badge.IBadgeable,
+                            description: str,
+                            registry: Registry) -> IBadgeAssignment:
+    """Create badge assignment."""
+    appstructs = {sheets.badge.IBadgeAssignment.__identifier__:
+                  {'subject': user,
+                   'badge': badge,
+                   'object': badgeable
+                   }}
+    if description != '':
+        appstructs[sheets.description.IDescription.__identifier__] =\
+            {'description': description}
+    assignments = find_service(badgeable, 'badge_assignments')
+    assignmnet = registry.content.create(IBadgeAssignment.__identifier__,
+                                         parent=assignments,
+                                         appstructs=appstructs)
+    return assignmnet

--- a/src/adhocracy_core/adhocracy_core/scripts/test_assign_badges.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_assign_badges.py
@@ -1,10 +1,10 @@
+import os
 from copy import deepcopy
 
 from pyramid import testing
 from unittest.mock import Mock
 from pytest import fixture
 
-from adhocracy_core.interfaces import IResource
 
 class TestAssignBadges:
 
@@ -17,37 +17,46 @@ class TestAssignBadges:
         return pool
 
     def test_create_badge_assignment(self, service, context):
-        from .assign_badges import _create_badge_assignment
+        import json
+        from tempfile import mkstemp
+        from .assign_badges import _import_assignments
         from substanced.interfaces import IFolder
         import adhocracy_core.resources.badge
-
-        entry = {"user": "/principals/users/0000000",
+        self._tempfd, filename = mkstemp()
+        with open(filename, 'w') as f:
+            f.write(json.dumps([
+                 {"user": "/principals/users/0000000",
                  "badge": "/organisation/badges/winning/",
-                 "proposalversion": "/organisation/Winning_123/VERSION_0000001/",
-                 "proposalitem": "/organisation/Winning_123/",
+                 "badgeable": "/organisation/Winning_123/VERSION_0000001/",
                  "description" : "## Lorem ipsum"
-        }
+                }
+            ]))
         user = testing.DummyResource()
         context['principals']['users']['0000000'] = user
         badge = testing.DummyResource()
         context['organisation']['badges']['winning'] = badge
         # without the __provides__, the find_service blocks and does not return!
-        proposalitem = testing.DummyResource(__provides__=IFolder)
-        context['organisation']['Winning_123'] = proposalitem
-        proposalversion = testing.DummyResource()
-        context['organisation']['Winning_123']['VERSION_0000001'] = proposalitem
+        item = testing.DummyResource(__provides__=IFolder)
+        context['organisation']['Winning_123'] = item
+        badgeable = testing.DummyResource()
+        context['organisation']['Winning_123']['VERSION_0000001'] = badgeable
         badge_assignments_service = deepcopy(service)
         context['organisation']['Winning_123']['badge_assignments'] = badge_assignments_service
         registry = Mock()
 
-        _create_badge_assignment(entry, context, registry)
+        _import_assignments(context, registry, filename)
 
         registry.content.create.assert_called_with(
             adhocracy_core.resources.badge.IBadgeAssignment.__identifier__,
             parent=badge_assignments_service,
             appstructs={'adhocracy_core.sheets.badge.IBadgeAssignment':
-                        {'object': proposalitem,
+                        {'object': badgeable,
                          'subject': user,
                          'badge': badge},
                         'adhocracy_core.sheets.description.IDescription':
                         {'description': '## Lorem ipsum'}})
+
+    def teardown_method(self, method):
+        if hasattr(self, 'tempfd'):
+            os.close(self._tempfd)
+

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/sample_badge_assingments.json
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/scripts/sample_badge_assingments.json
@@ -1,14 +1,12 @@
 [
     {"user": "/principals/users/0000000",
      "badge": "/organisation/kiezkasse/badges/not_realizeable/",
-     "proposalversion": "/organisation/kiezkasse/Test/VERSION_0000001/",
-     "proposalitem": "/organisation/kiezkasse/Test/",
+     "badgeable": "/organisation/kiezkasse/Test/VERSION_0000001/",
      "description" : ""
     },
     {"user": "/principals/users/0000000",
      "badge": "/organisation/kiezkasse/badges/going_to_be_realized/",
-     "proposalversion": "/organisation/kiezkasse/Test2/VERSION_0000001/",
-     "proposalitem": "/organisation/kiezkasse/Test2/",
+     "badgeable": "/organisation/kiezkasse/Test2/VERSION_0000001/",
      "description" : ""
     }
 ]

--- a/src/adhocracy_mercator/adhocracy_mercator/scripts/sample_badge_assignments.json
+++ b/src/adhocracy_mercator/adhocracy_mercator/scripts/sample_badge_assignments.json
@@ -1,20 +1,17 @@
 [
     {"user": "/principals/users/0000000",
      "badge": "/mercator/badges/winning/",
-     "proposalversion": "/mercator/Winning_17235/VERSION_0000001/",
-     "proposalitem": "/mercator/Winning_17235/",
+     "badgeable": "/mercator/Wiiner_16764/VERSION_0000001/",
      "description" : "## Lorem ipsum dolor sit amet, \n consectetur adipiscing elit. Phasellus quis lectus metus, at posuere neque. Sed pharetra nibh eget orci convallis at posuere leo convallis. Sed blandit augue vitae augue scelerisque bibendum. Vivamus sit amet libero turpis, non venenatis urna. In blandit, odio convallis suscipit venenatis, ante ipsum cursus augue."
     },
     {"user": "/principals/users/0000000",
      "badge": "/mercator/badges/winning/",
-     "proposalversion": "/mercator/Winning_25974/VERSION_0000001/",
-     "proposalitem": "/mercator/Winning_25974/",
+     "badgeable": "/mercator/Winner_29475/VERSION_0000001/",
      "description" : "## Lorem ipsum dolor sit amet, \n consectetur adipiscing elit. Phasellus quis lectus metus, at posuere neque. Sed pharetra nibh eget orci convallis at posuere leo convallis. Sed blandit augue vitae augue scelerisque bibendum. Vivamus sit amet libero turpis, non venenatis urna. In blandit, odio convallis suscipit venenatis, ante ipsum cursus augue."
     },
     {"user": "/principals/users/0000000",
      "badge": "/mercator/badges/community/",
-     "proposalversion": "/mercator/Community6136/VERSION_0000001/",
-     "proposalitem": "/mercator/Community6136/",
+     "badgeable": "/mercator/Community9618/VERSION_0000001/",
      "description" : "## Lorem ipsum dolor sit amet, \n consectetur adipiscing elit. Phasellus quis lectus metus, at posuere neque. Sed pharetra nibh eget orci convallis at posuere leo convallis. Sed blandit augue vitae augue scelerisque bibendum. Vivamus sit amet libero turpis, non venenatis urna. In blandit, odio convallis suscipit venenatis, ante ipsum cursus augue."
     }
 ]


### PR DESCRIPTION
The json file format for the assign_badges script has changed.

old field names: user, badge, proposalversion, proposalitem, description
new field names: user, badge badgeable, description

migration: mv values from proposalversion to badgeable field