### PR TITLE
Add backend i18n to pcompass package

### DIFF
--- a/src/adhocracy_pcompass/adhocracy_pcompass/__init__.py
+++ b/src/adhocracy_pcompass/adhocracy_pcompass/__init__.py
@@ -8,6 +8,8 @@ def includeme(config):
     """Setup adhocracy extension."""
     # include adhocracy_core
     config.include('adhocracy_sample')
+    config.add_translation_dirs('adhocracy_core:locale/',
+                                'adhocracy_pcompass:locale/')
 
 
 def main(global_config, **settings):


### PR DESCRIPTION
We allow to overwrite strings in the pcompass packages, but don't do it
yet.