### PR TITLE
fix kiezkassen not badgeable

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/proposal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/proposal.py
@@ -41,6 +41,7 @@ proposal_meta = item_meta._replace(
     element_types=(IProposalVersion,),
     item_type=IProposalVersion,
     is_implicit_addable=True,
+    autonaming_prefix='proposal_',
     permission_create='create_proposal',
 )._add(after_creation=(
     add_commentsservice,

--- a/src/adhocracy_core/adhocracy_core/resources/test_proposal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_proposal.py
@@ -14,6 +14,9 @@ class TestProposal:
         assert meta.element_types == (IProposalVersion,)
         assert meta.item_type == IProposalVersion
         assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'proposal_'
+        assert meta.use_autonaming
+        assert meta.is_implicit_addable
 
     @mark.usefixtures('integration')
     def test_create(self, meta, registry):

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/bplan.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/bplan.py
@@ -1,41 +1,32 @@
 """BPlan process resources."""
-from adhocracy_core.interfaces import IItemVersion
-from adhocracy_core.interfaces import IItem
 from adhocracy_core.resources import add_resource_type_to_registry
-from adhocracy_core.resources.itemversion import itemversion_meta
-from adhocracy_core.resources.item import item_meta
 from adhocracy_core.resources import process
+from adhocracy_core.resources import proposal
 import adhocracy_meinberlin.sheets.bplan
 
 
-class IProposalVersion(IItemVersion):
+class IProposalVersion(proposal.IProposalVersion):
 
     """BPlan proposal version."""
 
 
-proposal_version_meta = itemversion_meta._replace(
+proposal_version_meta = proposal.proposal_version_meta._replace(
     content_name='ProposalVersion',
     iresource=IProposalVersion,
     extended_sheets=(adhocracy_meinberlin.sheets.bplan.IProposal,
                      ),
-    permission_create='edit_proposal',
 )
 
 
-class IProposal(IItem):
+class IProposal(proposal.IProposal):
 
     """BPlan proposal versions pool."""
 
 
-proposal_meta = item_meta._replace(
-    content_name='Proposal',
+proposal_meta = proposal.proposal_meta._replace(
     iresource=IProposal,
     element_types=(IProposalVersion,),
     item_type=IProposalVersion,
-    is_implicit_addable=True,
-    permission_create='create_proposal',
-    use_autonaming=True,
-    autonaming_prefix='proposal_',
     workflow_name = 'bplan_private',
 )
 

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/burgerhaushalt.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/burgerhaushalt.py
@@ -1,6 +1,4 @@
 """Burgerhaushalt proposal."""
-from adhocracy_core.interfaces import IItemVersion
-from adhocracy_core.interfaces import IItem
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources import process
 from adhocracy_core.resources import proposal
@@ -11,7 +9,7 @@ from adhocracy_core.sheets.image import IImageReference
 import adhocracy_meinberlin.sheets.burgerhaushalt
 
 
-class IProposalVersion(IItemVersion):
+class IProposalVersion(proposal.IProposalVersion):
 
     """Burgerhaushalt proposal version."""
 
@@ -22,7 +20,7 @@ proposal_version_meta = proposal.proposal_version_meta._replace(
                         IPoint))
 
 
-class IProposal(IItem):
+class IProposal(proposal.IProposal):
 
     """Burgerhaushalt proposal versions pool."""
 
@@ -31,9 +29,6 @@ proposal_meta = proposal.proposal_meta._replace(
     iresource=IProposal,
     element_types=(IProposalVersion,),
     item_type=IProposalVersion,
-    is_implicit_addable=True,
-    use_autonaming=True,
-    autonaming_prefix='proposal_',
 )
 
 

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/kiezkassen.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/kiezkassen.py
@@ -1,6 +1,4 @@
 """Mercator proposal."""
-from adhocracy_core.interfaces import IItemVersion
-from adhocracy_core.interfaces import IItem
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources import process
 from adhocracy_core.resources import proposal
@@ -11,7 +9,7 @@ from adhocracy_core.sheets.image import IImageReference
 import adhocracy_meinberlin.sheets.kiezkassen
 
 
-class IProposalVersion(IItemVersion):
+class IProposalVersion(proposal.IProposalVersion):
 
     """Kiezkassen proposal version."""
 
@@ -22,7 +20,7 @@ proposal_version_meta = proposal.proposal_version_meta._replace(
                         IPoint))
 
 
-class IProposal(IItem):
+class IProposal(proposal.IProposal):
 
     """Kiezkassen proposal versions pool."""
 
@@ -31,10 +29,6 @@ proposal_meta = proposal.proposal_meta._replace(
     iresource=IProposal,
     element_types=(IProposalVersion,),
     item_type=IProposalVersion,
-    is_implicit_addable=True,
-    permission_create='create_proposal',
-    use_autonaming=True,
-    autonaming_prefix='proposal_',
 )
 
 


### PR DESCRIPTION
API Change:

all meinberlin proposals item/versions l inherit from resource interface  adhocracy_core.proposal.IProposal/IProposalVersion now

all meinberlin proposal items have a badge_assignment service pool now

MANUAL UPGRADE:

Please run first:
     bin/sd_reindex etc/development.ini
then the upgrade step:
     bin/sd_evolve --latest etc/developmnet.init