### PR TITLE
Fix use of AdhDocument in Mercator

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -2,6 +2,7 @@ import AdhConfig = require("../Config/Config");
 import AdhDocument = require("../Document/Document");
 import AdhEmbed = require("../Embed/Embed");
 import AdhHttp = require("../Http/Http");
+import AdhImage = require("../Image/Image");
 import AdhMarkdown = require("../Markdown/Markdown");
 import AdhPermissions = require("../Permissions/Permissions");
 import AdhListing = require("../Listing/Listing");
@@ -210,6 +211,7 @@ export var register = (angular) => {
         .module(moduleName, [
             AdhEmbed.moduleName,
             AdhHttp.moduleName,
+            AdhImage.moduleName,
             AdhMarkdown.moduleName,
             AdhPermissions.moduleName,
             AdhListing.moduleName

--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -3,9 +3,9 @@ import AdhDocument = require("../Document/Document");
 import AdhEmbed = require("../Embed/Embed");
 import AdhHttp = require("../Http/Http");
 import AdhImage = require("../Image/Image");
+import AdhListing = require("../Listing/Listing");
 import AdhMarkdown = require("../Markdown/Markdown");
 import AdhPermissions = require("../Permissions/Permissions");
-import AdhListing = require("../Listing/Listing");
 import AdhPreliminaryNames = require("../PreliminaryNames/PreliminaryNames");
 import AdhUtil = require("../Util/Util");
 
@@ -212,9 +212,9 @@ export var register = (angular) => {
             AdhEmbed.moduleName,
             AdhHttp.moduleName,
             AdhImage.moduleName,
+            AdhListing.moduleName,
             AdhMarkdown.moduleName,
-            AdhPermissions.moduleName,
-            AdhListing.moduleName
+            AdhPermissions.moduleName
         ])
         .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
             adhEmbedProvider.embeddableDirectives.push("blog-post");

--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -63,7 +63,8 @@ export var detailDirective = (
     adhPermissions : AdhPermissions.Service,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhShowError,
-    adhSubmitIfValid
+    adhSubmitIfValid,
+    adhUploadImage
 ) => {
     return {
         restrict: "E",
@@ -105,7 +106,8 @@ export var detailDirective = (
 
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
-                    return AdhDocument.postEdit(adhHttp, adhPreliminaryNames)(scope, scope.documentVersion, scope.paragraphVersions);
+                    return AdhDocument.postEdit(adhHttp, adhPreliminaryNames, adhUploadImage)(
+                        scope, scope.documentVersion, scope.paragraphVersions);
                 }).then((documentVersion : RIDocumentVersion) => {
                     if (typeof scope.onChange !== "undefined") {
                         scope.onChange();
@@ -123,7 +125,8 @@ export var createDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhShowError,
-    adhSubmitIfValid
+    adhSubmitIfValid,
+    adhUploadImage
 ) => {
     return {
         restrict: "E",
@@ -170,7 +173,7 @@ export var createDirective = (
 
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
-                    return AdhDocument.postCreate(adhHttp, adhPreliminaryNames)(scope, scope.path);
+                    return AdhDocument.postCreate(adhHttp, adhPreliminaryNames, adhUploadImage)(scope, scope.path);
                 }).then((documentVersion : RIDocumentVersion) => {
 
                     scope.cancel();
@@ -225,8 +228,9 @@ export var register = (angular) => {
             "adhPreliminaryNames",
             "adhShowError",
             "adhSubmitIfValid",
+            "adhUploadImage",
             detailDirective])
         .directive("adhBlog", ["adhConfig", listingDirective])
         .directive("adhBlogPostCreate", [
-            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", createDirective]);
+            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", "adhUploadImage", createDirective]);
 };


### PR DESCRIPTION
The mercator build was broken by #1564. This fixes that.

Note that `adhUploadImage` is not actually used. But injecting it only when needed would also be complicated. This is a potential refactoring task.