### PR TITLE
Add more options to set workflow script

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,12 +84,17 @@ Check that everything is running smoothly::
 
     ./bin/supervisorctl status
 
+Get information about the current workflow::
+
+  ./bin/set_workflow_state --info etc/development.ini <path-to-process>
+  # Example
+  ./bin/set_workflow_state --info etc/development.ini /mercator
+
 Change the workflow state (most actions are not allowed for a normal user in the initial 'draft' state)::
 
-  ./bin/set_workflow_state etc/development.ini <path-to-process> <workflow-state>
-  # examples
-  ./bin/set_workflow_state etc/development.ini /mercator participate
-  ./bin/set_workflow_state etc/development.ini /organisation/bplan frozen
+  ./bin/set_workflow_state etc/development.ini <path-to-process> <states-to-transition>
+  # Example
+  ./bin/set_workflow_state etc/development.ini /mercator announce participate
 
 Open the javascript front-end with your web browser::
 

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -7,6 +7,7 @@ from pyramid.security import ACLPermitsResult
 from pyramid.threadlocal import get_current_registry
 from pyramid.traversal import lineage
 from pyramid.registry import Registry
+from pyramid.request import Request
 from pyramid.router import Router
 from zope.interface import implementer
 from substanced.util import get_acl
@@ -150,3 +151,11 @@ def set_god_all_permissions(resource: IResource, registry=None) -> bool:
     old_acl = get_acl(resource)
     new_acl = [god_all_permission_ace] + old_acl
     set_acl(resource, new_acl, registry)
+
+
+def create_fake_god_request(registry):
+    """Create a fake request issued by god."""
+    request = Request.blank('/dummy')
+    request.registry = registry
+    request.__cached_principals__ = ['role:god']
+    return request

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -300,3 +300,8 @@ def test_set_god_all_permissions():
     resource = testing.DummyResource(__acl__=[(Deny, 'role:creator', 'edit_comment')])
     set_god_all_permissions(resource)
     assert resource.__acl__[0] == (Allow, 'role:god', ALL_PERMISSIONS)
+
+def test_create_fake_god_request(registry):
+    from . import create_fake_god_request
+    req = create_fake_god_request(registry)
+    assert req.__cached_principals__ == ['role:god']

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -29,13 +29,16 @@ def set_workflow_state():  # pragma: no cover
     parser.add_argument('resource_path',
                         type=str,
                         help='path of the resource')
