### PR TITLE
Fix cameFrom in alexanderplatz workbench

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -452,7 +452,7 @@ export var createDirective = (
 
             scope.cancel = () => {
                 var processUrl = adhTopLevelState.get("processUrl");
-                adhTopLevelState.redirectToCameFrom(adhResourceUrlFilter(processUrl));
+                adhTopLevelState.goToCameFrom(adhResourceUrlFilter(processUrl));
             };
 
             scope.submit = () => {
@@ -501,7 +501,7 @@ export var editDirective = (
 
             scope.cancel = () => {
                 var itemPath = AdhUtil.parentPath(scope.documentVersion.path);
-                adhTopLevelState.redirectToCameFrom(adhResourceUrlFilter(itemPath));
+                adhTopLevelState.goToCameFrom(adhResourceUrlFilter(itemPath));
             };
 
             scope.submit = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -293,7 +293,7 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
 
                 if (!scope.optionsPostPool.POST) {
                     if (!adhCredentials.loggedIn) {
-                        adhTopLevelState.redirectToLogin();
+                        adhTopLevelState.setCameFromAndGo("/login");
                     } else {
                         // FIXME
                     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -290,7 +290,7 @@ export class Service {
                         message: error.message
                     });
                 } else {
-                    this.redirectToLogin();
+                    this.setCameFromAndGo("/login");
                 }
                 break;
             default:
@@ -414,7 +414,11 @@ export class Service {
 
     private cameFrom : string;
 
-    public setCameFrom(path : string) : boolean {
+    public setCameFrom(path? : string) : boolean {
+        if (typeof path === "undefined") {
+            path = this.$location.path();
+        }
+
         var denylist = [
             "/login",
             "/register",
@@ -440,7 +444,10 @@ export class Service {
         this.cameFrom = undefined;
     }
 
-    public redirectToCameFrom(_default? : string) : void {
+    public goToCameFrom(_default : string, replace = false) : void {
+        if (replace) {
+            this.$location.replace();
+        }
         var cameFrom = this.getCameFrom();
         if (typeof cameFrom !== "undefined") {
             this.$location.url(cameFrom);
@@ -449,13 +456,15 @@ export class Service {
         }
     }
 
-    public redirectToLogin() : void {
-        this.setCameFrom(this.$location.path());
-        this.$location.replace();
-        this.$location.url("/login");
+    public setCameFromAndGo(url : string, replace = false) : void {
+        if (replace) {
+            this.$location.replace();
+        }
+        this.setCameFrom();
+        this.$location.url(url);
     }
 
-    public redirectToSpaceHome(space) : void {
+    public goToSpaceHome(space) : void {
         // FIXME : This only works in resource area, needs to be refactored
         var spaceDefaults = this.provider.getSpaceDefaults(space);
         var area = this.getArea();
@@ -497,7 +506,7 @@ export var spaceSwitch = (
             scope.$on("$destroy", adhTopLevelState.bind("space", scope, "currentSpace"));
             scope.setSpace = (space : string) => {
                 if (scope.currentSpace === space) {
-                    adhTopLevelState.redirectToSpaceHome(space);
+                    adhTopLevelState.goToSpaceHome(space);
                 } else {
                     adhTopLevelState.set("space", space);
                 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelStateSpec.ts
@@ -298,26 +298,21 @@ export var register = () => {
                     expect(adhTopLevelState.getCameFrom()).not.toBeDefined();
                 });
 
-                describe("redirectToCameFrom", () => {
-                    it("does nothing if neither cameFrom nor default are set", () => {
-                        adhTopLevelState.redirectToCameFrom();
-                        expect(locationMock.url).not.toHaveBeenCalled();
-                    });
-
+                describe("goToCameFrom", () => {
                     it("redirects to cameFrom if cameFrom is set and default is not", () => {
                         adhTopLevelState.setCameFrom("foo");
-                        adhTopLevelState.redirectToCameFrom();
+                        adhTopLevelState.goToCameFrom("/");
                         expect(locationMock.url).toHaveBeenCalledWith("foo");
                     });
 
-                    it("redirects to cameFrom both if cameFrom and default are set", () => {
+                    it("redirects to cameFrom if both cameFrom and default are set", () => {
                         adhTopLevelState.setCameFrom("foo");
-                        adhTopLevelState.redirectToCameFrom("bar");
+                        adhTopLevelState.goToCameFrom("bar");
                         expect(locationMock.url).toHaveBeenCalledWith("foo");
                     });
 
                     it("redirects to default if default is set but cameFrom not", () => {
-                        adhTopLevelState.redirectToCameFrom("bar");
+                        adhTopLevelState.goToCameFrom("bar");
                         expect(locationMock.url).toHaveBeenCalledWith("bar");
                     });
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -189,7 +189,7 @@ export var loginDirective = (
             };
 
             scope.cancel = () => {
-                 adhTopLevelState.redirectToCameFrom("/");
+                 adhTopLevelState.goToCameFrom("/");
             };
 
             scope.logIn = () => {
@@ -197,7 +197,7 @@ export var loginDirective = (
                     scope.credentials.nameOrEmail,
                     scope.credentials.password
                 ).then(() => {
-                    adhTopLevelState.redirectToCameFrom("/");
+                    adhTopLevelState.goToCameFrom("/", true);
                 }, (errors) => {
                     bindServerErrors(scope, errors);
                     scope.credentials.password = "";
@@ -247,7 +247,7 @@ export var registerDirective = (
             };
 
             scope.cancel = scope.goBack = () => {
-                 adhTopLevelState.redirectToCameFrom("/");
+                 adhTopLevelState.goToCameFrom("/");
             };
 
 
@@ -288,7 +288,7 @@ export var passwordResetDirective = (
             };
 
             scope.goBack = scope.cancel = () => {
-                 adhTopLevelState.redirectToCameFrom("/");
+                 adhTopLevelState.goToCameFrom("/");
             };
 
             scope.errors = [];
@@ -330,7 +330,7 @@ export var createPasswordResetDirective = (
             };
 
             scope.goBack = scope.cancel = () => {
-                 adhTopLevelState.redirectToCameFrom("/");
+                 adhTopLevelState.goToCameFrom("/");
             };
 
             scope.errors = [];
@@ -494,7 +494,7 @@ export var userProfileDirective = (
                 if (scope.messageOptions.POST) {
                     column.showOverlay("messaging");
                 } else if (!adhCredentials.loggedIn) {
-                    adhTopLevelState.redirectToLogin();
+                    adhTopLevelState.setCameFromAndGo("/login");
                 } else {
                     // FIXME
                 }

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
@@ -5,7 +5,7 @@
             {{ "TR__MEINBERLIN_ALEXANDERPLATZ_DOCUMENT" | translate }}
         </div>
 
-        <a class="moving-column-menu-button" href="{{ processUrl | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+        <a class="moving-column-menu-button" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl:'create_document' }}">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
@@ -8,6 +8,7 @@
         <a
             class="moving-column-menu-button"
             data-ng-if="documentItemOptions.POST"
+            data-ng-click="setCameFrom()"
             data-ng-href="{{ documentUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
 
         <div class="moving-column-menu-nav">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/DocumentEditColumn.html
@@ -5,7 +5,7 @@
             {{ "TR__MEINBERLIN_ALEXANDERPLATZ_DOCUMENT" | translate }}
         </div>
 
-        <a class="moving-column-menu-button" data-ng-href="{{ documentUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+        <a class="moving-column-menu-button" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
 
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
@@ -11,10 +11,12 @@
 
         <a
             class="moving-column-menu-button"
+            data-ng-click="setCameFrom()"
             href="{{ processUrl | adhResourceUrl:'create_document'}}"
             data-ng-if="processOptions.POST && tab === 'documents'">{{ "TR__CREATE_DOCUMENT" | translate }}</a>
         <a
             class="moving-column-menu-button"
+            data-ng-click="setCameFrom()"
             href="{{ processUrl | adhResourceUrl:'create_proposal'}}"
             data-ng-if="processOptions.POST && tab === 'proposals'">{{ "TR__CREATE_PROPOSAL" | translate }}</a>
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
@@ -5,7 +5,7 @@
             {{ "TR__PROPOSAL" | translate }}
         </div>
 
-        <a class="moving-column-menu-button" href="{{ processUrl | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+        <a class="moving-column-menu-button" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl:'create_proposal' }}">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalDetailColumn.html
@@ -7,6 +7,7 @@
         <a
             class="moving-column-menu-button"
             data-ng-if="proposalItemOptions.POST"
+            data-ng-click="setCameFrom()"
             data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
 
         <div class="moving-column-menu-nav">

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/ProposalEditColumn.html
@@ -4,7 +4,8 @@
             <i class="icon-document moving-column-icon"></i>
             {{ "TR__PROPOSAL" | translate }}
         </div>
-        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+
+        <a class="moving-column-menu-button" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
 
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl:'proposals' }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
@@ -86,7 +86,8 @@ export var processDetailColumnDirective = (
 
 export var documentDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
@@ -95,6 +96,10 @@ export var documentDetailColumnDirective = (
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "documentUrl"]);
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.documentUrl), "documentItemOptions");
+
+            scope.setCameFrom = () => {
+                adhTopLevelState.setCameFrom();
+            };
         }
     };
 };
@@ -137,7 +142,9 @@ export var documentCreateColumnDirective = (
 
 export var documentEditColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -152,6 +159,11 @@ export var documentEditColumnDirective = (
                     });
                 }
             });
+
+            scope.cancel = () => {
+                var url = adhResourceUrl(AdhUtil.parentPath(scope.documentUrl));
+                adhTopLevelState.goToCameFrom(url);
+            };
         }
     };
 };
@@ -347,10 +359,12 @@ export var register = (angular) => {
         .directive("adhMeinBerlinAlexanderplatzWorkbench", ["adhConfig", "adhTopLevelState", workbenchDirective])
         .directive("adhMeinBerlinAlexanderplatzProcessColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", "adhHttp", processDetailColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzDocumentDetailColumn", ["adhConfig", "adhPermissions", documentDetailColumnDirective])
+        .directive("adhMeinBerlinAlexanderplatzDocumentDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", documentDetailColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalDetailColumn", ["adhConfig", "adhPermissions", proposalDetailColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzDocumentCreateColumn", ["adhConfig", "adhHttp", documentCreateColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalCreateColumn", ["adhConfig", proposalCreateColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzDocumentEditColumn", ["adhConfig", "adhHttp", documentEditColumnDirective])
+        .directive("adhMeinBerlinAlexanderplatzDocumentEditColumn", [
+            "adhConfig", "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", documentEditColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalEditColumn", ["adhConfig", proposalEditColumnDirective]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
@@ -106,7 +106,8 @@ export var documentDetailColumnDirective = (
 
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
@@ -115,6 +116,10 @@ export var proposalDetailColumnDirective = (
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
+
+            scope.setCameFrom = () => {
+                adhTopLevelState.setCameFrom();
+            };
         }
     };
 };
@@ -182,7 +187,9 @@ export var proposalCreateColumnDirective = (
 };
 
 export var proposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -190,6 +197,11 @@ export var proposalEditColumnDirective = (
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+
+            scope.cancel = () => {
+                var url = adhResourceUrl(AdhUtil.parentPath(scope.proposalUrl));
+                adhTopLevelState.goToCameFrom(url);
+            };
         }
     };
 };
@@ -361,10 +373,12 @@ export var register = (angular) => {
             "adhConfig", "adhPermissions", "adhTopLevelState", "adhHttp", processDetailColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzDocumentDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", documentDetailColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzProposalDetailColumn", ["adhConfig", "adhPermissions", proposalDetailColumnDirective])
+        .directive("adhMeinBerlinAlexanderplatzProposalDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", proposalDetailColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzDocumentCreateColumn", ["adhConfig", "adhHttp", documentCreateColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalCreateColumn", ["adhConfig", proposalCreateColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzDocumentEditColumn", [
             "adhConfig", "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", documentEditColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzProposalEditColumn", ["adhConfig", proposalEditColumnDirective]);
+        .directive("adhMeinBerlinAlexanderplatzProposalEditColumn", [
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", proposalEditColumnDirective]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Workbench/Workbench.ts
@@ -69,6 +69,10 @@ export var processDetailColumnDirective = (
             scope.documentType = RIGeoDocumentVersion.content_type;
             scope.shared.isShowMap = true;
 
+            scope.setCameFrom = () => {
+                adhTopLevelState.setCameFrom();
+            };
+
             scope.showMap = (isShowMap) => {
                 scope.shared.isShowMap = isShowMap;
             };
@@ -126,7 +130,9 @@ export var proposalDetailColumnDirective = (
 
 export var documentCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -141,6 +147,11 @@ export var documentCreateColumnDirective = (
                     });
                 }
             });
+
+            scope.cancel = () => {
+                var url = adhResourceUrl(scope.processUrl);
+                adhTopLevelState.goToCameFrom(url);
+            };
         }
     };
 };
@@ -174,7 +185,9 @@ export var documentEditColumnDirective = (
 };
 
 export var proposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -182,6 +195,11 @@ export var proposalCreateColumnDirective = (
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl"]);
+
+            scope.cancel = () => {
+                var url = adhResourceUrl(scope.processUrl);
+                adhTopLevelState.goToCameFrom(url);
+            };
         }
     };
 };
@@ -375,8 +393,10 @@ export var register = (angular) => {
             "adhConfig", "adhPermissions", "adhTopLevelState", documentDetailColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", proposalDetailColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzDocumentCreateColumn", ["adhConfig", "adhHttp", documentCreateColumnDirective])
-        .directive("adhMeinBerlinAlexanderplatzProposalCreateColumn", ["adhConfig", proposalCreateColumnDirective])
+        .directive("adhMeinBerlinAlexanderplatzDocumentCreateColumn", [
+            "adhConfig", "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", documentCreateColumnDirective])
+        .directive("adhMeinBerlinAlexanderplatzProposalCreateColumn", [
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", proposalCreateColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzDocumentEditColumn", [
             "adhConfig", "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", documentEditColumnDirective])
         .directive("adhMeinBerlinAlexanderplatzProposalEditColumn", [

--- a/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -38,7 +38,7 @@ export var mercatorWorkbenchDirective = (
 
 var bindRedirectsToScope = (scope, adhConfig, adhResourceUrlFilter, $location) => {
     scope.redirectAfterProposalCancel = (resourcePath : string) => {
-        // FIXME: use adhTopLevelState.redirectToCameFrom
+        // FIXME: use adhTopLevelState.goToCameFrom
         $location.url(adhResourceUrlFilter(resourcePath));
     };
     scope.redirectAfterProposalSubmit = (result : any[]) => {


### PR DESCRIPTION
I fixed all action/cancel links in the workbench to correctly set and get `cameFrom`. While working on that I also refactored the cameFrom related functions. Note however that #1061 is still in effect.

An interesting observation: While working on this I also tried to keep the cancel URLs and use them as default url for `goToCameFrom()`. However, canceling all other event handlers with `event.preventDefault()` or even `event.stopImmediatePropagation()` did not work because of our href hack introduced in #406. We should definitely look into it again soon.