### PR TITLE
Adding pre-wrap styles to user ediable text

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
@@ -11,10 +11,12 @@ export var parseMarkdown = (adhConfig : AdhConfig.IService, markdownit) => {
         restrict: "E",
         link: (scope, element) => {
             var md = new markdownit();
+            var mdEl = angular.element("<div class=\"markdown-rendered\"></div>");
 
             scope.$watch("parsetext", (newValue) => {
-                element.children().remove();
-                element.append(md.render(newValue));
+                mdEl.remove();
+                mdEl.append(md.render(newValue));
+                element.append(mdEl);
             });
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Markdown/Markdown.ts
@@ -14,7 +14,10 @@ export var parseMarkdown = (adhConfig : AdhConfig.IService, markdownit) => {
             var mdEl = angular.element("<div class=\"markdown-rendered\"></div>");
 
             scope.$watch("parsetext", (newValue) => {
-                mdEl.remove();
+                var mdElPrev = angular.element(element[0].querySelector(".markdown-rendered"));
+                if (mdElPrev) {
+                    mdElPrev.remove();
+                }
                 mdEl.append(md.render(newValue));
                 element.append(mdEl);
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -74,6 +74,10 @@ is selected, no state is applied.
 .comment-content {
     line-height: 1.15;
     white-space: pre-line;
+
+    .markdown-rendered {
+        white-space: normal;
+    }
 }
 
 .comment-children-create-form,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -73,6 +73,7 @@ is selected, no state is applied.
 
 .comment-content {
     line-height: 1.15;
+    white-space: pre-line;
 }
 
 .comment-children-create-form,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_commentable_section.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_commentable_section.scss
@@ -64,6 +64,10 @@ States:
         margin-bottom: 0;
     }
 
+    p {
+        white-space: pre-line;
+    }
+
     &.is-not-selected {
         background: $color-background-base-introvert;
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_commentable_section.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_commentable_section.scss
@@ -68,6 +68,12 @@ States:
         white-space: pre-line;
     }
 
+    .markdown-rendered {
+        p {
+            white-space: normal;
+        }
+    }
+
     &.is-not-selected {
         background: $color-background-base-introvert;
     }


### PR DESCRIPTION
Fixes lack of text-wrapping in user entered sections. Tested in mercator, SPD & MeinBerlin