### PR TITLE
Add title sheet for badges in import_users script

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scripts/import_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/import_users.py
@@ -181,14 +181,22 @@ def _create_badges(user: IUser, badge_names: [str],
     badges_service = find_service(user, 'badges')
     badges = []
     for name in badge_names:
-        badge = badges_service.get(name, None)
+        normalized_name = _normalize_badge_name(name)
+        badge = badges_service.get(normalized_name, None)
         if badge is None:
-            appstructs = {sheets.name.IName.__identifier__: {'name': name}}
+            appstructs = {sheets.name.IName.__identifier__:
+                          {'name': normalized_name},
+                          sheets.title.ITitle.__identifier__:
+                          {'title': name}}
             badge = registry.content.create(IBadge.__identifier__,
                                             parent=badges_service,
                                             appstructs=appstructs)
         badges.append(badge)
     return badges
+
+
+def _normalize_badge_name(name: str) -> str:
+    return name.lower()
 
 
 def _assign_badges(user: IUser, badges: [IBadge], registry: Registry):

--- a/src/adhocracy_core/adhocracy_core/scripts/test_import_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_import_users.py
@@ -212,10 +212,10 @@ class TestImportUsers:
             f.write(json.dumps([
                 {'name': 'Alice', 'email': 'alice@example.org',
                  'initial-password': '', 'roles': [],
-                 'groups': ['gods'], 'badges': ['expert']},
+                 'groups': ['gods'], 'badges': ['Expert']},
                 {'name': 'Bob', 'email': 'bob@example.org',
                  'initial-password': 'weak', 'roles': [],
-                 'groups': [], 'badges': ['expert']},
+                 'groups': [], 'badges': ['Expert']},
             ]))
         locator = self._get_user_locator(context, registry)
 
@@ -237,6 +237,8 @@ class TestImportUsers:
         assert assignment_sheet.get() == {'object': bob,
                                           'badge': badge,
                                           'subject': bob}
+        title = get_sheet_field(badge, sheets.title.ITitle, 'title')
+        assert title == 'Expert'
 
     def test_create_and_send_invitation_mail_with_custom_subject(
             self, context, registry, mock_messenger):


### PR DESCRIPTION
Set title sheet when assigning a badge to an user. The title of the
badge is name given in the JSON file, the name in the graph and url is
the lower case version of the title.

No further validation is done yet as we don't have a good concept to
validate input in the scripts.