### PR TITLE
Reduce routing code duplication in Kiezkassen

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/Context.ts
@@ -9,13 +9,7 @@ import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
 import AdhMeinBerlinAlexanderplatzWorkbench = require("../Workbench/Workbench");
 
 import RIAlexanderplatzProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/alexanderplatz/IProcess");
-import RIGeoDocument = require("../../../../Resources_/adhocracy_core/resources/document/IGeoDocument");
-import RIGeoDocumentVersion = require("../../../../Resources_/adhocracy_core/resources/document/IGeoDocumentVersion");
 import RIGeoProposal = require("../../../../Resources_/adhocracy_core/resources/proposal/IGeoProposal");
-import RIGeoProposalVersion = require("../../../../Resources_/adhocracy_core/resources/proposal/IGeoProposalVersion");
-import RIParagraph = require("../../../../Resources_/adhocracy_core/resources/paragraph/IParagraph");
-import RIParagraphVersion = require("../../../../Resources_/adhocracy_core/resources/paragraph/IParagraphVersion");
-import SIParagraph = require("../../../../Resources_/adhocracy_core/sheets/document/IParagraph");
 
 var pkgLocation = "/MeinBerlin/Alexanderplatz/Context";
 

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Alexanderplatz/Context/Context.ts
@@ -6,7 +6,7 @@ import AdhPermissions = require("../../../Permissions/Permissions");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
 
-import AdhMeinBerlinWorkbench = require("../Workbench/Workbench");
+import AdhMeinBerlinAlexanderplatzWorkbench = require("../Workbench/Workbench");
 
 import RIAlexanderplatzProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/alexanderplatz/IProcess");
 import RIGeoDocument = require("../../../../Resources_/adhocracy_core/resources/document/IGeoDocument");
@@ -51,7 +51,7 @@ export var register = (angular) => {
         .module(moduleName, [
             AdhEmbed.moduleName,
             AdhHttp.moduleName,
-            AdhMeinBerlinWorkbench.moduleName,
+            AdhMeinBerlinAlexanderplatzWorkbench.moduleName,
             AdhPermissions.moduleName,
             AdhResourceArea.moduleName,
             AdhTopLevelState.moduleName
@@ -68,7 +68,7 @@ export var register = (angular) => {
                     ) => {
                     return $templateRequest(adhConfig.pkg_path + pkgLocation + "/template.html");
                 }]);
-            AdhMeinBerlinWorkbench.registerRoutes(processType, "alexanderplatz")(adhResourceAreaProvider);
+            AdhMeinBerlinAlexanderplatzWorkbench.registerRoutes(processType, "alexanderplatz")(adhResourceAreaProvider);
         }])
         .config(["adhMapDataProvider", (adhMapDataProvider: AdhMapping.MapDataProvider) => {
             adhMapDataProvider.icons["document"] = {

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -1,6 +1,5 @@
 import AdhConfig = require("../../../Config/Config");
 import AdhEmbed = require("../../../Embed/Embed");
-import AdhHttp = require("../../../Http/Http");
 import AdhPermissions = require("../../../Permissions/Permissions");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
@@ -35,7 +34,6 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhEmbed.moduleName,
-            AdhHttp.moduleName,
             AdhMeinBerlinKiezkassenWorkbench.moduleName,
             AdhPermissions.moduleName,
             AdhResourceArea.moduleName,

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -5,7 +5,7 @@ import AdhPermissions = require("../../../Permissions/Permissions");
 import AdhResourceArea = require("../../../ResourceArea/ResourceArea");
 import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
 
-import AdhMeinBerlinWorkbench = require("../Workbench/Workbench");
+import AdhMeinBerlinKiezkassenWorkbench = require("../Workbench/Workbench");
 
 import RIComment = require("../../../../Resources_/adhocracy_core/resources/comment/IComment");
 import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
@@ -41,7 +41,7 @@ export var register = (angular) => {
         .module(moduleName, [
             AdhEmbed.moduleName,
             AdhHttp.moduleName,
-            AdhMeinBerlinWorkbench.moduleName,
+            AdhMeinBerlinKiezkassenWorkbench.moduleName,
             AdhPermissions.moduleName,
             AdhResourceArea.moduleName,
             AdhTopLevelState.moduleName

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Context/Context.ts
@@ -7,12 +7,7 @@ import AdhTopLevelState = require("../../../TopLevelState/TopLevelState");
 
 import AdhMeinBerlinKiezkassenWorkbench = require("../Workbench/Workbench");
 
-import RIComment = require("../../../../Resources_/adhocracy_core/resources/comment/IComment");
-import RICommentVersion = require("../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion");
 import RIKiezkassenProcess = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess");
-import RIProposal = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposal");
-import RIProposalVersion = require("../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion");
-import SIComment = require("../../../../Resources_/adhocracy_core/sheets/comment/IComment");
 
 var pkgLocation = "/MeinBerlin/Kiezkassen/Context";
 
@@ -57,89 +52,10 @@ export var register = (angular) => {
                     $templateRequest : angular.ITemplateRequestService
                 ) => {
                     return $templateRequest(adhConfig.pkg_path + pkgLocation + "/template.html");
-                }])
-                .default(RIKiezkassenProcess, "", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-show-hide-hide"
-                })
-                .default(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {};
-                            }
-                        });
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
-                        return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {
-                                    proposalUrl: version.path
-                                };
-                            }
-                        });
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    () => (item : RIProposal, version : RIProposalVersion) => {
-                        return {
-                            proposalUrl: version.path
-                        };
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-collapse-show-show"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "kiezkassen", [
-                    () => (item : RIProposal, version : RIProposalVersion) => {
-                        return {
-                            commentableUrl: version.path,
-                            commentCloseUrl: version.path,
-                            proposalUrl: version.path
-                        };
-                    }])
-                .defaultVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", {
-                    space: "content",
-                    movingColumns: "is-collapse-show-show"
-                })
-                .specificVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "kiezkassen", ["adhHttp", "$q", (
-                    adhHttp : AdhHttp.Service<any>,
-                    $q : angular.IQService
-                ) => {
-                    var getCommentableUrl = (resource) : angular.IPromise<any> => {
-                        if (resource.content_type !== RICommentVersion.content_type) {
-                            return $q.when(resource);
-                        } else {
-                            var url = resource.data[SIComment.nick].refers_to;
-                            return adhHttp.get(url).then(getCommentableUrl);
-                        }
-                    };
-
-                    return (item : RIComment, version : RICommentVersion) => {
-                        return getCommentableUrl(version).then((commentable) => {
-                            return {
-                                commentableUrl: commentable.path,
-                                commentCloseUrl: commentable.path,
-                                proposalUrl: commentable.path
-                            };
-                        });
-                    };
                 }]);
