### PR TITLE
Update B-Plan confirmation email text

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/templates/bplan_submission_confirmation.txt.mako
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/templates/bplan_submission_confirmation.txt.mako
@@ -1,28 +1,25 @@
 Ihre Stellungnahme zum Bebauungsplan ${plan_number}, ${participation_kind} von ${participation_start_date.strftime('%d/%m/%Y')} - ${participation_end_date.strftime('%d/%m/%Y')}.
 
-Vielen Dank für Ihre Stellungnahme. Ihre Stellungnahme geht in die
-abschließende Abwägung ein. In jedem Fall informiert Sie die
-verantwortliche Stelle nach Festsetzung des Bebauungsplans schriftlich
-(per Mail oder postalisch) über das Ergebnis, sofern Sie Ihre Adresse
-gegeben haben.
+Vielen Dank für Ihre Stellungnahme. Sie geht in die Abwägung der öffentlichen
+und privaten Belange ein. Haben Sie sich an einer öffentlichen Auslegung
+beteiligt, werden Sie zudem nach Festsetzung des Bebauungsplans von der
+verantwortlichen Stelle schriftlich (per E-Mail oder postalisch) über das
+Ergebnis informiert, sofern Sie Ihre Adresse angegeben haben.
 
 
 Name
-
 ${name}
 
 Straße, Hausnummer
-
 ${street_number}
 
 PLZ, Ort
-
 ${postal_code_city}
 
 Email-Adresse
-
 ${email}
 
-Stellungsnahme
+
+Ihre Stellungsnahme
 
 ${statement}


### PR DESCRIPTION
This new text is supposed to be generic for both *frühzeitige Beteiligung* and *öffentliche Auslegung*.