### PR TITLE
alexanderplatz phase information

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Alexanderplatz.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Alexanderplatz.ts
@@ -1,16 +1,19 @@
 import AdhMeinBerlinAlexanderplatzWorkbench = require("./Workbench/Workbench");
 import AdhMeinBerlinAlexanderplatzContext = require("./Context/Context");
+import AdhMeinBerlinAlexanderplatzProcess = require("./Process/Process");
 
 
 export var moduleName = "adhMeinBerlinAlexanderplatz";
 
 export var register = (angular) => {
     AdhMeinBerlinAlexanderplatzContext.register(angular);
+    AdhMeinBerlinAlexanderplatzProcess.register(angular);
     AdhMeinBerlinAlexanderplatzWorkbench.register(angular);
 
     angular
         .module(moduleName, [
             AdhMeinBerlinAlexanderplatzContext.moduleName,
+            AdhMeinBerlinAlexanderplatzProcess.moduleName,
             AdhMeinBerlinAlexanderplatzWorkbench.moduleName
         ]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/template.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/template.html
@@ -4,6 +4,7 @@
             <div class="l-cell">
                 <div class="l-cell-inner">
                     <adh-alexanderplatz-context-header></adh-alexanderplatz-context-header>
+                    <adh-mein-berlin-alexanderplatz-phase-header></adh-mein-berlin-alexanderplatz-phase-header>
                 </div>
             </div>
         </div>
@@ -13,7 +14,6 @@
                     <adh-space data-key="content">
                         <adh-process-view></adh-process-view>
                     </adh-space>
-
                     <adh-space data-key="error">
                         <adh-routing-error></adh-routing-error>
                     </adh-space>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Phase.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Phase.html
@@ -1,0 +1,29 @@
+<div class="phase">
+    <h3 class="phase-title">{{phase.title}}</h3>
+    <div class="phase-process-type">{{phase.processType}}</div>
+    <p class="phase-description">{{phase.description}}</p>
+    <div class="phase-meta">
+        <span class="phase-availability">
+            <i class="icon-comment-gap m-availability-indicator" data-ng-class="{'is-available': phase.commentAvailable}"></i>
+            <i class="icon-voting-gap m-availability-indicator" data-ng-class="{'is-available': phase.votingAvailable}"></i>
+
+            <span class="phase-availability-summary">
+                <span data-ng-if="phase.commentAvailable && phase.votingAvailable">{{ "TR__AVAILABLE_PARTICIPATION" | translate}}</span>
+                <span data-ng-if="phase.commentAvailable && !phase.votingAvailable">{{ "TR__AVAILABLE_COMMENT" | translate}}</span>
+                <span data-ng-if="!phase.commentAvailable && phase.votingAvailable">{{ "TR__AVAILABLE_VOTING" | translate}}</span>
+                <span data-ng-if="!phase.commentAvailable && !phase.votingAvailable">{{ "TR__AVAILABLE_NONE" | translate}}</span>
+            </span>
+        </span>
+
+        <!--<span class="phase-date">
+            <i class="icon-calendar"></i>
+            <span data-ng-if="phase.startDate" title="{{ 'TR__START_DATE' | translate }}">
+                <adh-time data-datetime="phase.startDate" format="L"></adh-time>
+            </span>
+            <span data-ng-if="phase.startDate && phase.endDate"> / </span>
+            <span data-ng-if="phase.endDate" title="{{ 'TR__END_DATE' | translate }}">
+                <adh-time data-datetime="phase.endDate" format="L"></adh-time>
+            </span>
+        </span>-->
+    </div>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Phase.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Phase.html
@@ -14,16 +14,5 @@
                 <span data-ng-if="!phase.commentAvailable && !phase.votingAvailable">{{ "TR__AVAILABLE_NONE" | translate}}</span>
             </span>
         </span>
-
-        <!--<span class="phase-date">
-            <i class="icon-calendar"></i>
-            <span data-ng-if="phase.startDate" title="{{ 'TR__START_DATE' | translate }}">
-                <adh-time data-datetime="phase.startDate" format="L"></adh-time>
-            </span>
-            <span data-ng-if="phase.startDate && phase.endDate"> / </span>
-            <span data-ng-if="phase.endDate" title="{{ 'TR__END_DATE' | translate }}">
-                <adh-time data-datetime="phase.endDate" format="L"></adh-time>
-            </span>
-        </span>-->
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/PhaseHeader.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/PhaseHeader.html
@@ -1,0 +1,13 @@
+<div class="phase-header">
+    <tabset
+        data-full-width="true"
+        data-closed-by-default="true">
+        <tab
+            data-ng-repeat="phase in phases"
+            data-heading="{{phase.shorttitle}}"
+            data-classes="m-phase"
+            data-highlighted="phase.name == currentPhase">
+            <adh-mein-berlin-alexanderplatz-phase data-phase="phase"></adh-mein-berlin-alexanderplatz-phase>
+        </tab>
+    </tabset>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
@@ -1,0 +1,105 @@
+/// <reference path="../../../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
+/// <reference path="../../../../../lib/DefinitelyTyped/moment/moment.d.ts"/>
+
+import _ = require("lodash");
+
+import AdhConfig = require("..././../Config/Config");
+import AdhHttp = require("../../../Http/Http");
+import AdhMovingColumns = require("../../../MovingColumns/MovingColumns");
+import AdhPermissions = require("../../../Permissions/Permissions");
+import AdhTabs = require("../../../Tabs/Tabs");
+import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
+import AdhUtil = require("../../../Util/Util");
+
+import SILocationReference = require("../../../../Resources_/adhocracy_core/sheets/geo/ILocationReference");
+import SIMultiPolygon = require("../../../../Resources_/adhocracy_core/sheets/geo/IMultiPolygon");
+import SITitle = require("../../../../Resources_/adhocracy_core/sheets/title/ITitle");
+import SIWorkflow = require("../../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment");
+
+var pkgLocation = "/MeinBerlin/Alexanderplatz/Process";
+
+
+export var phaseHeaderDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/PhaseHeader.html",
+        scope: {},
+        link: (scope) => {
+            var processUrl = adhTopLevelState.get("processUrl");
+            adhHttp.get(processUrl).then((resource) => {
+                scope.currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                /*scope.phases[0].startDate = resource.data[SIWorkflow.nick].announce.start_date;
+                scope.phases[0].endDate = resource.data[SIWorkflow.nick].participate.start_date;
+                scope.phases[1].startDate = resource.data[SIWorkflow.nick].participate.start_date;
+                scope.phases[1].endDate = resource.data[SIWorkflow.nick].frozen.start_date;
+                scope.phases[2].startDate = resource.data[SIWorkflow.nick].frozen.start_date;
+                scope.phases[2].endDate = resource.data[SIWorkflow.nick].result.start_date;
+                scope.phases[3].startDate = resource.data[SIWorkflow.nick].result.start_date;*/
+            });
+
+            scope.phases = [{
+                name: "participate",
+                shorttitle: "Phase 1",
+                title: "Veränderungsstrategien für den neuen Masterplan.",
+                description: "Was bleibt wie es ist und was muss und kann geändert werden (thematisch und räumlich) " +
+                    "am Masterplan für den Alexanderplatz? Die Auswertung des 1. Fachworkshops sowie Anmerkungen aus " +
+                    "der Onlinebeteiligung fließen in den Bürgerworkshop am 01.09 ein. In den Workshops, in der begleitenden " +
+                    "Ausstellung am Alexanderplatz (20.08. – 06.09., Alexanderhaus - Eingang Dircksenstraße)" +
+                    "sowie hier online wird zusammengetragen und diskutiert.",
+                processType: "Workshopverfahren Alexanderplatz",
+                votingAvailable: true,
+                commentAvailable: true
+            }, {
+                name: "evaluate",
+                shorttitle: "Phase 2",
+                title: "Varianten und Alternativen für den neuen Masterplan.",
+                description: "November bis Dezember 2015. Im zweiten Fachworkshop am 02.11. und im zweiten Bürgerworkshop am 09.11. " +
+                    "geht es um die Arbeit am neuen Masterplan. Zwischenergebnisse und Vorschläge erweitern die Ausstellung im Alexanderhaus. " +
+                    "Die Anmerkungen aus der Onlinebeteiligung werden in die Workshops mit einfließen.",
+                processType: "Workshopverfahren Alexanderplatz",
+                votingAvailable: true,
+                commentAvailable: true
+            }, {
+                name: "result",
+                shorttitle: "Phase 3",
+                title: "Der neue Masterplan wird vorgestellt.",
+                description: "Aus den Ergebnissen der Workshops, der Onlinebeteiligung sowie Anregungen aus der Ausstellung wird ein " +
+                    "neuer Masterplan zum Beschluss für das Abgeordnetenhaus entwickelt. Voraussichtlich im Frühjahr 2016 gibt es eine" +
+                    "Finissage /Abschlussausstellung.",
+                processType: "Workshopverfahren Alexanderplatz",
+                votingAvailable: false,
+                commentAvailable: false
+            }];
+        }
+    };
+};
+
+
+export var phaseDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Phase.html",
+        scope: {
+            phase: "="
+        }
+    };
+};
+
+export var moduleName = "adhMeinBerlinAlexanderplatzProcess";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhHttp.moduleName,
+            AdhMovingColumns.moduleName,
+            AdhPermissions.moduleName,
+            AdhTabs.moduleName,
+            AdhTopLevelState.moduleName
+        ])
+        .directive("adhMeinBerlinAlexanderplatzPhase", ["adhConfig", phaseDirective])
+        .directive("adhMeinBerlinAlexanderplatzPhaseHeader", ["adhConfig", "adhHttp", "adhTopLevelState", phaseHeaderDirective]);
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
@@ -1,19 +1,10 @@
-/// <reference path="../../../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
-/// <reference path="../../../../../lib/DefinitelyTyped/moment/moment.d.ts"/>
-
-import _ = require("lodash");
-
 import AdhConfig = require("..././../Config/Config");
 import AdhHttp = require("../../../Http/Http");
 import AdhMovingColumns = require("../../../MovingColumns/MovingColumns");
 import AdhPermissions = require("../../../Permissions/Permissions");
 import AdhTabs = require("../../../Tabs/Tabs");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
