### PR TITLE
add simple form to assign badges

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Assignment.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Assignment.html
@@ -1,27 +1,26 @@
 <h2>Badge Assignment</h2>
 <form
-	name="form"
-	data-ng-if="badges"
-	novalidate="novalidate"
-	data-ng-submit="submit()">
-	<select
-	    data-ng-model="data.badge"
-	    name="badges"
-	    required="required"
-	    >
-	    <option value="" data-selected="selected">Choose a badge</option>
-	    <option value="{{ badge.path }}" data-ng-repeat="badge in badges">{{ badge.title }}</option>
-	</select>
-	<span ng-show="form.$submitted || form.badges.$touched">
-    	<span class="input-error" data-ng-show="form.badges.$error.required">Please choose a badge</span>
+    name="form"
+    data-ng-if="badges"
+    novalidate="novalidate"
+    data-ng-submit="submit()">
+    <select
+        data-ng-model="data.badge"
+        name="badges"
+        required="required">
+        <option value="" data-selected="selected">Choose a badge</option>
+        <option value="{{ badge.path }}" data-ng-repeat="badge in badges">{{ badge.title }}</option>
+    </select>
+    <span data-ng-show="form.$submitted || form.badges.$touched">
+        <span class="input-error" data-ng-show="form.badges.$error.required">Please choose a badge</span>
     </span>
 
-	<textarea
-		data-ng-model="data.description"
-		name="description">
-	</textarea>
+    <textarea
+        data-ng-model="data.description"
+        name="description">
+    </textarea>
 
-	<footer class="form-footer">
+    <footer class="form-footer">
         <input
             type="submit"
             name="submit"
@@ -29,5 +28,3 @@
             class="button-cta form-footer-button-cta" />
     </footer>
 </form>
-
-

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Assignment.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Assignment.html
@@ -1,0 +1,33 @@
+<h2>Badge Assignment</h2>
+<form
+	name="form"
+	data-ng-if="badges"
+	novalidate="novalidate"
+	data-ng-submit="submit()">
+	<select
+	    data-ng-model="data.badge"
+	    name="badges"
+	    required="required"
+	    >
+	    <option value="" data-selected="selected">Choose a badge</option>
+	    <option value="{{ badge.path }}" data-ng-repeat="badge in badges">{{ badge.title }}</option>
+	</select>
+	<span ng-show="form.$submitted || form.badges.$touched">
+    	<span class="input-error" data-ng-show="form.badges.$error.required">Please choose a badge</span>
+    </span>
+
+	<textarea
+		data-ng-model="data.description"
+		name="description">
+	</textarea>
+
+	<footer class="form-footer">
+        <input
+            type="submit"
+            name="submit"
+            value="{{ 'TR__PUBLISH' | translate }}"
+            class="button-cta form-footer-button-cta" />
+    </footer>
+</form>
+
+

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -110,6 +110,8 @@ export var moduleName = "adhBadge";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhCredentials.moduleName,
+            AdhEmbed.moduleName,
             AdhHttp.moduleName
         ])
         .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -7,11 +7,12 @@ import AdhCredentials = require("../User/Credentials");
 import AdhHttp = require("../Http/Http");
 import AdhEmbed = require("../Embed/Embed");
 
+import RIBadgeAssignment = require("../../Resources_/adhocracy_core/resources/badge/IBadgeAssignment");
 import SIBadgeable = require("../../Resources_/adhocracy_core/sheets/badge/IBadgeable");
 import SIBadgeAssignment = require("../../Resources_/adhocracy_core/sheets/badge/IBadgeAssignment");
 import SIDescription = require("../../Resources_/adhocracy_core/sheets/description/IDescription");
-import RIBadgeAssignment = require("../../Resources_/adhocracy_core/resources/badge/IBadgeAssignment");
 import SIName = require("../../Resources_/adhocracy_core/sheets/name/IName");
+import SIPool = require("../../Resources_/adhocracy_core/sheets/pool/IPool");
 import SITitle = require("../../Resources_/adhocracy_core/sheets/title/ITitle");
 
 var pkgLocation = "/Badge";
@@ -61,18 +62,13 @@ export var badgeAssignmentDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Assignment.html",
         scope: {
             badgesPath: "@",
-            poolpath: "@",
+            poolPath: "@",
             badgeablePath: "@"
-
         },
         link: (scope, element) => {
             scope.data = {
-                badge : "",
-                description:""
-            };
-
-            var getBadgePromise = (badgepath : string) => {
-                return adhHttp.get(badgepath);
+                badge: "",
+                description: ""
             };
 
             var getBadge = (badge) => {
@@ -80,18 +76,18 @@ export var badgeAssignmentDirective = (
                     title: badge.data[SITitle.nick].title,
                     path: badge.path
                 };
-            }
+            };
 
             adhHttp.get(scope.badgesPath).then((badges) => {
-                var badgelist = badges["data"]["adhocracy_core.sheets.pool.IPool"]["elements"];
-                $q.all(<any>(_.map(badgelist, getBadgePromise))).then((result)=>{
+                var badgelist : string[] = badges.data[SIPool.nick].elements;
+                $q.all(_.map(badgelist, (b) => adhHttp.get(b))).then((result) => {
                     scope.badges = _.map(result, getBadge);
                 });
             });
 
             scope.submit = () => {
                 var postdata = {
-                    content_type: "adhocracy_core.resources.badge.IBadgeAssignment",
+                    content_type: RIBadgeAssignment.content_type,
                     data: {}
                 };
                 postdata.data[SIDescription.nick] = {
@@ -101,8 +97,8 @@ export var badgeAssignmentDirective = (
                     badge : scope.data.badge,
                     object : scope.badgeablePath,
                     subject : adhCredentials.userPath
-                }
-                return adhHttp.post(scope.poolpath, postdata);
+                };
+                return adhHttp.post(scope.poolPath, postdata);
             };
         }
     };


### PR DESCRIPTION
This implements a simple way to assign badges. Got to url like that: 

http://localhost:6551/embed/assign-badge?badges-path=http:%2F%2Flocalhost:6541%2Forganisation%2Falexanderplatz%2Fbadges%2F&poolpath=http:%2F%2Flocalhost:6541%2Forganisation%2Falexanderplatz%2Fdocument_0000003%2Fbadge_assignments%2F&badgeable-path=http:%2F%2Flocalhost:6541%2Forganisation%2Falexanderplatz%2Fdocument_0000003%2FVERSION_0000002%2F