### PR TITLE
enable image upload widget for meinberlin

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -16,6 +16,7 @@ import angularTranslate = require("angularTranslate");  if (angularTranslate) { 
 import angularTranslateLoader = require("angularTranslateLoader");  if (angularTranslateLoader) { ; };
 import angularElastic = require("angularElastic");  if (angularElastic) { ; };
 import angularScroll = require("angularScroll");  if (angularScroll) { ; };
+import angularFlow = require("angularFlow");  if (angularFlow) { ; };
 
 import markdownit = require("markdownit");
 import modernizr = require("modernizr");
@@ -88,8 +89,10 @@ export var init = (config : AdhConfig.IService, metaApi) => {
         "ngAnimate",
         "ngAria",
         "ngMessages",
+        "flow",
         AdhComment.moduleName,
         AdhDone.moduleName,
+        AdhImage.moduleName,
         AdhMapping.moduleName,
 
         AdhCrossWindowMessaging.moduleName,


### PR DESCRIPTION
This adds the possibility of adding an image to a document to meinberlin. Use the following link:

http://localhost:6551/embed/upload-image?pool-path=http:%2F%2Flocalhost:6541%2Forganisation%2Falexanderplatz%2F&path=http:%2F%2Flocalhost:6541%2Forganisation%2Falexanderplatz%2Fdocument_0000003%2FVERSION_0000001%2F