-import AdhUtil = require("../../../Util/Util");
 
-import SILocationReference = require("../../../../Resources_/adhocracy_core/sheets/geo/ILocationReference");
-import SIMultiPolygon = require("../../../../Resources_/adhocracy_core/sheets/geo/IMultiPolygon");
-import SITitle = require("../../../../Resources_/adhocracy_core/sheets/title/ITitle");
 import SIWorkflow = require("../../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment");
 
 var pkgLocation = "/MeinBerlin/Alexanderplatz/Process";

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
@@ -32,13 +32,6 @@ export var phaseHeaderDirective = (
             var processUrl = adhTopLevelState.get("processUrl");
             adhHttp.get(processUrl).then((resource) => {
                 scope.currentPhase = resource.data[SIWorkflow.nick].workflow_state;
-                /*scope.phases[0].startDate = resource.data[SIWorkflow.nick].announce.start_date;
-                scope.phases[0].endDate = resource.data[SIWorkflow.nick].participate.start_date;
-                scope.phases[1].startDate = resource.data[SIWorkflow.nick].participate.start_date;
-                scope.phases[1].endDate = resource.data[SIWorkflow.nick].frozen.start_date;
-                scope.phases[2].startDate = resource.data[SIWorkflow.nick].frozen.start_date;
-                scope.phases[2].endDate = resource.data[SIWorkflow.nick].result.start_date;
-                scope.phases[3].startDate = resource.data[SIWorkflow.nick].result.start_date;*/
             });
 
             scope.phases = [{

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Process/Process.ts
@@ -32,7 +32,7 @@ export var phaseHeaderDirective = (
                 description: "Was bleibt wie es ist und was muss und kann geändert werden (thematisch und räumlich) " +
                     "am Masterplan für den Alexanderplatz? Die Auswertung des 1. Fachworkshops sowie Anmerkungen aus " +
                     "der Onlinebeteiligung fließen in den Bürgerworkshop am 01.09 ein. In den Workshops, in der begleitenden " +
-                    "Ausstellung am Alexanderplatz (20.08. – 06.09., Alexanderhaus - Eingang Dircksenstraße)" +
+                    "Ausstellung am Alexanderplatz (20.08. – 06.09., Alexanderhaus - Eingang Dircksenstraße) " +
                     "sowie hier online wird zusammengetragen und diskutiert.",
                 processType: "Workshopverfahren Alexanderplatz",
                 votingAvailable: true,
@@ -52,8 +52,8 @@ export var phaseHeaderDirective = (
                 shorttitle: "Phase 3",
                 title: "Der neue Masterplan wird vorgestellt.",
                 description: "Aus den Ergebnissen der Workshops, der Onlinebeteiligung sowie Anregungen aus der Ausstellung wird ein " +
-                    "neuer Masterplan zum Beschluss für das Abgeordnetenhaus entwickelt. Voraussichtlich im Frühjahr 2016 gibt es eine" +
-                    "Finissage /Abschlussausstellung.",
+                    "neuer Masterplan zum Beschluss für das Abgeordnetenhaus entwickelt. Voraussichtlich im Frühjahr 2016 gibt es eine " +
+                    "Finissage/Abschlussausstellung.",
                 processType: "Workshopverfahren Alexanderplatz",
                 votingAvailable: false,
                 commentAvailable: false


### PR DESCRIPTION
*continued from #1528*

This adds a phase information widget to the alexanderplatz context. There are still two issues:

-   [ ] Clicking on a phase tab will only open the drop down on second try. This also affects kiezkassen.
-   [ ] `currentPhase` is currently bound to the workflow state. It should not be in this case.

These issues can be fix in this branch or in separate ones. I don't care.