### PR TITLE
Fix: modifications with attribute storage sheets are not persistent

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -143,7 +143,6 @@ def set_acms_for_app_root(app: Router, acms: (dict)=()):
 def set_acl(resource: IResource, acl: list, registry=None) -> bool:
     """Set the acl and mark the resource as dirty."""
     substanced.util.set_acl(resource, acl, registry)
-    resource._p_changed = True
 
 
 def set_god_all_permissions(resource: IResource, registry=None) -> bool:

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -287,7 +287,9 @@ def test_set_acl_set_changes_acl():
 def test_set_acl_set_resource_dirty():
     from . import set_acl
     from pyramid.security import Deny
-    resource = testing.DummyResource()
+    from persistent.mapping import PersistentMapping
+    resource = PersistentMapping()
+    resource._p_jar = Mock()  # make _p_changed property work
     set_acl(resource, [(Deny, 'role:creator', 'edit_comment')])
     assert resource._p_changed is True
 

--- a/src/adhocracy_core/adhocracy_core/scripts/import_groups.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/import_groups.py
@@ -62,8 +62,6 @@ def _update_group(group_info: dict, groups: IResource):
     group = groups[group_info['name']]
     group_sheet = get_sheet(group, adhocracy_core.sheets.principal.IGroup)
     group_sheet.set({'roles': group_info['roles']})
-    # mark resource as dirty otherwise commit does nothing?!
-    group._p_changed = True
 
 
 def _create_group(group_info: dict, registry: Registry, groups: IResource):

--- a/src/adhocracy_core/adhocracy_core/scripts/import_local_roles.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/import_local_roles.py
@@ -42,11 +42,11 @@ def _import_local_roles(context: IResource, registry: Registry, filename: str):
     transaction.commit()
 
 
-def _set_local_roles(local_roles_info: dict, context: IResource, registry: Registry):
+def _set_local_roles(local_roles_info: dict, context: IResource,
+                     registry: Registry):
     resource = find_resource(context, local_roles_info['path'])
     local_roles_info['roles'] = _deserialize_roles(local_roles_info['roles'])
     set_local_roles(resource, local_roles_info['roles'])
-    resource._p_changed = True
 
 
 def _deserialize_roles(roles: dict) -> dict:

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -280,6 +280,18 @@ class AttributeResourceSheet(BaseResourceSheet):
     def _data(self):
         return self.context.__dict__
 
