### PR TITLE
raise tab width calculation precision

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
@@ -35,7 +35,7 @@ export class TabSetController {
         if (this.$scope.fullWidth) {
             var value = this.$scope.tabs.length;
             if (value !== 0) {
-                var tabWidth = Math.floor(100 / value);
+                var tabWidth = Math.floor(100 * 10 / value) / 10;
                 this.$timeout(() => {
                     this.$element.find(".tab").css("width", tabWidth + "%");
                 });


### PR DESCRIPTION
the tab width is measured in percentage. Thie issue with this is that the rounding that occours when converting % into px may leave us with more than 100%.

To counter that, we floor the width. However, 1% is actually a lot. So this improves the precision slightly.

This may be supplemented by some CSS hacks. But it already improves the situation a lot.