### PR TITLE
modify map listing for meinberlin

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -114,6 +114,7 @@ export var mapInput = (
 
             if (typeof scope.zoom !== "undefined") {
                 map.setZoom(scope.zoom);
+                //
             }
 
             var selectedItemLeafletIcon = (<any>leaflet).divIcon(cssAddIcon);
@@ -346,11 +347,16 @@ export class MapListingController {
         var mapElement = this.$element.find(".map-list-map");
         mapElement.height(this.$scope.height);
 
-        var map = this.leaflet.map(mapElement[0]);
+        var map = this.leaflet.map(mapElement[0], {
+            zoomControl: false
+        });
         this.leaflet.tileLayer("https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png", {maxZoom: 18}).addTo(map);
 
         this.$scope.polygon = this.leaflet.polygon(this.leaflet.GeoJSON.coordsToLatLngs(this.$scope.rawPolygon), style);
         this.$scope.polygon.addTo(map);
+
+        // add zoom control bottom right
+        map.addControl( this.leaflet.control.zoom({position: 'bottomright'}) );
 
         // limit map to polygon
         map.fitBounds(this.$scope.polygon.getBounds());

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/a3.scss
@@ -33,6 +33,7 @@
 @import "components/login";
 @import "components/login_theme";
 @import "components/map";
+@import "components/map_theme";
 @import "components/navbar";
 @import "components/meinberlin_proposal";
 @import "components/moving_columns";

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_map_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_map_theme.scss
@@ -1,0 +1,4 @@
+.map-list-zoom {
+    bottom: auto;
+    top: 0;
+}


### PR DESCRIPTION
*split from #1487*

This moves `map-list-zoom` to the top of the map list map. To avoid overcrowding the top part, the zoom controls are then moved to the bottom right.

I personally feel like this should either be implemented for all maps or for none. Additionally, the zoom controls are moved for all packages while the `map-list-zoom` is only moved in meinberlin.

@local-girl will talk to the designers about this tomorrow.