+            AdhMeinBerlinKiezkassenWorkbench.registerRoutes(
+                RIKiezkassenProcess.content_type,
+                "kiezkassen"
+            )(adhResourceAreaProvider);
         }]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/MeinBerlin/Kiezkassen/Workbench/Workbench.ts
@@ -152,6 +152,110 @@ export var kiezkassenEditColumnDirective = (
     };
 };
 
+export var registerRoutes = (
+    processType : string = "",
+    context : string = ""
+) => (adhResourceAreaProvider : AdhResourceArea.Provider) => {
+    adhResourceAreaProvider
+        .default(RIKiezkassenProcess, "", processType, context, {
+            space: "content",
+            movingColumns: "is-show-hide-hide"
+        })
+        .default(RIKiezkassenProcess, "edit", processType, context, {
+            space: "content",
+            movingColumns: "is-show-hide-hide"
+        })
+        .specific(RIKiezkassenProcess, "edit", processType, context, [
+            "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
+                return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                    if (!options.PUT) {
+                        throw 401;
+                    } else {
+                        return {};
+                    }
+                });
+            }])
+        .default(RIKiezkassenProcess, "create_proposal", processType, context, {
+            space: "content",
+            movingColumns: "is-show-show-hide"
+        })
+        .specific(RIKiezkassenProcess, "create_proposal", processType, context, [
+            "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
+                return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
+                    if (!options.POST) {
+                        throw 401;
+                    } else {
+                        return {};
+                    }
+                });
+            }])
+        .defaultVersionable(RIProposal, RIProposalVersion, "edit", processType, context, {
+            space: "content",
+            movingColumns: "is-show-show-hide"
+        })
+        .specificVersionable(RIProposal, RIProposalVersion, "edit", processType, context, [
+            "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
+                return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
+                    if (!options.POST) {
+                        throw 401;
+                    } else {
+                        return {
+                            proposalUrl: version.path
+                        };
+                    }
+                });
+            }])
+        .defaultVersionable(RIProposal, RIProposalVersion, "", processType, context, {
+            space: "content",
+            movingColumns: "is-show-show-hide"
+        })
+        .specificVersionable(RIProposal, RIProposalVersion, "", processType, context, [
+            () => (item : RIProposal, version : RIProposalVersion) => {
+                return {
+                    proposalUrl: version.path
+                };
+            }])
+        .defaultVersionable(RIProposal, RIProposalVersion, "comments", processType, context, {
+            space: "content",
+            movingColumns: "is-collapse-show-show"
+        })
+        .specificVersionable(RIProposal, RIProposalVersion, "comments", processType, context, [
+            () => (item : RIProposal, version : RIProposalVersion) => {
+                return {
+                    commentableUrl: version.path,
+                    commentCloseUrl: version.path,
+                    proposalUrl: version.path
+                };
+            }])
+        .defaultVersionable(RIComment, RICommentVersion, "", processType, context, {
+            space: "content",
+            movingColumns: "is-collapse-show-show"
+        })
+        .specificVersionable(RIComment, RICommentVersion, "", processType, context, ["adhHttp", "$q", (
+            adhHttp : AdhHttp.Service<any>,
+            $q : angular.IQService
+        ) => {
+            var getCommentableUrl = (resource) : angular.IPromise<any> => {
+                if (resource.content_type !== RICommentVersion.content_type) {
+                    return $q.when(resource);
+                } else {
+                    var url = resource.data[SIComment.nick].refers_to;
+                    return adhHttp.get(url).then(getCommentableUrl);
+                }
+            };
+
+            return (item : RIComment, version : RICommentVersion) => {
+                return getCommentableUrl(version).then((commentable) => {
+                    return {
+                        commentableUrl: commentable.path,
+                        commentCloseUrl: commentable.path,
+                        proposalUrl: commentable.path
+                    };
+                });
+            };
+        }]);
+};
+
 export var moduleName = "adhMeinBerlinWorkbench";
 
 export var register = (angular) => {
@@ -167,106 +271,7 @@ export var register = (angular) => {
             AdhResourceArea.moduleName,
             AdhTopLevelState.moduleName
         ])
