### PR TITLE
Fix: Email subject shall not contain newlines

### DIFF
--- a/src/adhocracy_core/adhocracy_core/messaging/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/messaging/__init__.py
@@ -234,7 +234,8 @@ class Messenger:
                         mapping=mapping,
                         default='Invitation to join ${site_name}')
         else:
-            subject = render(subject_tmpl, mapping)
+            # remove potential newline, as it causes invalid headers
+            subject = render(subject_tmpl, mapping).rstrip()
         if body_tmpl is None:
             body = _('mail_invitation_body_txt',
                      mapping=mapping,


### PR DESCRIPTION
However files in POSIX typically end with newlines (because each *line*
has to end with a newline character).