### PR TITLE
remove needless dictonaries (save 15% database size)

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/test_init.py
@@ -251,3 +251,75 @@ def test_get_autonaming_prefixes(resource_meta, registry_with_content):
     registry_with_content.content = inst
     result = _get_autonaming_prefixes(registry_with_content)
     assert sorted(result) == ['', 'VERSION_']
+
+
+class TestMigrateToAttributeStorageSheet:
+
+    @fixture
+    def registry(self, registry_with_content, mock_sheet):
+        registry = registry_with_content
+        registry.content.sheets_meta[mock_sheet.meta.isheet] = mock_sheet.meta
+        return registry
+
+    @fixture
+    def context(self, pool, mock_catalogs):
+        pool['catalogs'] = mock_catalogs
+        pool._sheets = {}
+        return pool
+
+    def call_fut(self, *args, **kwargs):
+        from . import migrate_to_attribute_storage
+        return migrate_to_attribute_storage(*args, **kwargs)
+
+    def test_ignore_if_no_resources_with_sheet(
+            self, context, mock_catalogs, search_result, registry, query):
+        mock_catalogs.search.return_value = search_result._replace(elements=[])
+        self.call_fut(context, ISheet)
+        search_query = query._replace(interfaces=(ISheet,))
+        assert mock_catalogs.search.call_args[0][0] == search_query
+
+    def test_ignore_if_resources_with_sheet_but_no_annotation_sheet_data(
+            self, context, registry, mock_catalogs, search_result):
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[context])
+        context._sheet = {}
+        assert self.call_fut(context, ISheet) is None
+
+    def test_ignore_if_resources_with_sheet_but_no_annotation_data(
+            self, context, registry, mock_catalogs, search_result):
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[context])
+        assert self.call_fut(context, ISheet) is None
+
+    def test_cp_annotation_sheet_data_to_attribute_storage(
+            self, context, registry, mock_catalogs, search_result,
+            mock_sheet):
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[context])
+        annotation_key = mock_sheet.meta.isheet.__identifier__
+        context._sheets = {annotation_key: {'field1': 'value'}}
+        self.call_fut(context, ISheet)
+        assert context.field1 == 'value'
+
+    def test_rm_annotation_sheet_data(
+            self, context, registry, mock_catalogs, search_result,
+            mock_sheet):
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[context])
+        annotation_key = mock_sheet.meta.isheet.__identifier__
+        context._sheets = {'other': {},
+                           annotation_key: {'field1': 'value'}}
+        self.call_fut(context, ISheet)
+        assert 'other' in context._sheets
+        assert annotation_key not in context._sheets
+
+    def test_rm_sheets_attribute_if_empty(
+            self, context, registry, mock_catalogs, search_result,
+            mock_sheet):
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[context])
+        annotation_key = mock_sheet.meta.isheet.__identifier__
+        context._sheets = {annotation_key: {'field1': 'value'}}
+        self.call_fut(context, ISheet)
+        assert not hasattr(context, '_sheets')
+

--- a/src/adhocracy_core/adhocracy_core/resources/pool.py
+++ b/src/adhocracy_core/adhocracy_core/resources/pool.py
@@ -48,7 +48,6 @@ class Pool(Base, Folder):
         Folder.__init__(self, data=data, family=family)
         Base.__init__(self)
         self.__changed_descendants_counter__ = Length()
-        self._autoname_lasts = PersistentMapping()
 
     def next_name(self, subobject, prefix='') -> str:
         """Generate name to add subobject to the folder.
@@ -82,12 +81,12 @@ class Pool(Base, Folder):
         return str(int(name)).zfill(self._autoname_length)
 
     def _get_next_number(self, prefix):
-        if prefix in self._autoname_lasts:
-            number = self._autoname_lasts[prefix].value
-        else:
-            self._autoname_lasts[prefix] = Length()
-            number = self._autoname_lasts[prefix].value
-        self._autoname_lasts[prefix].change(1)
+        last = getattr(self, '_autoname_last_' + prefix, None)
+        if last is None:
+            last = Length()
+            setattr(self, '_autoname_last_' + prefix, last)
+        number = last.value
+        last.change(1)
         return number
 
     def find_service(self, service_name, *sub_service_names):

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -78,11 +78,6 @@ class BaseResourceSheet:
         catalogs = find_service(self.context, 'catalogs')
         return catalogs
 
-    @property
-    def _data(self):
-        """Return dictionary to store data."""
-        raise NotImplementedError
-
     def get(self, params: dict={}, add_back_references=True) -> dict:
         """Return appstruct data.
 
