### PR TITLE
Fix dependance on process

### DIFF
--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/Detail.html
@@ -16,7 +16,7 @@
                 <i class="icon-calendar m-definition-before" title="{{ 'TR__CREATION_DATE' | translate }}:"></i>
                 <adh-time data-datetime="data.user_info.createtime" data-format="D/M/YYYY"></adh-time>
             </li>
-            <li data-ng-if="data.currentPhase != 'result'" class="meta-list-item meta-list-item-budget screen-only">
+            <li data-ng-if="data.currentPhase && data.currentPhase != 'result'" class="meta-list-item meta-list-item-budget screen-only">
                 <i class="icon-pig" title="{{ 'TR__MERCATOR_PROPOSAL_REQUESTED' | translate }}"></i>
                 {{data.finance.requested_funding | number}} &euro;
             </li>

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/ListItem.html
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/ListItem.html
@@ -23,12 +23,12 @@
                 <i class="icon-speechbubbles"></i>
                 {{ data.commentCountTotal }} <span class="print-only" aria-hidden="true">{{ "TR__COMMENTS_TOTAL" | translate }}</span>
             </li>
-            <li data-ng-if="data.currentPhase != 'result'" class="meta-list-item meta-list-item-supporters">
+            <li data-ng-if="data.currentPhase && data.currentPhase != 'result'" class="meta-list-item meta-list-item-supporters">
                 <i class="icon-pointy-rectangle-left"></i>
                 {{ data.supporterCount }}
                 {{ "TR__SUPPORTERS" | translate }}
             </li>
-            <li data-ng-if="data.currentPhase != 'result'" class="meta-list-item meta-list-item-budget">
+            <li data-ng-if="data.currentPhase && data.currentPhase != 'result'" class="meta-list-item meta-list-item-budget">
                 {{ data.finance.requested_funding | number }} &euro; <span class="print-only" aria-hidden="true">{{ "TR__MERCATOR_PROPOSAL_REQUESTED_FUNDING" | translate }}</span>
             </li>
             <li data-ng-if="data.winnerBadgeAssignment.name === 'winning'" class="meta-list-item meta-list-item-badge">

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -448,9 +448,11 @@ export class Widget<R extends ResourcesBase.Resource> extends AdhResourceWidgets
         });
 
         var processUrl = this.adhTopLevelState.get("processUrl");
-        this.adhHttp.get(processUrl).then((resource) => {
-            data.currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
-        });
+        if (typeof processUrl !== "undefined") {
+            this.adhHttp.get(processUrl).then((resource) => {
+                data.currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
+            });
+        }
 
         var subResourcePaths : SIMercatorSubResources.Sheet = mercatorProposalVersion.data[SIMercatorSubResources.nick];
         var subResourcePromises : angular.IPromise<ResourcesBase.Resource[]> = this.$q.all([
@@ -973,9 +975,11 @@ export var listItem = (
                 });
 
                 var processUrl = adhTopLevelState.get("processUrl");
-                adhHttp.get(processUrl).then((resource) => {
-                    scope.data.currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
-                });
+                if (typeof processUrl !== "undefined") {
+                    adhHttp.get(processUrl).then((resource) => {
+                        scope.data.currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
+                    });
+                }
 
                 scope.$on("$destroy", adhTopLevelState.on("proposalUrl", (proposalVersionUrl) => {
                     if (!proposalVersionUrl) {
@@ -1011,10 +1015,12 @@ export var addButton = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/AddButton.html",
         link: (scope) => {
             var processUrl = adhTopLevelState.get("processUrl");
-            adhHttp.get(processUrl).then((resource) => {
-                var currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
-                scope.loggedOutAndParticipate = (!adhCredentials.loggedIn && currentPhase === "participate");
-            });
+            if (typeof processUrl !== "undefined") {
+                adhHttp.get(processUrl).then((resource) => {
+                    var currentPhase = resource.data[SIMercatorWorkflow.nick].workflow_state;
+                    scope.loggedOutAndParticipate = (!adhCredentials.loggedIn && currentPhase === "participate");
+                });
+            }
             adhPermissions.bindScope(scope, adhConfig.rest_url + adhConfig.custom["mercator_platform_path"], "poolOptions");
         }
     };

--- a/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -308,7 +308,9 @@ export var getWorkflowState = (
     if (typeof processUrl !== "undefined") {
         return adhHttp.get(processUrl).then((resource) => {
             var workflowSheet = resource.data[SIMercatorWorkflow.nick];
-            return workflowSheet.workflow_state;
+            if (typeof workflowSheet !== "undefined") {
+                return workflowSheet.workflow_state;
+            }
         });
     } else {
         return $q.when(undefined);


### PR DESCRIPTION
If you open a user profile with a non-empty list of mercator proposals you will get a error like this:

    TypeError: Cannot read property 'workflow_state' of undefined
    at MercatorProposal.ts:976

The reason is that there is no process in the URL and therefore `processUrl` is not set in topLevelState.

I worked around this by making the use of `processUrl` optional. An actual fix would probably be to find a process for each proposal instead of taking one from the current route. But that would also be relatively slow. Not sure what to do about this.