### PR TITLE
invalidate cache on login

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Credentials.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Credentials.ts
@@ -88,6 +88,10 @@ export class Service {
     }
 
     private enableToken(token : string, userPath : string) : void {
+        if (this.token !== token) {
+            this.adhCache.invalidateAll();
+        }
+
         this.token = token;
         this.userPath = userPath;
         this.loggedIn = true;


### PR DESCRIPTION
the frontend cache was completely purged on logout. However, it was not purged on login. This meant that after logging in, cached responses to OPTIONS requests would be reused. We noticed that on the example of blog posts.