@@ -107,11 +102,9 @@ class BaseResourceSheet:
         items = [(n.name, n.default) for n in schema]
         return dict(items)
 
-    def _get_data_appstruct(self) -> iter:
-        """Might be overridden in subclasses."""
-        for key in self._fields['data']:
-            if key in self._data:
-                yield (key, self._data[key])
+    def _get_data_appstruct(self) -> dict:
+        """Get data appstruct."""
+        raise NotImplementedError
 
     def _get_references_query(self, params: dict) -> SearchQuery:
         """Might be overridden in subclasses."""
@@ -189,10 +182,8 @@ class BaseResourceSheet:
         return remove_keys_from_dict(appstruct, keys_to_remove=omit_keys)
 
     def _store_data(self, appstruct):
-        """Might be overridden in subclasses."""
-        for key in self._fields['data']:
-            if key in appstruct:
-                self._data[key] = appstruct[key]
+        """Store data appstruct."""
+        raise NotImplementedError
 
     def _store_references(self, appstruct, registry):
         """Might be overridden in subclasses."""
@@ -240,9 +231,7 @@ class BaseResourceSheet:
 
     def delete_field_values(self, fields: [str]):
         """Delete value for every field name in `fields`."""
-        for key in fields:
-            if key in self._data:
-                del self._data[key]
+        raise NotImplementedError
 
     def after_set(self, changed: bool):
         """Hook to run after setting data. Not used."""
@@ -257,20 +246,32 @@ class AnnotationRessourceSheet(BaseResourceSheet):
     def __init__(self, meta, context, registry=None):
         """Initialize self."""
         super().__init__(meta, context, registry)
-        self._data_key = self.meta.isheet.__identifier__
+        isheet_name = meta.isheet.__identifier__
+        self._annotation_key = '_sheet_' + isheet_name.replace('.', '_')
 
-    @property
-    def _data(self):
-        """Return dictionary to store data."""
-        sheets_data = getattr(self.context, '_sheets', None)
-        if sheets_data is None:
-            sheets_data = PersistentMapping()
-            setattr(self.context, '_sheets', sheets_data)
-        data = sheets_data.get(self._data_key, None)
+    def _get_data_appstruct(self) -> dict:
+        """Get data appstruct."""
+        data = getattr(self.context, self._annotation_key, {})
+        return {k: v for k, v in data.items() if k in self._fields['data']}
+
+    def _store_data(self, appstruct):
+        """Store data appstruct."""
+        data = getattr(self.context, self._annotation_key, None)
         if data is None:
             data = PersistentMapping()
-            sheets_data[self._data_key] = data
-        return data
+            setattr(self.context, self._annotation_key, data)
+        for key in self._fields['data']:
+            if key in appstruct:
+                data[key] = appstruct[key]
+
+    def delete_field_values(self, fields: [str]):
+        """Delete value for every field name in `fields`."""
+        appstruct = getattr(self.context, self._annotation_key, {})
+        for key in fields:
+            if key in appstruct:
+                del appstruct[key]
+        if appstruct == {}:
+            delattr(self.context, self._annotation_key)
 
 
 @implementer(IResourceSheet)
@@ -278,12 +279,13 @@ class AttributeResourceSheet(BaseResourceSheet):
 
     """Resource Sheet that stores data as context attributes."""
 
-    @property
-    def _data(self):
-        return self.context.__dict__
+    def _get_data_appstruct(self) -> dict:
+        """Get data appstruct."""
+        data = self.context.__dict__
+        return {k: v for k, v in data.items() if k in self._fields['data']}
 
     def _store_data(self, appstruct):
-        """Might be overridden in subclasses."""
+        """Store data appstruct."""
         for key in self._fields['data']:
             if key in appstruct:
                 setattr(self.context, key, appstruct[key])

--- a/src/adhocracy_core/adhocracy_core/sheets/rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/rate.py
@@ -11,6 +11,7 @@ from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
 from adhocracy_core.interfaces import Reference
 from adhocracy_core.sheets import add_sheet_to_registry
