### PR TITLE
2015 07 mn allow owners to delete

### DIFF
--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -6,6 +6,10 @@ Two boolean fields (flags) defined in the
 hide resources: *deleted* and *hidden*. Both default to false. If this sheet
 is omitted when POSTing new resources, the default values are used.
 
+The usecase for deleting is that users want to withdraw some content.
+The usecase for hiding is that moderators want to hide unapproriate
+content.  In terms of implementation, they differ only by permissions.
+
 Deleting or hiding an existing resource is only possible for updatable
 resources, i.e. *not* for Versions (which are immutable and hence don't
 allow PUT).

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -248,6 +248,18 @@ export class Service<Content extends ResourcesBase.Resource> {
         return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
     }
 
+    public delete(path : string, contentType : string, config : IHttpConfig = {}) : angular.IPromise<any> {
+        var obj = {
+            content_type: contentType,
+            data: {}
+        };
+        obj.data[SIMetadata.nick] = {
+            deleted: true
+        };
+
+        return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
+    }
+
     public postRaw(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<any> {
         var _self = this;
 

--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -81,10 +81,10 @@ export var detailDirective = (
             adhPermissions.bindScope(scope, () => scope.path);
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.path), "itemOptions");
 
-            scope.hide = () => {
+            scope.delete = () => {
                 if ($window.confirm("Do you really want to delete this?")) {
                     var itemPath = AdhUtil.parentPath(scope.path);
-                    adhHttp.hide(itemPath, RIDocument.content_type)
+                    adhHttp.delete(itemPath, RIDocument.content_type)
                         .then(() => {
                             if (typeof scope.onChange !== "undefined") {
                                 scope.onChange();

--- a/src/mercator/mercator/static/js/Packages/Blog/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Blog/Detail.html
@@ -5,7 +5,7 @@
             <h1 class="blog-post-title">{{ data.title }}</h1>
 
             <div class="blog-post-actions">
-                <a href="" data-ng-if="itemOptions.POST" data-ng-click="edit()" class="blog-post-actions-item"><i class="icon-pencil"></i>{{ "TR__EDIT" | translate }}</a>
+                <a href="" data-ng-if="itemOptions.POST" data-ng-click="edit()" class="blog-post-actions-item"><i class="icon-pencil"></i> {{ "TR__EDIT" | translate }}</a>
                 <a href="" data-ng-if="options.delete" data-ng-click="delete()" class="blog-post-actions-item"><i class="icon-trash"></i> {{ "TR__DELETE" | translate }}</a>
             </div>
         </header>

--- a/src/mercator/mercator/static/js/Packages/Blog/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Blog/Detail.html
@@ -5,8 +5,8 @@
             <h1 class="blog-post-title">{{ data.title }}</h1>
 
             <div class="blog-post-actions">
-                <a href="" data-ng-if="itemOptions.POST" data-ng-click="edit()" class="blog-post-actions-item"><i class="icon-pencil"></i> {{ "TR__EDIT" | translate }}</a>
-                <a href="" data-ng-if="options.hide" data-ng-click="hide()" class="blog-post-actions-item"><i class="icon-trash"></i> {{ "TR__DELETE" | translate }}</a>
+                <a href="" data-ng-if="itemOptions.POST" data-ng-click="edit()" class="blog-post-actions-item"><i class="icon-pencil"></i>{{ "TR__EDIT" | translate }}</a>
+                <a href="" data-ng-if="options.delete" data-ng-click="delete()" class="blog-post-actions-item"><i class="icon-trash"></i> {{ "TR__DELETE" | translate }}</a>
             </div>
         </header>
 


### PR DESCRIPTION
This enables creators (and also admins) of a blog entry to delete their blog entry instead of hiding. Fixes #1439 

PROBLEM: the blogentry gets deleted but I need to refresh the page to see the changes. How can that be fixed? Is this a backend or a frontend issue?