### PR TITLE
Add option to turn user token validation off

### DIFF
--- a/etc/development.ini.in
+++ b/etc/development.ini.in
@@ -37,6 +37,8 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 # If true, new user accounts are activated immediately without email verification
 adhocracy.skip_registration_mail = false
+# Allows turning off user token validation if behind a validating proxy
+adhocracy.validate_user_token = true
 # URL of the Varnish cache
 #adhocracy.varnish_url = http://127.0.0.1:8088
 

--- a/etc/test.ini.in
+++ b/etc/test.ini.in
@@ -26,6 +26,7 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # usable variables: {site_name}, {sender_name}, {title})
 adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 adhocracy.skip_registration_mail = true
+adhocracy.validate_user_token = true
 
 # Canonical frontend base URL. If this is an embedding URL, it should end with
 # #!. This is used for the creation of activation links.

--- a/etc/test_with_ws.ini.in
+++ b/etc/test_with_ws.ini.in
@@ -24,6 +24,7 @@ adhocracy.abuse_handler_mail = abuse_handler@unconfigured.domain
 # usable variables: {site_name}, {sender_name}, {title})
 adhocracy.message_user_subject = [{site_name}] Message from {sender_name}: {title}
 adhocracy.skip_registration_mail = true
+adhocracy.validate_user_token = true
 
 # Canonical frontend base URL. If this is an embedding URL, it should end with
 # #!. This is used for the creation of activation links.

--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -177,6 +177,21 @@ class TokenHeaderAuthenticationPolicy(unittest.TestCase):
         self.request.headers = self.token_and_user_id_headers
         assert inst.authenticated_userid(self.request) == None
 
+    def test_authenticated_userid_with_token_validation_off_no_token(self):
+        tokenmanager = Mock()
+        inst = self.make_one('', get_tokenmanager=lambda x: tokenmanager)
+        self.request.registry.settings['adhocracy.validate_user_token'] = False
+        self.request.headers = {'X-User-Path': self.user_url}
+        assert inst.authenticated_userid(self.request) == self.userid
+
+    def test_authenticated_userid_with_token_validation_off_wrong_token(self):
+        tokenmanager = Mock()
+        inst = self.make_one('', get_tokenmanager=lambda x: tokenmanager)
+        self.request.registry.settings['adhocracy.validate_user_token'] = False
+        self.request.headers = {'X-User-Path': self.user_url,
+                                'X-User-Token': 'whatever'}
+        assert inst.authenticated_userid(self.request) == self.userid
+
     def test_effective_principals_without_headers(self):
         from pyramid.security import Everyone
         from . import Anonymous


### PR DESCRIPTION
This allows running A3 behind a Thentos proxy that handles user authentication and only grants properly authenticated users access to the A3 backend.