+from adhocracy_core.sheets import AttributeResourceSheet
 from adhocracy_core.schema import Integer
 from adhocracy_core.schema import Reference as ReferenceSchema
 from adhocracy_core.schema import UniqueReferences
@@ -165,6 +166,7 @@ class RateSchema(colander.MappingSchema):
 
 rate_meta = sheet_meta._replace(isheet=IRate,
                                 schema_class=RateSchema,
+                                sheet_class=AttributeResourceSheet,
                                 create_mandatory=True)
 
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_comment.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_comment.py
@@ -54,4 +54,4 @@ class TestCommentableSheet:
     def test_set_with_comments(self, meta, context, sheet_catalogs):
         inst = meta.sheet_class(meta, context)
         inst.set({'comments': []})
-        assert not 'comments' in inst._data
+        assert not 'comments' in getattr(context, inst._annotation_key)

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -58,14 +58,10 @@ class TestBaseResourceSheet:
 
     @fixture
     def inst(self, sheet_meta, context, registry):
-        sheet_class = self.get_class()
-        class DummyStorage(sheet_class):
-
-            @property
-            def _data(self):
-                return context.__dict__
-
-        inst = DummyStorage(sheet_meta, context, registry=registry)
+        inst = self.get_class()(sheet_meta, context, registry=registry)
+        inst._get_data_appstruct = Mock(spec=inst._get_data_appstruct)
+        inst._get_data_appstruct.return_value = {}
+        inst._store_data = Mock(spec=inst._store_data)
         return inst
 
     def get_class(self):
@@ -94,7 +90,7 @@ class TestBaseResourceSheet:
         assert inst.get() == {'count': 0}
 
     def test_get_non_empty(self, inst):
-        inst._data['count'] = 11
+        inst._get_data_appstruct.return_value = {'count': 11}
         assert inst.get() == {'count': 11}
 
     def test_get_with_custom_query(self, inst, sheet_catalogs,
@@ -113,7 +109,7 @@ class TestBaseResourceSheet:
 
     def test_set(self, inst):
         assert inst.set({'count': 11}) is True
-        assert inst.get() == {'count': 11}
+        inst._store_data.assert_called_with({'count': 11})
 
     def test_set_empty(self, inst):
         assert inst.set({}) is False
@@ -244,7 +240,7 @@ class TestBaseResourceSheet:
         assert events[0].new_appstruct == {'count': 2}
 
     def test_get_cstruct(self, inst, request_):
-        inst.set({'count': 2})
+        inst._get_data_appstruct.return_value = {'count': 2}
         assert inst.get_cstruct(request_) == {'count': '2'}
 
     def test_get_cstruct_with_params(self, inst, request_):
@@ -281,23 +277,21 @@ class TestBaseResourceSheet:
         cstruct = inst.get_cstruct(request_)
         assert 'only_visible' not in inst.get.call_args[1]['params']
 
-    def test_delete_field_values(self, inst):
-        inst._data['count'] = 2
-        inst.delete_field_values(['count'])
-        assert 'count' not in inst._data
-
-    def test_delete_field_values_ignore_if_wrong_field(self, inst):
-        inst._data['count'] = 2
-        inst.delete_field_values(['wrong'])
-        assert 'count' in inst._data
-
 
 class TestAnnotationRessourceSheet:
 
     @fixture
     def sheet_meta(self, sheet_meta):
         from . import AnnotationRessourceSheet
-        return sheet_meta._replace(sheet_class=AnnotationRessourceSheet)
+        class SheetASchema(colander.MappingSchema):
+            count = colander.SchemaNode(colander.Int(),
+                                        missing=colander.drop,
+                                        default=0)
+            other = colander.SchemaNode(colander.Int(),
+                                        missing=colander.drop,
+                                        default=0)
+        return sheet_meta._replace(sheet_class=AnnotationRessourceSheet,
+                                   schema_class=SheetASchema)
 
     @fixture
     def inst(self, sheet_meta, context):
@@ -313,6 +307,25 @@ class TestAnnotationRessourceSheet:
         assert inst.meta == sheet_meta
         assert IResourceSheet.providedBy(inst)
         assert verifyObject(IResourceSheet, inst)
+
+    def test_delete_field_values(self, inst):
+        appstruct = {'count': 2, 'other': 3}
+        setattr(inst.context, inst._annotation_key, appstruct)
+        inst.delete_field_values(['count'])
+        assert 'other' in appstruct
+        assert 'count' not in appstruct
+
+    def test_delete_field_values_ignore_if_wrong_field(self, inst):
+        appstruct = {'count': 2}
+        setattr(inst.context, inst._annotation_key, appstruct)
+        inst.delete_field_values(['wrong'])
+        assert 'count' in appstruct
+
+    def test_delete_field_values_remove_data_dict_if_empty(self, inst):
+        appstruct = {'count': 2}
+        setattr(inst.context, inst._annotation_key, appstruct)
+        inst.delete_field_values(['count'])
+        assert not hasattr(inst.context, inst._annotation_key)
 
     def test_set_with_other_sheet_name_conflicts(self, inst, sheet_meta,
                                                        context):
@@ -333,8 +346,8 @@ class TestAnnotationRessourceSheet:
         inst.set({'count': 1})
         inst_b.set({'count': 2})
 
-        assert inst.get() == {'count': 1}
-        assert inst_b.get() == {'count': 2}
+        assert inst.get() == {'count': 1, 'other': 0}
+        assert inst_b.get() == {'count': 2, 'other': 0}
 
     def test_set_with_subtype_and_name_conflicts(self, inst,  sheet_meta,
                                                        context):
@@ -347,14 +360,14 @@ class TestAnnotationRessourceSheet:
                 default=0)
 
         sheet_b_meta = sheet_meta._replace(isheet=ISheetB,
-                                             schema_class=SheetBSchema)
+                                           schema_class=SheetBSchema)
         inst_b = sheet_meta.sheet_class(sheet_b_meta, context)
 
