### PR TITLE
set login form to pristine on backend error (fixes #1454)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -201,6 +201,7 @@ export var loginDirective = (
                 }, (errors) => {
                     bindServerErrors(scope, errors);
                     scope.credentials.password = "";
+                    scope.loginForm.$setPristine();
                 });
             };
         }


### PR DESCRIPTION
we clear the password field which resultes in a "password required" error on it. Setting the whole form to pristine fixes that.