### PR TITLE
Added home link to activation success message

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -1,5 +1,5 @@
 {
-    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Danke für Deine Registrierung. Dein Account ist nun aktiviert. Du kannst diese Seite schließen und zurück gehen zu {{siteName}}.",
+    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Danke für Deine Registrierung. Dein Account ist nun aktiviert. Du kannst diese Seite schließen und zurück gehen zu [[link:{{siteName}}]].",
     "TR__ACTIVATION_ERROR_1": "Wir werden Dir innerhalb der nächsten 24 Stunden einen neuen Link zur Authentifizierung zusenden. Bitte überprüfe Deine E-Mails und schaue auch im Spam-Ordner nach.",
     "TR__ACTIVATION_ERROR_2": "Bitte entschuldige die Schwierigkeiten und aktiviere Deinen Account innerhalb der nächsten 6 Tage.",
     "TR__ACTIVATION_ERROR_3": "Danke!",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -1,5 +1,6 @@
 {
     "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Danke für Deine Registrierung. Dein Account ist nun aktiviert. Du kannst diese Seite schließen und zurück gehen zu [[link:{{siteName}}]].",
+    "TR__ACTIVATION_SUCCESS_GO_HOME": "Vielen Dank für Deine Registrierung. Dein Account wurde aktiviert. Du kannst nun zurück auf die Seite [[link:{{siteName}}]] gehen.",
     "TR__ACTIVATION_ERROR_1": "Wir werden Dir innerhalb der nächsten 24 Stunden einen neuen Link zur Authentifizierung zusenden. Bitte überprüfe Deine E-Mails und schaue auch im Spam-Ordner nach.",
     "TR__ACTIVATION_ERROR_2": "Bitte entschuldige die Schwierigkeiten und aktiviere Deinen Account innerhalb der nächsten 6 Tage.",
     "TR__ACTIVATION_ERROR_3": "Danke!",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -1,5 +1,6 @@
 {
     "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Thank you for your registration. Your account has been activated. You can now close this tab and go back to [[link:{{siteName}}]].",
+    "TR__ACTIVATION_SUCCESS_GO_HOME": "Thank you for your registration. Your account has been activated. You may now proceed to [[link:{{siteName}}]].",
     "TR__ACTIVATION_ERROR_1": "We will send you a new authentification link within the next 24h. Please check your mail and SPAM meanwhile.",
     "TR__ACTIVATION_ERROR_2": "Please excuse the inconvience and make sure you activate your account within the next 6 days.",
     "TR__ACTIVATION_ERROR_3": "Thanks!",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -1,5 +1,5 @@
 {
-    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Thank you for your registration. Your account has been activated. You can now close this tab and go back to {{siteName}}.",
+    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Thank you for your registration. Your account has been activated. You can now close this tab and go back to [[link:{{siteName}}]].",
     "TR__ACTIVATION_ERROR_1": "We will send you a new authentification link within the next 24h. Please check your mail and SPAM meanwhile.",
     "TR__ACTIVATION_ERROR_2": "Please excuse the inconvience and make sure you activate your account within the next 6 days.",
     "TR__ACTIVATION_ERROR_3": "Thanks!",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/templates/Activation.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/templates/Activation.html
@@ -2,7 +2,9 @@
     <div data-ng-if="ready">
         <div data-ng-if="success">
             <h1 class="standalone-wrapper-title">{{ "TR__ACTIVATION_SUCCESS_TITLE" | translate }}</h1>
-            <p>{{ "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED" | translate:{siteName: siteName} }}</p>
+            <p data-adh-html-translate="TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED" data-translate-values="{siteName: siteName}" data-translate-templates="{
+            link: '&lt;a href=&quot;/&quot;&gt;{{ content }}&lt;/a&gt;'
+        }"></p>
         </div>
         <div data-ng-if="!success">
             <h1 class="standalone-wrapper-title">{{ "TR__ACTIVATION_ERROR_TITLE" | translate }}</h1>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/templates/Activation.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/templates/Activation.html
@@ -2,7 +2,7 @@
     <div data-ng-if="ready">
         <div data-ng-if="success">
             <h1 class="standalone-wrapper-title">{{ "TR__ACTIVATION_SUCCESS_TITLE" | translate }}</h1>
-            <p data-adh-html-translate="TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED" data-translate-values="{siteName: siteName}" data-translate-templates="{
+            <p data-adh-html-translate="TR__ACTIVATION_SUCCESS_GO_HOME" data-translate-values="{siteName: siteName}" data-translate-templates="{
             link: '&lt;a href=&quot;/&quot;&gt;{{ content }}&lt;/a&gt;'
         }"></p>
         </div>

--- a/src/meinberlin/meinberlin/static/i18n/core_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/core_de.json
@@ -1,5 +1,5 @@
 {
-    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Danke für Ihre Registrierung. Ihr Account ist nun aktiviert. Sie können diese Seite schließen und zurück gehen zu {{siteName}}.",
+    "TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED": "Danke für Ihre Registrierung. Ihr Account ist nun aktiviert. Sie können diese Seite schließen und zurück gehen zu [[link:{{siteName}}]].",
     "TR__ACTIVATION_ERROR_1": "Wir werden Ihnen innerhalb der nächsten 24 Stunden einen neuen Link zur Authentifizierung zusenden. Bitte überprüfen Sie Ihre E-Mails und schauen Sie auch im Spam-Ordner nach.",
     "TR__ACTIVATION_ERROR_2": "Bitte entschuldigen Sie die Schwierigkeiten und aktivieren Sie Ihren Account innerhalb der nächsten 6 Tage.",
     "TR__ACTIVATION_ERROR_3": "Danke!",


### PR DESCRIPTION
OK so the functionality for this is working, the trouble is the translation key is ```TR__ACTIVATION_CLOSE_THIS_TAB_AND_PROCEED``` and I guess they don't need to close this tab any more? 
![download 3](https://cloud.githubusercontent.com/assets/701632/8594510/ab4d81d2-2641-11e5-8504-cd52ee52d433.png) so not only should the key name change but the translation should be altered. who is responsible for this ? @nidico ?

I just used a / link to link to the homepage as ```adhTopLevelState.redirectToSpaceHome("content")``` fails (exceeded stack call) as it's outside of resource area, this is in a FIXME in the function.