-        inst.set({'count': 1})
+        inst.set({'count': 1, 'other': 0})
         inst_b.set({'count': 2})
 
-        assert inst.get() == {'count': 1}
-        assert inst_b.get() == {'count': 2}
+        assert inst.get() == {'count': 1, 'other': 0}
+        assert inst_b.get() == {'count': 2, 'other': 0}
 
 
 class TestAttributeResourceSheet:

--- a/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
@@ -56,9 +56,9 @@ class TestRateSheet:
     def test_create(self, meta, context):
         from adhocracy_core.sheets.rate import IRate
         from adhocracy_core.sheets.rate import RateSchema
-        from adhocracy_core.sheets import AnnotationRessourceSheet
+        from adhocracy_core.sheets import AttributeResourceSheet
         inst = meta.sheet_class(meta, context)
-        assert isinstance(inst, AnnotationRessourceSheet)
+        assert issubclass(meta.sheet_class, AttributeResourceSheet)
         assert inst.meta.isheet == IRate
         assert inst.meta.schema_class == RateSchema
         assert inst.meta.create_mandatory

--- a/src/adhocracy_core/adhocracy_core/sheets/test_versions.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_versions.py
@@ -197,7 +197,8 @@ class TestVersionableSheet:
     def test_set_with_followed_by(self, meta, context):
         inst = meta.sheet_class(meta, context)
         inst.set({'followed_by': iter([])})
-        assert not 'followed_by' in inst._data
+        appstruct = getattr(context, inst._annotation_key)
+        assert not 'followed_by' in appstruct
 
 
 def test_includeme_register_versionable_sheet(config):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_workflow.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_workflow.py
@@ -211,7 +211,9 @@ class TestWorkflowAssignmentSheet:
         inst.schema = inst.schema.clone()
         inst.schema.add(MappingSchema(name='other'))
         inst.set({'other': {}})
-        assert 'other' in inst._data
+        appstruct = getattr(context, inst._annotation_key)
+        assert 'other' in appstruct
+
 
     def tesget_next_states(self, meta, context, registry, mock_workflow):
         registry.content.get_workflow.return_value = mock_workflow


### PR DESCRIPTION
- use attribute storage for resources with rate sheet 
- use attribute storage for autoname last counters 
- rm needless autoname last  counters
- store data for sheets with annotation storage in attributes referencing a dictionary

UPDATE NOTE:

3 long running migration scripts added,
backend server should be shutdown or readonly ( @slomo ).
Check that all migration script pass.


