### PR TITLE
allow to set cameFrom in URL

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -246,6 +246,10 @@ export class Service {
                         return this.fromLocation();
                     }
 
+                    if (search.cameFrom) {
+                        this.setCameFrom(search.cameFrom);
+                    }
+
                     this._set("space", data["space"] || "");
                     delete data["space"];
 


### PR DESCRIPTION
This is useful when you want to embed some login protected functionality: You can in that case embed the login form and set `cameFrom`.

Another option to get to the same behavior would be to directly embed the protected feature. The routing should then redirect to login and set `cameFrom` automatically. (I only realised that the second option exists when writing this. I still think the code could be helpful).