### PR TITLE
Fix classes on tabs

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/Tabs.ts
@@ -123,9 +123,11 @@ export var tabDirective = (adhConfig : AdhConfig.IService) => {
                 scope.active = active;
                 if (active) {
                     paneElement.removeClass("ng-hide");
+                    paneElement.addClass("is-active");
                     scope.height = paneElement.outerHeight();
                 } else {
                     paneElement.addClass("ng-hide");
+                    paneElement.removeClass("is-active");
                 }
             };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tab.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Tabs/tab.html
@@ -1,5 +1,3 @@
-<div
-    class="tab-pane {{classes}}"
-    data-ng-class="{'is-active': active}">
+<div class="tab-pane" data-ng-class="classes">
     <ng-transclude></ng-transclude>
 </div>


### PR DESCRIPTION
*Fixes #1566*

It seems like `$element.addClass()` and `class="{{foo}}"` don't play well together.  That's why initially, all panes were visible. To the user it seemed like they always saw the first pane when they first opened any.