-        .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
-            adhResourceAreaProvider
-                .default(RIKiezkassenProcess, "", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-show-hide-hide"
-                })
-                .default(RIKiezkassenProcess, "edit", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-show-hide-hide"
-                })
-                .specific(RIKiezkassenProcess, "edit", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.PUT) {
-                                throw 401;
-                            } else {
-                                return {};
-                            }
-                        });
-                    }])
-                .default(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specific(RIKiezkassenProcess, "create_proposal", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (resource : RIKiezkassenProcess) => {
-                        return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {};
-                            }
-                        });
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "edit", RIKiezkassenProcess.content_type, "", [
-                    "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
-                        return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
-                            if (!options.POST) {
-                                throw 401;
-                            } else {
-                                return {
-                                    proposalUrl: version.path
-                                };
-                            }
-                        });
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-show-show-hide"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "", RIKiezkassenProcess.content_type, "", [
-                    () => (item : RIProposal, version : RIProposalVersion) => {
-                        return {
-                            proposalUrl: version.path
-                        };
-                    }])
-                .defaultVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-collapse-show-show"
-                })
-                .specificVersionable(RIProposal, RIProposalVersion, "comments", RIKiezkassenProcess.content_type, "", [
-                    () => (item : RIProposal, version : RIProposalVersion) => {
-                        return {
-                            commentableUrl: version.path,
-                            commentCloseUrl: version.path,
-                            proposalUrl: version.path
-                        };
-                    }])
-                .defaultVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "", {
-                    space: "content",
-                    movingColumns: "is-collapse-show-show"
-                })
-                .specificVersionable(RIComment, RICommentVersion, "", RIKiezkassenProcess.content_type, "", ["adhHttp", "$q", (
-                    adhHttp : AdhHttp.Service<any>,
-                    $q : angular.IQService
-                ) => {
-                    var getCommentableUrl = (resource) : angular.IPromise<any> => {
-                        if (resource.content_type !== RICommentVersion.content_type) {
-                            return $q.when(resource);
-                        } else {
-                            var url = resource.data[SIComment.nick].refers_to;
-                            return adhHttp.get(url).then(getCommentableUrl);
-                        }
-                    };
-
-                    return (item : RIComment, version : RICommentVersion) => {
-                        return getCommentableUrl(version).then((commentable) => {
-                            return {
-                                commentableUrl: commentable.path,
-                                commentCloseUrl: commentable.path,
-                                proposalUrl: commentable.path
-                            };
-                        });
-                    };
-                }]);
-        }])
+        .config(["adhResourceAreaProvider", registerRoutes(RIKiezkassenProcess.content_type)])
         .config(["adhProcessProvider", (adhProcessProvider : AdhProcess.Provider) => {
             adhProcessProvider.templateFactories[RIKiezkassenProcess.content_type] = ["$q", ($q : angular.IQService) => {
                 return $q.when("<adh-mein-berlin-workbench></adh-mein-berlin-workbench>");


### PR DESCRIPTION
This is very similar to #1541, only for kiezkassen. Additionally, this also removes some left-over imports in alexanderplatz.