### PR TITLE
Fixed white background hover

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_button.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_button.scss
@@ -116,4 +116,9 @@ input[type="button"] {
             background-color: $color-brand-two-introvert;
         }
     }
+
+    &.m-call-to-action-secondary {
+        background-color: transparent;
+        color: $color-text-highlight-normal;
+    }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_button.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_button.scss
@@ -12,16 +12,6 @@
     }
 }
 
-@mixin button-color($fg, $bg) {
-    color: $fg;
-    background-color: $bg;
-
-    &.m-call-to-action {
-        color: $bg;
-        background-color: $fg;
-    }
-}
-
 /*doc
 ---
 title: button
@@ -98,27 +88,28 @@ input[type="button"] {
 
     &:focus:not(:disabled):not(.ng-disabled),
     &:hover:not(:disabled):not(.ng-disabled) {
-        @include button-color($color-brand-two-normal, $color-text-inverted);
+        color: $color-text-highlight-normal;
     }
 
     &:disabled,
     &.ng-disabled {
         &, &:focus, &:hover {
             @include opacity(0.5);
-            background: transparent;
             cursor: default;
         }
     }
 
     &.m-call-to-action,
     &.m-call-to-action-secondary {
-        @include button-color($color-brand-two-normal, $color-text-inverted);
+        background: $color-text-highlight-normal;
+        color: $color-text-inverted;
         padding: 0 1em;
         min-width: 110px / $font-size-normal * 1em;
 
         &:hover:not(:disabled):not(.ng-disabled),
         &:focus:not(:disabled):not(.ng-disabled) {
             background: $color-brand-two-extrovert;
+            color: $color-text-inverted;
         }
 
         &:active:not(:disabled):not(.ng-disabled) {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
@@ -43,6 +43,7 @@ input[type="button"] {
 
         &.m-call-to-action,
         &.m-call-to-action-secondary {
+            color: $color-text-inverted;
             height: 24px / $font-size-normal * 1em;
             line-height: 24px / $font-size-normal * 1em;
             font-size: $font-size-normal;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
@@ -41,16 +41,10 @@ input[type="button"] {
             color: $color-shadow;
         }
 
-        &.m-call-to-action,
-        &.m-call-to-action-secondary {
-            color: $color-text-inverted;
-            height: 24px / $font-size-normal * 1em;
-            line-height: 24px / $font-size-normal * 1em;
-            font-size: $font-size-normal;
-        }
-
         &.m-call-to-action {
             @include border-radius(1em);
+            color: $color-text-inverted;
+            font-size: $font-size-normal;
             font-weight: $font-weight-extrovert;
 
             &:hover:not(:disabled):not(.ng-disabled),
@@ -72,6 +66,7 @@ input[type="button"] {
             &:hover:not(:disabled):not(.ng-disabled),
             &:focus:not(:disabled):not(.ng-disabled) {
                 background: transparent;
+                color: $color-text-normal;
                 text-decoration: underline;
             }
         }
@@ -97,6 +92,25 @@ input[type="button"] {
         }
     }
 }
+
+/*doc
+---
+title: Call to action button index of moving column or embed
+name: button.m-call-to-action.inside
+parent: button
+---
+
+For Mein Berlin CTA buttons inside of the moving columns or embed contexr appear square
+
+```html_example
+<div class="l-center m-embed">
+<a class="button m-call-to-action">Link</a>
+<button type="button" class="m-call-to-action">Button</button>
+<input type="submit" class="m-call-to-action" value="Disabled" disabled="disabled" />
+</div>
+```
+
+*/
 
 .moving-column-body, .l-center.m-embed {
     button,

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
@@ -100,7 +100,7 @@ name: button.m-call-to-action.inside
 parent: button
 ---
 
-For Mein Berlin CTA buttons inside of the moving columns or embed contexr appear square
+For Mein Berlin CTA buttons inside of the moving columns or embed context appear square
 
 ```html_example
 <div class="l-center m-embed">

--- a/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
@@ -11,7 +11,6 @@ input[type="button"] {
     }
 
     &.m-call-to-action-secondary {
-        background: $color-background-base;
         border: 2px solid $color-brand-two-normal;
         color: $color-brand-two-normal;
 

--- a/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
@@ -6,19 +6,20 @@ input[type="button"] {
     height: 36px / $font-size-normal * 1em;
     line-height: 36px / $font-size-normal * 1em;
 
+    &.m-call-to-action {
+        background: $color-brand-two-normal;
+    }
+
     &.m-call-to-action-secondary {
+        background: $color-background-base;
         border: 2px solid $color-brand-two-normal;
+        color: $color-brand-two-normal;
 
         &:hover:not(:disabled):not(.ng-disabled),
         &:focus:not(:disabled):not(.ng-disabled) {
             background: $color-brand-two-normal;
             color: $color-text-inverted;
         }
-    }
-
-    &:hover:not(:disabled):not(.ng-disabled),
-    &:focus:not(:disabled):not(.ng-disabled) {
-        background: transparent;
     }
 
     &.m-add:before {

--- a/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_button_theme.scss
@@ -16,6 +16,11 @@ input[type="button"] {
         }
     }
 
+    &:hover:not(:disabled):not(.ng-disabled),
+    &:focus:not(:disabled):not(.ng-disabled) {
+        background: transparent;
+    }
+
     &.m-add:before {
         content: "+ ";
     }


### PR DESCRIPTION
Continued from #1423 which I had to revert. There is call for this to be a core change but as we use this mixin
```
@mixin button-color($fg, $bg) {
    color: $fg;
    background-color: $bg;

    &.m-call-to-action {
        color: $bg;
        background-color: $fg;
    }
}
```
You see the FG and BG are reversed for m-call-to-action meaning the font-color would become transparent. I think this mixin is pretty redundant but as it's in core I'd like to sit down and look at it properly before making a core change. Keeping this to just an SPD change for now, will revisit soon.