### PR TITLE
Refactor REST permissions check

### DIFF
--- a/src/adhocracy_core/adhocracy_core/content/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/content/test_init.py
@@ -213,11 +213,10 @@ class TestResourceContentRegistry:
         effective_principals = ['authenticated']
         mock_authpolicy.effective_principals.return_value = effective_principals
         mock_authpolicy.permits.return_value = True
-        result = inst.get_resources_meta_addable(item, request_)
+        assert inst.get_resources_meta_addable(item, request_) == [version_meta]
         mock_authpolicy.permits.assert_called_once_with(item,
                                                         effective_principals,
                                                         'create_xyz')
-        assert result == [version_meta]
 
     def test_get_resources_meta_addable_only_first_version_exists_no_permission(
             self, inst, item, config, request_, resource_meta, mock_authpolicy):
@@ -234,11 +233,10 @@ class TestResourceContentRegistry:
         effective_principals = ['authenticated']
         mock_authpolicy.effective_principals.return_value = effective_principals
         mock_authpolicy.permits.return_value = False
-        result = inst.get_resources_meta_addable(item, request_)
+        assert inst.get_resources_meta_addable(item, request_) == []
         mock_authpolicy.permits.assert_called_once_with(item,
                                                         effective_principals,
                                                         'create_xyz')
-        assert result == []
 
     def test_permissions_resource_permission_create_defined(
             self, inst, resource_meta, mock_registry):

--- a/src/adhocracy_core/adhocracy_core/content/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/content/test_init.py
@@ -59,6 +59,15 @@ class TestResourceContentRegistry:
         registry.introspector.get_category.return_value = []
         return registry
 
+    @fixture
+    def mock_authpolicy(self, registry):
+        from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.interfaces import IAuthorizationPolicy
+        policy = Mock()
+        registry.registerUtility(policy, IAuthenticationPolicy)
+        registry.registerUtility(policy, IAuthorizationPolicy)
+        return policy
+
     def make_one(self, registry):
         from adhocracy_core.content import ResourceContentRegistry
         return ResourceContentRegistry(registry)
@@ -189,16 +198,47 @@ class TestResourceContentRegistry:
         config.testing_securitypolicy(userid='hank', permissive=False)
         assert inst.get_resources_meta_addable(context, request_) == []
 
-    def test_get_resources_meta_addable_no_permission_but_only_first_version_exists(
-            self, inst, item, config, request_, resource_meta):
+    def test_get_resources_meta_addable_only_first_version_exists_has_permission(
+            self, inst, item, config, request_, resource_meta, mock_authpolicy):
         from adhocracy_core.interfaces import IItem
         from adhocracy_core.interfaces import IItemVersion
         version0 = testing.DummyResource(__provides__=IItemVersion)
         item['VERSION_0000000'] = version0
-        version_meta = resource_meta._replace(iresource=IItemVersion)
+        item_meta = resource_meta._replace(iresource=IItem,
+                                           permission_create='create_xyz')
+        version_meta = resource_meta._replace(iresource=IItemVersion,
+                                               permission_create='edit_xyz')
+        inst.resources_meta = {IItem: item_meta}
         inst.resources_meta_addable = {IItem: [version_meta]}
-        config.testing_securitypolicy(userid='hank', permissive=False)
-        assert inst.get_resources_meta_addable(item, request_) == [version_meta]
+        effective_principals = ['authenticated']
+        mock_authpolicy.effective_principals.return_value = effective_principals
+        mock_authpolicy.permits.return_value = True
+        result = inst.get_resources_meta_addable(item, request_)
+        mock_authpolicy.permits.assert_called_once_with(item,
+                                                        effective_principals,
+                                                        'create_xyz')
+        assert result == [version_meta]
+
+    def test_get_resources_meta_addable_only_first_version_exists_no_permission(
+            self, inst, item, config, request_, resource_meta, mock_authpolicy):
+        from adhocracy_core.interfaces import IItem
+        from adhocracy_core.interfaces import IItemVersion
+        version0 = testing.DummyResource(__provides__=IItemVersion)
+        item['VERSION_0000000'] = version0
+        item_meta = resource_meta._replace(iresource=IItem,
+                                           permission_create='create_xyz')
+        version_meta = resource_meta._replace(iresource=IItemVersion,
+                                               permission_create='edit_xyz')
+        inst.resources_meta = {IItem: item_meta}
+        inst.resources_meta_addable = {IItem: [version_meta]}
+        effective_principals = ['authenticated']
+        mock_authpolicy.effective_principals.return_value = effective_principals
+        mock_authpolicy.permits.return_value = False
+        result = inst.get_resources_meta_addable(item, request_)
+        mock_authpolicy.permits.assert_called_once_with(item,
+                                                        effective_principals,
+                                                        'create_xyz')
+        assert result == []
 
     def test_permissions_resource_permission_create_defined(
             self, inst, resource_meta, mock_registry):


### PR DESCRIPTION
When only the version zero of an ItemVersion exists, check the
permission for adding version one with the permission of the
Item (parent), not the one from the ItemVersion. This allows a more
intuitive definition of permissions.