### PR TITLE
Change default autobahn port to 6561

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.network :forwarded_port, guest: 6541, host: 6541
   config.vm.network :forwarded_port, guest: 6551, host: 6551
-  config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 6561, host: 6561
 
   config.vm.provision :shell, inline: PROVISION_ROOT
   config.vm.provision :shell, inline: PROVISION_USER, :privileged => false

--- a/etc/development.ini.in
+++ b/etc/development.ini.in
@@ -27,7 +27,7 @@ substanced.initial_email = admin@example.com
 substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
 substanced.autosync_catalogs = true
 substanced.autoevolve = false
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # Set to false to use the SMTP server instead
 adhocracy.use_mail_queue = true
 # Email address receiving abuse complaints
@@ -77,7 +77,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/etc/frontend_development.ini.in
+++ b/etc/frontend_development.ini.in
@@ -21,7 +21,7 @@ rest_platform_path = /adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-adhocracy.frontend.ws_url = ws://localhost:8080
+adhocracy.frontend.ws_url = ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service

--- a/etc/noserver.ini.in
+++ b/etc/noserver.ini.in
@@ -52,7 +52,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 
 # Begin logging configuration

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -26,7 +26,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The login name for the initial user
 adhocracy.initial_login = god
 # The password for the initial user
@@ -66,7 +66,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/adhocracy_core/adhocracy_core/websockets/client.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/client.py
@@ -176,7 +176,7 @@ def includeme(config):
 
     You need to set the ws server url in your settings to make this work::
 
-        adhocracy.ws_url =  ws://localhost:8080
+        adhocracy.ws_url =  ws://localhost:6561
 
     """
     settings = config.registry.settings

--- a/src/adhocracy_core/adhocracy_core/websockets/test_client.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/test_client.py
@@ -312,7 +312,7 @@ class TestFunctionalClient:
         from adhocracy_core.websockets.client import includeme
         from adhocracy_core.websockets.client import Client
         settings = config.registry.settings
-        settings['adhocracy.ws_url'] = 'ws://localhost:8080'
+        settings['adhocracy.ws_url'] = 'ws://localhost:6561'
         includeme(config)
         assert isinstance(config.registry.ws_client, Client)
 

--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -121,7 +121,7 @@ def root_view(request):
 
 def _build_ws_url(request: Request) -> str:
     ws_domain = request.domain
-    ws_port = 8080
+    ws_port = 6561
     ws_scheme = 'wss' if request.scheme == 'https' else 'ws'
     return '{}://{}:{}'.format(ws_scheme, ws_domain, ws_port)
 

--- a/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/development.ini_tmpl
@@ -13,7 +13,7 @@ rest_platform_path = /adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-adhocracy.frontend.ws_url = ws://localhost:8080
+adhocracy.frontend.ws_url = ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service

--- a/src/adhocracy_frontend/adhocracy_frontend/test_init_.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/test_init_.py
@@ -15,7 +15,7 @@ class ConfigViewTest(unittest.TestCase):
         request = testing.DummyRequest(scheme='http')
         request.registry.settings = None
         assert self.call_fut(request) == \
-            {'ws_url': 'ws://example.com:8080',
+            {'ws_url': 'ws://example.com:6561',
              'pkg_path': '/static/js/Packages',
              'rest_url': 'http://localhost:6541',
              'rest_platform_path': '/adhocracy/',
@@ -36,7 +36,7 @@ class ConfigViewTest(unittest.TestCase):
     def test_ws_url_without_ws_url_settings_scheme_https(self):
         request = testing.DummyRequest(scheme='https')
         request.registry.settings = None
-        assert self.call_fut(request)['ws_url'] == 'wss://example.com:8080'
+        assert self.call_fut(request)['ws_url'] == 'wss://example.com:6561'
 
     def test_ws_url_with_ws_url_settings(self):
         request = testing.DummyRequest(scheme='http')

--- a/src/adhocracy_frontend/development.ini
+++ b/src/adhocracy_frontend/development.ini
@@ -14,7 +14,7 @@ adhocracy.platform_id = adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-#adhocracy.frontend.ws_url': ws://localhost:8080
+#adhocracy.frontend.ws_url': ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service

--- a/src/adhocracy_kit/development.ini
+++ b/src/adhocracy_kit/development.ini
@@ -26,7 +26,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The login name for the initial user
 adhocracy.initial_login = god
 # The password for the initial user
@@ -66,7 +66,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/adhocracy_meinberlin/development.ini
+++ b/src/adhocracy_meinberlin/development.ini
@@ -25,7 +25,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy
 # The login name for the initial user
@@ -63,7 +63,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/adhocracy_mercator/development.ini
+++ b/src/adhocracy_mercator/development.ini
@@ -25,7 +25,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy
 # The login name for the initial user
@@ -45,7 +45,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/adhocracy_pcompass/development.ini
+++ b/src/adhocracy_pcompass/development.ini
@@ -26,7 +26,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy
 # The login name for the initial user
@@ -64,7 +64,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/adhocracy_spd/development.ini
+++ b/src/adhocracy_spd/development.ini
@@ -26,7 +26,7 @@ substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
 # The websocket url to notify about resource modifications
-adhocracy.ws_url = ws://localhost:8080
+adhocracy.ws_url = ws://localhost:6561
 # The id for the root level adhocracy resource
 adhocracy.platform_id = adhocracy
 # The login name for the initial user
@@ -64,7 +64,7 @@ host = 0.0.0.0
 port = 6541
 
 [websockets]
-port = 8080
+port = 6561
 pid_file = var/WS_SERVER.pid
 # The URL prefix to let the websocket server create/resolve resource urls
 rest_url = http://localhost:6541

--- a/src/meinberlin/development.ini
+++ b/src/meinberlin/development.ini
@@ -13,7 +13,7 @@ adhocracy.platform_id = adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-adhocracy.frontend.ws_url = ws://localhost:8080
+adhocracy.frontend.ws_url = ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service

--- a/src/pcompass/development.ini
+++ b/src/pcompass/development.ini
@@ -13,7 +13,7 @@ adhocracy.platform_id = adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-adhocracy.frontend.ws_url = ws://localhost:8080
+adhocracy.frontend.ws_url = ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service

--- a/src/spd/development.ini
+++ b/src/spd/development.ini
@@ -13,7 +13,7 @@ adhocracy.platform_id = adhocracy
 # The url to find the backend websocket service
 # If you don't set this, the url is build based on the domain of the current
 # Request.
-adhocracy.frontend.ws_url = ws://localhost:8080
+adhocracy.frontend.ws_url = ws://localhost:6561
 # The URL path to find the frontend templates
 adhocracy.frontend.template_path = /static/templates
 # The url to find the backend rest service


### PR DESCRIPTION
Port 8080 is frequently used by other tools (e.g. tomcat, which is
installed in the policycompass project) and may conflict with autobahn.

The intention of using 8080 for autobahn is that this is on some
firewalls not blocked, but this doesn't matter for us anyway as we
typically put nginx in frontend of autobahn and use a dedicated path
/websockets for autobahn.

Port 6561 is somewhat inline with 6551 and 6541.

@slomo: please check whether this is relevant for some manual deployments.