### PR TITLE
Run linters on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - "python bootstrap.py --setuptools-version=12.0.4"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/buildout -c buildout-${BUILDOUT_TARGET}.cfg 2>/dev/null"
 script:
+  - "./bin/check_code -a"
   - "./bin/polytester -v pyunit,pyfunc,jsunit,jsint"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/protractor etc/protractorConfSauce.js"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
   - "python bootstrap.py --setuptools-version=12.0.4"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/buildout -c buildout-${BUILDOUT_TARGET}.cfg 2>/dev/null"
 script:
-  - "./bin/check_code -a"
   - "./bin/polytester -v pyunit,pyfunc,jsunit,jsint"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/protractor etc/protractorConfSauce.js"
 notifications:

--- a/src/adhocracy_core/checkcode.cfg
+++ b/src/adhocracy_core/checkcode.cfg
@@ -42,7 +42,11 @@ scripts =
 [check_code]
 recipe = collective.recipe.template
 python_check =
-    CHANGED_PY=`git diff --staged --name-only --diff-filter=ACMR | grep '\.py$'`
+    if [ x$1 == x"-a" ]; then
+        CHANGED_PY=`git ls-files | grep -v sdidemo | grep '\.py$'`
+    else
+        CHANGED_PY=`git diff --staged --name-only --diff-filter=ACMR | grep '\.py$'`
+    fi
     if [ -n "$CHANGED_PY" ] ; then
         ${buildout:bin-directory}/flake8 --ignore=N805,D101,D102 --exclude=bootstrap.py,conf.py,.svn,CVS,.bzr,.hg,.git,__pycache__,test_*,src/adhocracy_frontend/adhocracy_frontend/static/lib --max-complexity=14 $CHANGED_PY
         ret_code=$(($ret_code + $?))

--- a/src/adhocracy_core/checkcode.cfg
+++ b/src/adhocracy_core/checkcode.cfg
@@ -48,7 +48,7 @@ python_check =
         CHANGED_PY=`git diff --staged --name-only --diff-filter=ACMR | grep '\.py$'`
     fi
     if [ -n "$CHANGED_PY" ] ; then
-        ${buildout:bin-directory}/flake8 --ignore=N805,D101,D102 --exclude=bootstrap.py,conf.py,.svn,CVS,.bzr,.hg,.git,__pycache__,test_*,src/adhocracy_frontend/adhocracy_frontend/static/lib --max-complexity=14 $CHANGED_PY
+        ${buildout:bin-directory}/flake8 --ignore=N805,D101,D102 --exclude=bootstrap.py,conf.py,.svn,CVS,.bzr,.hg,.git,__pycache__,test_*,fixtures*,src/adhocracy_frontend/adhocracy_frontend/static/lib --max-complexity=14 $CHANGED_PY
         ret_code=$(($ret_code + $?))
     fi
 css_check =

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Makefile
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Makefile
@@ -42,9 +42,6 @@ warn_orphan_js:
 
 test: warn_orphan_js tslint compile_tests_node test_node
 
-tslint:
-	$(A3_ROOT)/bin/tslint_check_adhocracy | $(FIX_TSLINT_ERROR_FORMAT)
-
 test_node:
 	../../../../../bin/jasmine-node .
 	@echo "NOTE: leaving commonjs modules in place."

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -7,7 +7,6 @@ parts +=
     protractor
     merge_static_directories
     do_merge_static_directories
-    tslint_shortcut
     bower
     AdhocracySpec.ts
     meta_api
@@ -98,20 +97,6 @@ input = inline:
     }
 output = ${buildout:directory}/etc/tslint.json
 mode = 644
-
-[tslint_shortcut]
-recipe = collective.recipe.template
-input = inline:
-    #!/bin/bash
-    cd "${buildout:directory}"
-    export cl_args="${buildout:bin-directory}/tslint -c ${tslint_json:output}"
-    ${buildout:bin-directory}/tslint --version
-    while read line; do
-        cl_args="$cl_args -f $line"
-    done < <(git ls-files | grep '\.ts$' | grep -v '\.d\.ts$')
-    exec $cl_args
-output = ${buildout:bin-directory}/tslint_check_adhocracy
-mode = 755
 
 [check_code]
 # Extends adhocracy_core/checkcode.cfg['check_code']

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -116,13 +116,21 @@ mode = 755
 [check_code]
 # Extends adhocracy_core/checkcode.cfg['check_code']
 css_check =
-    CHANGED_SCSS=`git diff --staged --name-only --diff-filter=ACMR | grep '\.scss$' | grep -v 'third_party'`
+    if [ x$1 == x"-a" ]; then
+        CHANGED_SCSS=`git ls-files | grep '\.scss$' | grep -v 'third_party'`
+    else
+        CHANGED_SCSS=`git diff --staged --name-only --diff-filter=ACMR | grep '\.scss$' | grep -v 'third_party'`
+    fi
     if [ -n "$CHANGED_SCSS" ] ; then
         ${buildout:bin-directory}/scss-lint $CHANGED_SCSS
         ret_code=$(($ret_code + $?))
     fi
 js_check =
-    CHANGED_TS=`git diff --staged --name-only --diff-filter=ACMR | grep '\.ts$' | grep -v '\.d\.ts'`
+    if [ x$1 == x"-a" ]; then
+        CHANGED_TS=`git ls-files | grep '\.ts$' | grep -v '\.d\.ts'`
+    else
+        CHANGED_TS=`git diff --staged --name-only --diff-filter=ACMR | grep '\.ts$' | grep -v '\.d\.ts'`
+    fi
     if [ -n "$CHANGED_TS" ] ; then
         ret_code=$(($ret_code + $?))
         export cl_args="${buildout:bin-directory}/tslint -c ${tslint_json:output}"
@@ -132,7 +140,11 @@ js_check =
         exec $cl_args
     fi
 html_check =
-    CHANGED_HTML=`git diff --staged --name-only --diff-filter=ACMR | grep '\.html$'`
+    if [ x$1 == x"-a" ]; then
+        CHANGED_HTML=`git ls-files | grep '\.html$'`
+    else
+        CHANGED_HTML=`git diff --staged --name-only --diff-filter=ACMR | grep '\.html$'`
+    fi
     if [ -n "$CHANGED_HTML" ] ; then
         bin/grunt htmlhint
         ret_code=$(($ret_code + $?))


### PR DESCRIPTION
this extends `bin/check_code` to be able to check all files, not only the staged ones. This is then used to run the linters on travis.

Unfortunately, flake8 reports many issues. I guess this is due to wrong config. Can someone tell what needs to be changed?