+    def _store_data(self, appstruct):
+        """Might be overridden in subclasses."""
+        for key in self._fields['data']:
+            if key in appstruct:
+                setattr(self.context, key, appstruct[key])
+
+    def delete_field_values(self, fields: [str]):
+        """Delete value for every field name in `fields`."""
+        for key in fields:
+            if hasattr(self.context, key):
+                delattr(self.context, key)
+
 
 sheet_meta = SheetMetadata(isheet=ISheet,
                            sheet_class=AnnotationRessourceSheet,

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -115,30 +115,30 @@ class TestBaseResourceSheet:
         with raises(ValueError):
             inst.get({'WRONG': 100})
 
-    def test_set_valid(self, inst):
+    def test_set(self, inst):
         assert inst.set({'count': 11}) is True
         assert inst.get() == {'count': 11}
 
-    def test_set_valid_empty(self, inst):
+    def test_set_empty(self, inst):
         assert inst.set({}) is False
         assert inst.get() == {'count': 0}
 
-    def test_set_valid_omit_str(self, inst):
+    def test_set_omit_str(self, inst):
         assert inst.set({'count': 11}, omit='count') is False
 
-    def test_set_valid_omit_tuple(self, inst):
+    def test_set_omit_tuple(self, inst):
         assert inst.set({'count': 11}, omit=('count',)) is False
 
-    def test_set_valid_omit_wrong_key(self, inst):
+    def test_set_omit_wrong_key(self, inst):
         assert inst.set({'count': 11}, omit=('wrongkey',)) is True
 
-    def test_set_valid_omit_readonly(self, inst):
+    def test_set_omit_readonly(self, inst):
         inst.schema['count'].readonly = True
         inst.set({'count': 11})
         assert inst.get() == {'count': 0}
 
-    def test_set_valid_references(self, inst, context, mock_graph,
-                                  mock_node_unique_references, registry):
+    def test_set_references(self, inst, context, mock_graph,
+                            mock_node_unique_references, registry):
         from adhocracy_core.interfaces import ISheet
         node = mock_node_unique_references
         inst.schema.children.append(node)
@@ -186,8 +186,8 @@ class TestBaseResourceSheet:
         assert not sheet_catalogs.search.called
         assert appstruct['references'] == []
 
-    def test_set_valid_reference(self, inst, context, mock_graph,
-                                 mock_node_single_reference, registry):
+    def test_set_reference(self, inst, context, mock_graph,
+                           mock_node_single_reference, registry):
         from adhocracy_core.interfaces import ISheet
         node = mock_node_single_reference
         inst.schema.children.append(node)
@@ -197,8 +197,8 @@ class TestBaseResourceSheet:
         graph_set_args = mock_graph.set_references_for_isheet.call_args[0]
         assert graph_set_args == (context, ISheet, {'reference': target}, registry)
 
-    def test_get_valid_reference(self, inst, context, sheet_catalogs,
-                                 mock_node_single_reference):
+    def test_get_reference(self, inst, context, sheet_catalogs,
+                           mock_node_single_reference):
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import search_result
         from adhocracy_core.interfaces import search_query
@@ -218,8 +218,8 @@ class TestBaseResourceSheet:
         sheet_catalogs.search.call_args[0] == query
         assert appstruct['reference'] == target
 
-    def test_get_valid_back_reference(self, inst, context, sheet_catalogs,
-                                      mock_node_single_reference):
+    def test_get_back_reference(self, inst, context, sheet_catalogs,
+                                mock_node_single_reference):
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import search_result
         from adhocracy_core.interfaces import Reference
@@ -285,12 +285,12 @@ class TestBaseResourceSheet:
         cstruct = inst.get_cstruct(request_)
         assert 'only_visible' not in inst.get.call_args[1]['params']
 
-    def test_delete_field_values_ignore_if_wrong_field(self, inst):
+    def test_delete_field_values(self, inst):
         inst._data['count'] = 2
         inst.delete_field_values(['count'])
         assert 'count' not in inst._data
 
-    def test_delete_field_values(self, inst):
+    def test_delete_field_values_ignore_if_wrong_field(self, inst):
         inst._data['count'] = 2
         inst.delete_field_values(['wrong'])
         assert 'count' in inst._data
@@ -318,7 +318,7 @@ class TestAnnotationRessourceSheet:
         assert IResourceSheet.providedBy(inst)
         assert verifyObject(IResourceSheet, inst)
 
-    def test_set_valid_with_other_sheet_name_conflicts(self, inst, sheet_meta,
+    def test_set_with_other_sheet_name_conflicts(self, inst, sheet_meta,
                                                        context):
         from adhocracy_core.interfaces import ISheet
 
@@ -340,7 +340,7 @@ class TestAnnotationRessourceSheet:
         assert inst.get() == {'count': 1}
         assert inst_b.get() == {'count': 2}
 
-    def test_set_valid_with_subtype_and_name_conflicts(self, inst,  sheet_meta,
+    def test_set_with_subtype_and_name_conflicts(self, inst,  sheet_meta,
                                                        context):
         class ISheetB(sheet_meta.isheet):
             pass

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -390,7 +390,6 @@ class TestAttributeResourceSheet:
 
     def test_set_and_add_dirty_flag_for_persistent_context(self, inst):
         from persistent.mapping import PersistentMapping
-        import ipdb;ipdb.set_trace()
         inst.context = PersistentMapping()
         inst.context._p_jar = Mock()
         inst.set({'count': 2})


### PR DESCRIPTION
All modifications with the following sheets have not been persistent.
Modifications by import scripts are not related. 

The following sheets are affected: 

- IGroup (used only by import scripts)
- IMetadata (visibility change by evolutions scripts?,  
                    wrong modification date !!
                   )
- IUserBasic (used only by import scripts)
- IUserExtendended ( used only by import scripts)
- IPermissions (not used)