-    parser.add_argument('--info',
+    parser.add_argument('-i',
+                        '--info',
                         help='display information about the workflow',
                         action='store_true')
-    parser.add_argument('--absolute',
+    parser.add_argument('-a',
+                        '--absolute',
                         help='use an absolute path for the list of states',
                         action='store_true')
-    parser.add_argument('--reset',
+    parser.add_argument('-r',
+                        '--reset',
                         help='reset workflow to initial state',
                         action='store_true')
     parser.add_argument('states',

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -82,6 +82,7 @@ def _get_states_to_transition(resource: IResource,
                               states: [str],
                               absolute,
                               reset) -> [str]:
+    _check_states(states)
     if not absolute or reset:
         return states
     workflow = registry.content.get_workflow(resource)
@@ -89,6 +90,12 @@ def _get_states_to_transition(resource: IResource,
     if state in states:
         return states[states.index(state) + 1:]
     return states
+
+
+def _check_states(states):
+    for state in states:
+        if states.count(state) > 1:
+            raise ValueError('Duplicate state: {}'.format(state))
 
 
 def _set_workflow_state(root: IResource,

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -104,11 +104,8 @@ def _set_workflow_state(root: IResource,
                                                      states,
                                                      absolute,
                                                      reset)
-    if reset:
-        transition_to_states(resource,
-                             states_to_transition,
-                             registry,
-                             reset=reset)
-    else:
-        transition_to_states(resource, states_to_transition, registry)
+    transition_to_states(resource,
+                         states_to_transition,
+                         registry,
+                         reset=reset)
     transaction.commit()

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -63,11 +63,14 @@ def _print_workflow_info(root: IResource,
                          resource_path: str):
     resource = find_resource(root, resource_path)
     workflow = registry.content.get_workflow(resource)
-    states = set(registry.content.workflows_meta[workflow.type]['states'].keys())
-    print('\nname: {}\ncurrent state: {}\nnext states: {}\nall states (unordered): {}\n'
+    states = set(registry.content.workflows_meta[workflow.type]['states']
+                 .keys())
+    print('\nname: {}\ncurrent state: {}\nnext states: {}'
+          '\nall states (unordered): {}\n'
           .format(workflow.type,
                   workflow.state_of(resource),
-                  workflow.get_next_states(resource, create_fake_god_request(registry)),
+                  workflow.get_next_states(resource,
+                                           create_fake_god_request(registry)),
                   states))
 
 
@@ -99,7 +102,10 @@ def _set_workflow_state(root: IResource,
                                                      absolute,
                                                      reset)
     if reset:
-        transition_to_states(resource, states_to_transition, registry, reset=reset)
+        transition_to_states(resource,
+                             states_to_transition,
+                             registry,
+                             reset=reset)
     else:
         transition_to_states(resource, states_to_transition, registry)
     transaction.commit()

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -4,7 +4,6 @@ This is registered as console script in setup.py.
 """
 import argparse
 import inspect
-import logging
 import transaction
 
 from pyramid.paster import bootstrap
@@ -14,8 +13,6 @@ from pyramid.traversal import find_resource
 from adhocracy_core.authorization import create_fake_god_request
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.workflows import transition_to_states
-
-logger = logging.getLogger(__name__)
 
 
 def set_workflow_state():  # pragma: no cover

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -4,14 +4,18 @@ This is registered as console script in setup.py.
 """
 import argparse
 import inspect
+import logging
 import transaction
 
 from pyramid.paster import bootstrap
 from pyramid.registry import Registry
 from pyramid.traversal import find_resource
+from pyramid.request import Request
 
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.workflows import transition_to_states
+
+logger = logging.getLogger(__name__)
 
 
 def set_workflow_state():  # pragma: no cover
@@ -28,26 +32,53 @@ def set_workflow_state():  # pragma: no cover
     parser.add_argument('resource_path',
                         type=str,
                         help='path of the resource')
+    parser.add_argument('--info',
+                        help='display information about the workflow',
+                        action='store_true')
     parser.add_argument('--absolute',
                         help='use an absolute path for the list of states',
                         action='store_true')
-    parser.add_argument('states',
-                        type=str,
-                        nargs='+',
-                        help='list of state name to do transition to')
     parser.add_argument('--reset',
                         help='reset workflow to initial state',
                         action='store_true')
+    parser.add_argument('states',
+                        type=str,
+                        nargs='*',
+                        help='list of state name to do transition to')
     args = parser.parse_args()
     env = bootstrap(args.ini_file)
-    _set_workflow_state(env['root'],
-                        env['registry'],
-                        args.resource_path,
-                        args.states,
-                        args.absolute,
-                        args.reset,
-                        )
+    if args.info:
+        _print_workflow_info(env['root'],
+                             env['registry'],
+                             args.resource_path)
+    else:
+        _set_workflow_state(env['root'],
+                            env['registry'],
+                            args.resource_path,
+                            args.states,
+                            args.absolute,
+                            args.reset,)
     env['closer']()
+
+
+def _fake_root_request(registry):
+    request = Request.blank('/dummy')
+    request.registry = registry
+    request.__cached_principals__ = ['role:god']
+    return request
+
+
+def _print_workflow_info(root: IResource,
+                         registry: Registry,
+                         resource_path: str):
+    resource = find_resource(root, resource_path)
+    workflow = registry.content.get_workflow(resource)
+    states = set(registry.content.workflows_meta[workflow.type]['states'].keys())
+    print('\nname: {}\ncurrent state: {}\nnext states: {}\nall states (unordered): {}\n'
+          .format(workflow.type,
+                  workflow.state_of(resource),
+                  workflow.get_next_states(resource, _fake_root_request(registry)),
+                  states))
 
 
 def _get_states_to_transition(resource: IResource,

--- a/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/set_workflow_state.py
@@ -10,8 +10,8 @@ import transaction
 from pyramid.paster import bootstrap
 from pyramid.registry import Registry
 from pyramid.traversal import find_resource
-from pyramid.request import Request
 
+from adhocracy_core.authorization import create_fake_god_request
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.workflows import transition_to_states
 
@@ -61,13 +61,6 @@ def set_workflow_state():  # pragma: no cover
     env['closer']()
 
 
-def _fake_root_request(registry):
-    request = Request.blank('/dummy')
-    request.registry = registry
-    request.__cached_principals__ = ['role:god']
-    return request
-
-
 def _print_workflow_info(root: IResource,
                          registry: Registry,
                          resource_path: str):
@@ -77,7 +70,7 @@ def _print_workflow_info(root: IResource,
     print('\nname: {}\ncurrent state: {}\nnext states: {}\nall states (unordered): {}\n'
           .format(workflow.type,
                   workflow.state_of(resource),
-                  workflow.get_next_states(resource, _fake_root_request(registry)),
+                  workflow.get_next_states(resource, create_fake_god_request(registry)),
                   states))
 
 

--- a/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
@@ -32,7 +32,7 @@ def test_set_workflow_state(registry, context, transaction_mock,
     _set_workflow_state(context, registry, '/', ['announced', 'participate'])
 
     transition_to_mock.assert_called_with(context, ['announced', 'participate'],
-                                          registry)
+                                          registry, reset=False)
     assert transaction_mock.commit.called
 
 
@@ -49,7 +49,7 @@ def test_set_workflow_state_with_absolute(registry_with_content, context, transi
     registry.content.get_workflow.return_value = workflow_mock
     from .set_workflow_state import _set_workflow_state
     _set_workflow_state(context, registry, '/', ['announced', 'participate'], absolute=True)
-    transition_to_mock.assert_called_with(context, ['announced', 'participate'], registry)
+    transition_to_mock.assert_called_with(context, ['announced', 'participate'], registry, reset=False)
 
     _set_workflow_state(context, registry, '/', ['announced', 'participate', 'result'], absolute=True)
     transition_to_mock.assert_called_with(context, ['result'], registry)

--- a/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
@@ -61,7 +61,7 @@ def test_set_workflow_state_with_absolute(registry_with_content, context, transi
     transition_to_mock.assert_called_with(context, ['announced', 'participate'], registry, reset=False)
 
     _set_workflow_state(context, registry, '/', ['announced', 'participate', 'result'], absolute=True)
-    transition_to_mock.assert_called_with(context, ['result'], registry)
+    transition_to_mock.assert_called_with(context, ['result'], registry, reset=False)
 
 def test_print_workflow_info(registry_with_content, context, print_mock):
     registry = registry_with_content

--- a/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
@@ -18,6 +18,13 @@ def transition_to_mock(monkeypatch):
                         mock)
     return mock
 
+@fixture
+def print_mock(monkeypatch):
+    import builtins
+    mock = Mock(spec=builtins.print)
+    monkeypatch.setattr('builtins.print', mock)
+    return mock
+
 
 def test_set_workflow_state(registry, context, transaction_mock,
                             transition_to_mock):
@@ -46,3 +53,12 @@ def test_set_workflow_state_with_absolute(registry_with_content, context, transi
 
     _set_workflow_state(context, registry, '/', ['announced', 'participate', 'result'], absolute=True)
     transition_to_mock.assert_called_with(context, ['result'], registry)
+
+def test_print_workflow_info(registry_with_content, context, print_mock):
+    registry = registry_with_content
+    workflow_mock = Mock(type='standard')
+    registry.content.get_workflow.return_value = workflow_mock
+    registry.content.workflows_meta = {'standard': {'states': {'draft': None, 'announced': None}}}
+    from .set_workflow_state import _print_workflow_info
+    _print_workflow_info(context, registry, '/')
+    assert print_mock.called

--- a/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 from pytest import fixture
+import pytest
 
 
 @fixture
@@ -34,6 +35,14 @@ def test_set_workflow_state(registry, context, transaction_mock,
     transition_to_mock.assert_called_with(context, ['announced', 'participate'],
                                           registry, reset=False)
     assert transaction_mock.commit.called
+
+
+def test_set_workflow_state_duplicate_state(registry, context, transaction_mock,
+                                            transition_to_mock):
+    from .set_workflow_state import _set_workflow_state
+
+    with pytest.raises(ValueError):
+        _set_workflow_state(context, registry, '/', ['announced', 'participate', 'announced'])
 
 
 def test_set_workflow_state_with_reset(registry, context, transition_to_mock):

--- a/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_set_workflow_state.py
@@ -33,3 +33,16 @@ def test_set_workflow_state_with_reset(registry, context, transition_to_mock):
     from .set_workflow_state import _set_workflow_state
     _set_workflow_state(context, registry, '/', [], reset=True)
     transition_to_mock.assert_called_with(context, [], registry, reset=True)
+
+def test_set_workflow_state_with_absolute(registry_with_content, context, transition_to_mock):
+    registry = registry_with_content
+    workflow_mock = Mock()
+    state_of_mock = Mock(side_effect=['draft', 'participate'])
+    workflow_mock.state_of = state_of_mock
+    registry.content.get_workflow.return_value = workflow_mock
+    from .set_workflow_state import _set_workflow_state
+    _set_workflow_state(context, registry, '/', ['announced', 'participate'], absolute=True)
+    transition_to_mock.assert_called_with(context, ['announced', 'participate'], registry)
+
+    _set_workflow_state(context, registry, '/', ['announced', 'participate', 'result'], absolute=True)
+    transition_to_mock.assert_called_with(context, ['result'], registry)

--- a/src/adhocracy_core/adhocracy_core/workflows/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/workflows/__init__.py
@@ -64,10 +64,6 @@ def transition_to_states(context, states: [str], registry: Registry,
     # TODO: raise if workflow is None
     if not workflow.has_state(context) or reset:
         workflow.initialize(context)
-    current_state = workflow.state_of(context)
-    wanted_state = states and states[-1]
-    if wanted_state == current_state:
-        return
     for state in states:
         workflow.transition_to_state(context, request, state)
 

--- a/src/adhocracy_core/adhocracy_core/workflows/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/workflows/__init__.py
@@ -3,13 +3,13 @@ from colander import Invalid
 
 from pyramid.interfaces import IRequest
 from pyramid.registry import Registry
-from pyramid.request import Request
 from substanced.workflow import ACLWorkflow
 from substanced.workflow import WorkflowError
 from substanced.workflow import IWorkflow
 from zope.interface import implementer
 
 from adhocracy_core.authorization import acm_to_acl
+from adhocracy_core.authorization import create_fake_god_request
 from adhocracy_core.exceptions import ConfigurationError
 from adhocracy_core.interfaces import IAdhocracyWorkflow
 from adhocracy_core.workflows.schemas import create_workflow_meta_schema
@@ -59,9 +59,7 @@ def transition_to_states(context, states: [str], registry: Registry,
     :raises substanced.workflow.WorkflowError: if transition is missing to
     do transitions to `states`.
     """
-    request = Request.blank('/dummy')
-    request.registry = registry
-    request.__cached_principals__ = ['role:god']
+    request = create_fake_god_request(registry)
     workflow = registry.content.get_workflow(context)
     # TODO: raise if workflow is None
     if not workflow.has_state(context) or reset:

--- a/src/adhocracy_core/adhocracy_core/workflows/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/workflows/test_init.py
@@ -7,6 +7,8 @@ from pytest import fixture
 from pytest import mark
 from pytest import raises
 from unittest.mock import Mock
+import pytest
+from substanced.workflow import WorkflowError
 
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources import process
@@ -184,7 +186,7 @@ class TestTransitionToStates:
         workflow = registry.content.workflows['test_workflow']
         assert workflow.state_of(context) is 'participate'
 
-    def test_ignore_if_state_already_set(self, integration, context,
+    def test_error_if_state_already_set(self, integration, context,
                                          resource_meta):
         registry = integration.registry
         self._add_workflow(registry, 'test_workflow')
@@ -196,9 +198,8 @@ class TestTransitionToStates:
         workflow.transition_to_state(context, request, 'announced')
         workflow.transition_to_state(context, request, 'participate')
 
-        self.call_fut(context, ['announced', 'participate'], registry)
-
-        assert workflow.state_of(context) is 'participate'
+        with pytest.raises(WorkflowError):
+            self.call_fut(context, ['announced', 'participate'], registry)
 
     def test_optionally_reset_to_initial_state(self, integration, context,
                                                resource_meta):


### PR DESCRIPTION
- Add an `--absolute` option to `set_workflow_script`

Allow to use the absolute path to reach the wanted workflow state, whatever the current state is. There will be no transition to the states expressed in the path that are before the current state.

Example

     /bin/set_workflow_state --absolute etc/development.ini /mercator draft announce

- Add an `--info` option to `set_workflow_script`

Since everybody get confused with workflows, this option display the current workflow name, state, next reachable states and defined states

    ./bin/set_workflow_state --info etc/development.ini /mercator 

    name: mercator
    current state: announce
    next states: ['participate']
    all states (unordered): {'closed', 'evaluate', 'announce', 'participate', 'draft', 'result'}

@slomo should update production scripts