### PR TITLE
Switch to fixed rubygemsrecipe fork

### DIFF
--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -47,7 +47,6 @@ pytest-splinter = 1.2.10
 pytest-timeout = 0.4
 repoze.sendmail = 4.2
 requests = 2.5.1
-rubygemsrecipe = 0.2.1
 selenium = 2.44.0
 Babel = 1.3
 repoze.sphinx.autointerface = 0.7.1

--- a/src/adhocracy_frontend/sources.cfg
+++ b/src/adhocracy_frontend/sources.cfg
@@ -4,3 +4,5 @@ auto-checkout = *
 
 [sources]
 supervisor = git https://github.com/Supervisor/supervisor.git rev=03333b854625d5e948d077d1110f1b7f14bd2892
+rubygemsrecipe = hg ssh://hg@bitbucket.org/ximmm/rubygemsrecipe branch=fix-rubygems-url
+

--- a/src/adhocracy_frontend/sources.cfg
+++ b/src/adhocracy_frontend/sources.cfg
@@ -4,5 +4,5 @@ auto-checkout = *
 
 [sources]
 supervisor = git https://github.com/Supervisor/supervisor.git rev=03333b854625d5e948d077d1110f1b7f14bd2892
-rubygemsrecipe = hg ssh://hg@bitbucket.org/ximmm/rubygemsrecipe branch=fix-rubygems-url
+rubygemsrecipe = hg https://bitbucket.org/ximmm/rubygemsrecipe branch=fix-rubygems-url
 


### PR DESCRIPTION
*fixes #1543*

Installing rubygems with buildout currently fails because ruby changed their API and rubygemsrecipe has not yet been updated.

I fixed the upstream issue and switched to the fixed fork in the pull request. If travis succeedes in this PR I will create an upstream pull request.