### PR TITLE
Add map input to document form

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
@@ -26,6 +26,12 @@
                 {{ "TR__ERROR_REQUIRED_TITLE" | translate }}
             </span>
         </label>
+        <adh-map-input
+            data-ng-if="hasMap && polygon"
+            data-lng="data.coordinates[0]"
+            data-lat="data.coordinates[1]"
+            data-polygon="polygon"
+            data-height="170"></adh-map-input>
     </div><!-- /.cover -->
 
     <div class="section-jump-body">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -72,6 +72,7 @@ export interface IFormScope extends IScope {
     submit() : angular.IPromise<any>;
     cancel() : void;
     documentForm : any;
+    polygon? : number[][];
 }
 
 export var highlightSelectedParagraph = (
@@ -396,7 +397,8 @@ export var createDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         scope: {
             path: "@",
-            hasMap: "=?"
+            hasMap: "=?",
+            polygon: "=?"
         },
         link: (scope : IFormScope, element) => {
             scope.errors = [];
@@ -404,8 +406,10 @@ export var createDirective = (
                 title: "",
                 paragraphs: [{
                     body: ""
-                }]
+                }],
+                coordinates: []
             };
+            scope.polygon = [[13.43, 52.49], [13.44, 52.48], [13.44, 52.49]];
             scope.showError = adhShowError;
 
             scope.addParagraph = () => {
@@ -447,7 +451,8 @@ export var editDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         scope: {
             path: "@",
-            hasMap: "=?"
+            hasMap: "=?",
+            polygon: "=?"
         },
         link: (scope : IFormScope, element) => {
             scope.errors = [];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -409,7 +409,6 @@ export var createDirective = (
                 }],
                 coordinates: []
             };
-            scope.polygon = [[13.43, 52.49], [13.44, 52.48], [13.44, 52.49]];
             scope.showError = adhShowError;
 
             scope.addParagraph = () => {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
@@ -12,6 +12,6 @@
     </a>
 
     <div class="tabs" data-ng-switch-when="body">
-        <adh-document-create data-path="{{processUrl}}" data-has-map="true"></adh-document-create>
+        <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-polygon="polygon"></adh-document-create>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
@@ -30,7 +30,7 @@
         <div data-ng-if="tab === 'documents'">
             <adh-map-listing
                 data-path="{{processUrl}}"
-                data-polygon="[[13.43, 52.49], [13.44, 52.48]]"
+                data-polygon="polygon"
                 data-no-create-form="true"
                 data-empty-text="{{ 'TR__DOCUMENT_EMPTY_TEXT' | translate }}"
                 data-params="{tag: 'LAST'}"

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
@@ -47,6 +47,8 @@ export var processDetailColumnDirective = (
             column.bindVariablesAndClear(scope, ["processUrl"]);
             scope.$on("$destroy", adhTopLevelState.bind("tab", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
+            // FIXME: dummy data
+            scope.polygon = [[13.43, 52.49], [13.44, 52.48], [13.44, 52.49]];
         }
     };
 };
@@ -73,6 +75,8 @@ export var documentCreateColumnDirective = (
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl"]);
+            // FIXME: dummy data
+            scope.polygon = [[13.43, 52.49], [13.44, 52.48], [13.44, 52.49]];
         }
     };
 };


### PR DESCRIPTION
This continues on #1461 by adding an optional map input to the document create/edit form.