### PR TITLE
Fix reset password acceptance test for spd installation

### DIFF
--- a/src/adhocracy_core/adhocracy_core/locale/en/LC_MESSAGES/adhocracy.po
+++ b/src/adhocracy_core/adhocracy_core/locale/en/LC_MESSAGES/adhocracy.po
@@ -97,7 +97,7 @@ msgstr ""
 "\n"
 "Dein \"${site_name}\"-Team"
 
-#. Default: ${site_name}: Reset Password / Password neu setzen
+#. Default: ${site_name}: Reset Password / Passwort neu setzen
 #: src/adhocracy_core/adhocracy_core/messaging/__init__.py:199
 msgid "mail_reset_password_subject"
 msgstr "mail_reset_password_subject"

--- a/src/adhocracy_core/adhocracy_core/messaging/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/messaging/__init__.py
@@ -198,7 +198,7 @@ class Messenger:
                    }
         subject = _('mail_reset_password_subject',
                     mapping=mapping,
-                    default='${site_name}: Reset Password / Password neu'
+                    default='${site_name}: Reset Password / Passwort neu'
                             ' setzen')
         body = _('mail_reset_password_body_txt',
                  mapping=mapping,

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
@@ -97,9 +97,9 @@ describe("user password reset", function() {
 
             shared.parseEmail(mailpath, function(mail) {
                 // console.log('email=', mail);
-                expect(mail.subject).toContain("Reset Password");
+                expect(mail.subject).toContain("Passwor");
                 expect(mail.to[0].address).toContain("participant");
-                resetUrl = mail.text.split("\n\n")[4];
+                resetUrl = _.find(mail.text.split("\n"), function(line) {return _.startsWith(line, "http");});
             });
         });
 

--- a/src/adhocracy_spd/adhocracy_spd/locale/en/LC_MESSAGES/adhocracy.po
+++ b/src/adhocracy_spd/adhocracy_spd/locale/en/LC_MESSAGES/adhocracy.po
@@ -63,10 +63,10 @@ msgstr ""
 "\n"
 "Das #digitalLEBEN-Team"
 
-#. Default: ${site_name}: Reset Password / Password neu setzen
+#. Default: ${site_name}: Reset Password / Passwort neu setzen
 #: src/adhocracy_core/adhocracy_core/messaging/__init__.py:199
 msgid "mail_reset_password_subject"
-msgstr "Debatte - #digitalLEBEN:  Password neu setzen"
+msgstr "Debatte - #digitalLEBEN:  Passwort neu setzen"
 
 #. Default: ${reset_url}
 #: src/adhocracy_core/adhocracy_core/messaging/__init__.py:203
@@ -80,7 +80,7 @@ msgstr ""
 "\n"
 "Das #digitalLEBEN-Team"
 
-#. Default: ${site_name}: Reset Password / Password neu setzen
+#. Default: ${site_name}: Reset Password / Passwort neu setzen
 #: src/adhocracy_core/adhocracy_core/messaging/__init__.py:232
 #, fuzzy
 msgid "mail_invitation_subject"


### PR DESCRIPTION
As proposed in #1429, this should fix the reset password acceptance test also for the spd installation.

All acceptance tests are supposed to pass now...