### PR TITLE
change wording on top of user space

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -88,7 +88,7 @@
     "TR__MESSAGE_SEND": "senden",
     "TR__MESSAGE_STATUS_OK": "Die Nachricht wurde versendet.",
     "TR__MESSAGE_TO": "Nachricht an",
-    "TR__MESSAGING": "Benachrichtigungen",
+    "TR__MESSAGING": "Nachricht verfassen",
     "TR__NEWSLETTER": "Newsletter",
     "TR__NEW_PASSWORD": "Neues Passwort",
     "TR__NEXT": "weiter",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -90,7 +90,7 @@
     "TR__MESSAGE_SEND": "send",
     "TR__MESSAGE_STATUS_OK": "Message was sent",
     "TR__MESSAGE_TO": "Message to",
-    "TR__MESSAGING": "messaging",
+    "TR__MESSAGING": "Write Message",
     "TR__NEWSLETTER": "newsletter",
     "TR__NEW_PASSWORD": "New Password",
     "TR__NEXT": "next",


### PR DESCRIPTION
This fixes an issue in spd and all the other projects. On top of the user page it now says 'Nachricht schreiben' bzw 'Write Message' instead of 'Benachrichtigungen' bzw 'Messages'