### PR TITLE
Changed button styline meinberlin

### DIFF
--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_button_theme.scss
@@ -15,11 +15,6 @@
     font-size: $font-size-small;
     height: 24px / $font-size-small * 1em;
     line-height: 24px / $font-size-small * 1em;
-    text-transform: none;
-
-    &:first-letter {
-        text-transform: capitalize;
-    }
 
     &:focus:enabled,
     &:hover:enabled {
@@ -31,6 +26,10 @@
     @include border-radius(1em);
     font-weight: $font-weight-extrovert;
     padding: 0 (30px / $font-size-normal * 1em);
+}
+
+.button, .button-cta, .button-cta-secondary {
+    text-transform: capitalize;
 }
 
 /*doc


### PR DESCRIPTION
The pseudo class :first-letter doesn't really work for us (a) it doesn't work on input type="button" and (b) it doesn't work on a button that has a :before pseudo class (as that will act as the first-letter)

I have now made a general style of text-transform: capitalize; on all MB buttons, with the disadvantage that every letter is capitalized. I will ask the designers tomorrow.