### PR TITLE
mv mercator specific code to mercator package

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -19,12 +19,6 @@
         data-value="{{userUrl}}">
         <adh-user-profile
             data-path="{{userUrl}}">
-            <section class="mercator-user-profile-proposal-list">
-                <h3 class="mercator-user-profile-proposal-list-heading">{{ "TR__USERS_PROPOSALS" | translate:userBasic }}</h3>
-                <adh-mercator-user-proposal-listing
-                    data-path="{{path}}">
-                </adh-mercator-user-proposal-listing>
-            </section>
         </adh-user-profile>
     </adh-recompile-on-change>
 

--- a/src/mercator/mercator/static/js/Packages/User/UserDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/User/UserDetailColumn.html
@@ -19,7 +19,13 @@
         data-value="{{userUrl}}">
         <adh-user-profile
             data-path="{{userUrl}}">
-            </adh-user-profile>
+            <section class="mercator-user-profile-proposal-list">
+                <h3 class="mercator-user-profile-proposal-list-heading">{{ "TR__USERS_PROPOSALS" | translate:userBasic }}</h3>
+                <adh-mercator-user-proposal-listing
+                    data-path="{{path}}">
+                </adh-mercator-user-proposal-listing>
+            </section>
+        </adh-user-profile>
     </adh-recompile-on-change>
 
     <adh-user-message


### PR DESCRIPTION
There was mercator specific code in core which was then overwritten by a more general version in spd. This fixes that by having the general code in core and overwriting it in mercator.