### PR TITLE
Add 'authenticated' group to all imported users

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scripts/import_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/import_users.py
@@ -132,17 +132,15 @@ def _get_groups(groups_names: [str], groups: IResource) -> [IResource]:
 
 def _create_user(user_info: dict, users: IResource, registry: Registry,
                  groups: IResource, activate=True) -> IUser:
-    groups = _get_groups(user_info['groups'], groups)
-    if groups == []:
-        default = _get_default_group(users)
-        groups = [default]
+    default_groups = [_get_default_group(users)]
+    user_groups = default_groups + _get_groups(user_info['groups'], groups)
     appstruct = {sheets.principal.IUserBasic.__identifier__:
                  {'name': user_info['name']},
                  sheets.principal.IUserExtended.__identifier__:
                  {'email': user_info['email']},
                  sheets.principal.IPermissions.__identifier__:
                  {'roles': user_info['roles'],
-                  'groups': groups},
+                  'groups': user_groups},
                  sheets.principal.IPasswordAuthentication.
                  __identifier__: {'password': user_info['initial-password']},
                  }


### PR DESCRIPTION
When a group was defined in the JSON file for the import_users script,
the default group, 'authenticated', were not associated to the created
user if groups were already defined. This caused permissions problems
for logged in users.