### PR TITLE
Fix: Allow to update documents without image (fixes #1397)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -251,7 +251,10 @@ export var postEdit = (
         title: scope.data.title
     });
     // FIXME: workaround for a backend bug
-    documentVersion.data[SIImageReference.nick] = oldVersion.data[SIImageReference.nick];
+    var oldImageReferenceSheet = oldVersion.data[SIImageReference.nick];
+    if (oldImageReferenceSheet.picture) {
+        documentVersion.data[SIImageReference.nick] = oldImageReferenceSheet;
+    }
 
     return adhHttp.deepPost(<any[]>_.flatten([documentVersion, paragraphItems, paragraphVersions]))
         .then((result) => result[0]);


### PR DESCRIPTION
This works around a backend bug, addendum to
077c4398d0a5fd844668451f57fc9ec0f268245b

If the image reference was null and we *do* set the sheet, the backend
complains:

> This Resource does not provide interface
adhocracy_core.sheets.image.IImageMetadata