### PR TITLE
independed image upload directive

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -18,6 +18,7 @@ import RIDocumentVersion = require("../../Resources_/adhocracy_core/resources/do
 import RIParagraph = require("../../Resources_/adhocracy_core/resources/paragraph/IParagraph");
 import RIParagraphVersion = require("../../Resources_/adhocracy_core/resources/paragraph/IParagraphVersion");
 import SIDocument = require("../../Resources_/adhocracy_core/sheets/document/IDocument");
+import SIImageReference = require("../../Resources_/adhocracy_core/sheets/image/IImageReference");
 import SIName = require("../../Resources_/adhocracy_core/sheets/name/IName");
 import SIParagraph = require("../../Resources_/adhocracy_core/sheets/document/IParagraph");
 import SITitle = require("../../Resources_/adhocracy_core/sheets/title/ITitle");
@@ -89,7 +90,8 @@ export var bindPath = (
                         title: documentVersion.data[SITitle.nick].title,
                         paragraphs: paragraphs,
                         // FIXME: DefinitelyTyped
-                        commentCountTotal: (<any>_).sum(_.map(paragraphs, "commentCount"))
+                        commentCountTotal: (<any>_).sum(_.map(paragraphs, "commentCount")),
+                        picture: documentVersion.data[SIImageReference.nick].picture
                     };
                 });
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -220,6 +220,8 @@ export var postEdit = (
     documentVersion.data[SITitle.nick] = new SITitle.Sheet({
         title: scope.data.title
     });
+    // FIXME: workaround for a backend bug
+    documentVersion.data[SIImageReference.nick] = oldVersion.data[SIImageReference.nick];
 
     return adhHttp.deepPost(<any[]>_.flatten([documentVersion, paragraphItems, paragraphVersions]))
         .then((result) => result[0]);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -1,3 +1,5 @@
+import _ = require("lodash");
+
 import AdhConfig = require("../Config/Config");
 import AdhEmbed = require("../Embed/Embed");
 import AdhHttp = require("../Http/Http");
@@ -72,10 +74,11 @@ export var addImage = (
     imagePath : string
 ) => {
     return adhHttp.get(resourcePath).then((version) => {
-        version.data[SIImageReference.nick] = new SIImageReference.Sheet({
+        var newVersion = _.clone(version);
+        newVersion.data[SIImageReference.nick] = new SIImageReference.Sheet({
             picture: imagePath
         });
-        return adhHttp.postNewVersionNoFork(resourcePath, version);
+        return adhHttp.postNewVersionNoFork(resourcePath, newVersion);
     });
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -21,6 +21,8 @@ var pkgLocation = "/Image";
  *
  * NOTE: this uses several HTML5 APIs so you need to check for
  * compability before using it.
+ *
+ * FIXME: This should be exptended to cover a broader range of use cases.
  */
 export var uploadImageFactory = (
     adhHttp : AdhHttp.Service<any>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -1,3 +1,116 @@
+import AdhConfig = require("../Config/Config");
+import AdhEmbed = require("../Embed/Embed");
+import AdhHttp = require("../Http/Http");
+
+import RIImage = require("../../Resources_/adhocracy_core/resources/image/IImage");
+import SIHasAssetPool = require("../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool");
+import SIImageMetadata = require("../../Resources_/adhocracy_core/sheets/image/IImageMetadata");
+import SIImageReference = require("../../Resources_/adhocracy_core/sheets/image/IImageReference");
+
+var pkgLocation = "/Image";
+
+/**
+ * upload mercator proposal image file.  this function can potentially
+ * be more general; for now it just handles the Flow object and
+ * promises the path of the image resource as a string.
+ *
+ * as the a3 asset protocol is much simpler than HTML5 file upload, we
+ * compose the multi-part mime post request manually (no chunking).
+ * The $flow object is just used for meta data retrieval and cleared
+ * before it can upload anything.
+ *
+ * NOTE: this uses several HTML5 APIs so you need to check for
+ * compability before using it.
+ */
+export var uploadImageFactory = (
+    adhHttp : AdhHttp.Service<any>
+) => (
+    poolPath : string,
+    flow : Flow,
+    contentType : string = RIImage.content_type,
+    metadataSheet : string = SIImageMetadata.nick
+) : angular.IPromise<string> => {
+    if (flow.files.length !== 1) {
+        throw "could not upload file: $flow.files.length !== 1";
+    }
+    var file = flow.files[0].file;
+
+    var bytes = () : any => {
+        var func;
+        if (file.mozSlice) {
+            func = "mozSlice";
+        } else if (file.webkitSlice) {
+            func = "webkitSlice";
+        } else {
+            func = "slice";
+        }
+
+        return file[func](0, file.size, file.type);
+    };
+
+    var formData = new FormData();
+    formData.append("content_type", contentType);
+    formData.append("data:" + metadataSheet + ":mime_type", file.type);
+    formData.append("data:adhocracy_core.sheets.asset.IAssetData:data", bytes());
+
+    return adhHttp.get(poolPath)
+        .then((pool) => {
+            var postPath : string = pool.data[SIHasAssetPool.nick].asset_pool;
+            return adhHttp.postRaw(postPath, formData)
+                .then((rsp) => rsp.data.path)
+                .catch(<any>AdhHttp.logBackendError);
+        });
+};
+
+
+export var addImage = (
+    adhHttp : AdhHttp.Service<any>
+) => (
+    resourcePath : string,
+    imagePath : string
+) => {
+    return adhHttp.get(resourcePath).then((version) => {
+        var newVersion = {
+            content_type: version.content_type,
+            data: {}
+        };
+        newVersion.data[SIImageReference.nick] = new SIImageReference.Sheet({
+            picture: imagePath
+        });
+        return adhHttp.postNewVersionNoFork(resourcePath, newVersion);
+    });
+};
+
+
+export var uploadImageDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>,
+    adhUploadImage,
+    flowFactory
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Upload.html",
+        scope: {
+            poolPath: "@",
+            path: "@"
+        },
+        link: (scope) => {
+            scope.$flow = flowFactory.create();
+
+            scope.$flow.on("fileAdded", (file, event) => {
+                scope.$flow.files = [file];
+                return false;
+            });
+
+            scope.submit = () => {
+                return adhUploadImage(scope.poolPath, scope.$flow)
+                    .then((imagePath : string) => addImage(adhHttp)(scope.path, imagePath));
+            };
+        }
+    };
+};
+
 export var imageUriFilter = () => {
     return (path? : string, format : string = "detail") : string => {
         if (path) {
@@ -13,6 +126,14 @@ export var moduleName = "adhImage";
 
 export var register = (angular) => {
     angular
-        .module(moduleName, [])
+        .module(moduleName, [
+            AdhEmbed.moduleName,
+            AdhHttp.moduleName
+        ])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider.embeddableDirectives.push("upload-image");
+        }])
+        .factory("adhUploadImage", ["adhHttp", uploadImageFactory])
+        .directive("adhUploadImage", ["adhConfig", "adhHttp", "adhUploadImage", "flowFactory", uploadImageDirective])
         .filter("adhImageUri", imageUriFilter);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -70,14 +70,10 @@ export var addImage = (
     imagePath : string
 ) => {
     return adhHttp.get(resourcePath).then((version) => {
-        var newVersion = {
-            content_type: version.content_type,
-            data: {}
-        };
-        newVersion.data[SIImageReference.nick] = new SIImageReference.Sheet({
+        version.data[SIImageReference.nick] = new SIImageReference.Sheet({
             picture: imagePath
         });
-        return adhHttp.postNewVersionNoFork(resourcePath, newVersion);
+        return adhHttp.postNewVersionNoFork(resourcePath, version);
     });
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -12,7 +12,7 @@ import SIImageReference = require("../../Resources_/adhocracy_core/sheets/image/
 var pkgLocation = "/Image";
 
 /**
- * upload mercator proposal image file.  this function can potentially
+ * upload image file.  this function can potentially
  * be more general; for now it just handles the Flow object and
  * promises the path of the image resource as a string.
  *

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,0 +1,20 @@
+<form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support">
+    <span class="label-text">{{ "TR__IMAGE_UPLOAD" | translate }}</span>
+    <div
+        data-flow-init=""
+        data-flow-object="$flow">
+        <span
+            class="button m-call-to-action-secondary"
+            data-flow-btn=""
+            data-flow-attrs="{accept:'image/*'}">
+            <span data-ng-if="$flow.files.length > 0">{{ "TR__IMAGE_CHANGE" | translate }}</span>
+            <span data-ng-if="!$flow.files.length || $flow.files.length === 0">{{ "TR__IMAGE_CHOOSE" | translate }}</span>
+        </span>
+        <div data-ng-repeat="file in $flow.files">
+            <img data-flow-img="file" height="120" alt="{{ 'TR__IMAGE_SELECTED' | translate }}" /><br/>{{file.name}}
+        </div>
+        <div class="form-footer">
+            <input type="submit" />
+        </div>
+    </div>
+</form>

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -87,6 +87,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         "duScroll",
         "flow",
         "angular-data.DSCacheFactory",
+        AdhImage.moduleName,
         AdhComment.moduleName,
         AdhDone.moduleName,
         AdhCrossWindowMessaging.moduleName,


### PR DESCRIPTION
This duplicates some code from `MercatorProposal.ts` for uploading images. My first idea was to do a proper abstraction and refactor the mercator specific code. Unfortunately I did not have the time to finish this yet.

This part already implements a widget that can be used to upload an image and reference it from any compatible resource (one that has the `IVersionable` and `IImageReference` sheets). It can be used via the embed area.

Note that for some reason there are permission errors when trying to access an uploaded image. @joka can you please have a look?