### PR TITLE
Ensure all pools have an '_autoname_lasts' field

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -200,6 +200,8 @@ def change_pools_autonaming_scheme(root):  # pragma: no cover
             pool._autoname_lasts = {prefix: pool._autoname_last
                                     for prefix in prefixes}
             del pool._autoname_last
+        elif not hasattr(pool, '_autoname_lasts'):
+            pool._autoname_lasts = {prefix: 0 for prefix in prefixes}
 
 
 @log_migration


### PR DESCRIPTION
Fixes #1507.
Migration script need to be rerunned with `--mark-unfinished=adhocracy_core.evolution.evolution._autoname_lasts`