### PR TITLE
add script to  cleanup stale login data objects

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -92,7 +92,15 @@ class TokenMangerAnnotationStorage:
     def delete_token(self, token: str):
         """Delete authentication token."""
         if token in self.token_to_user_id_timestamp:
+
             del self.token_to_user_id_timestamp[token]
+
+    def delete_expired_tokens(self, timeout: float):
+        all = self.token_to_user_id_timestamp.items()
+        expired = [t for t, (u, date) in all if self._is_expired(date,
+                                                                 timeout)]
+        for token in expired:
+            self.delete_token(token)
 
 
 def get_tokenmanager(request: Request, **kwargs) -> ITokenManger:

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -496,6 +496,9 @@ class ITokenManger(Interface):  # pragma: no cover
     def delete_token(token: str):
         """ Delete authentication token."""
 
+    def delete_expired_tokens(timeout: float):
+        """ Delete expired authentication tokens."""
+
 
 class VisibilityChange(Enum):
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -380,7 +380,7 @@ def delete_not_activated_users(request: Request, age_in_days: int):
         msg = 'deleting user {0}: name {1} email {2}'.format(user,
                                                              user.email,
                                                              user.name)
-        print(msg)
+        logger.info(msg)
         del user.__parent__[user.__name__]
 
 
@@ -389,7 +389,7 @@ def delete_password_resets(request: Request, age_in_days: int):
     resets = find_service(request.root, 'principals', 'resets')
     expired = [u for u in resets.values() if is_older_than(u, age_in_days)]
     for reset in expired:
-        print('deleting reset {0}'.format(reset))
+        logger.info('deleting reset {0}'.format(reset))
         del resets[reset.__name__]
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -273,16 +273,15 @@ class UserLocatorAdapter(object):
     def get_user_by_login(self, login: str) -> IUser:
         """Find user per `login` name or return None."""
         # TODO use catalog for all get_user_by_ methods
-        users = self._get_users()
+        users = self.get_users()
         for user in users:
             if user.name == login:
                 return user
 
-    def _get_users(self) -> [IUser]:
+    def get_users(self) -> [IUser]:
+        """Return all users."""
         users = find_service(self.context, 'principals', 'users')
-        for user in users.values():
-            if IUser.providedBy(user):
-                yield user
+        return (u for u in users.values() if IUser.providedBy(u))
 
     def get_user_by_userid(self, userid: str) -> IUser:
         """Find user by :term:`userid` or return None."""
@@ -299,14 +298,14 @@ class UserLocatorAdapter(object):
 
     def get_user_by_email(self, email: str) -> IUser:
         """Find user per email or return None."""
-        users = self._get_users()
+        users = self.get_users()
         for user in users:
             if user.email == email:
                 return user
 
     def get_user_by_activation_path(self, activation_path: str) -> IUser:
         """Find user per activation path or return None."""
-        users = self._get_users()
+        users = self.get_users()
         for user in users:
             if user.activation_path == activation_path:  # pragma: no branch
                 return user

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -389,7 +389,7 @@ def delete_password_resets(request: Request, age_in_days: int):
     resets = find_service(request.root, 'principals', 'resets')
     expired = [u for u in resets.values() if is_older_then(u, age_in_days)]
     for reset in expired:
-        logger.info('deleting reset {0}.format(reset)'.format(reset))
+        print('deleting reset {0}'.format(reset))
         del resets[reset.__name__]
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -384,6 +384,15 @@ def delete_not_activated_users(request: Request, age_in_days: int):
         del user.__parent__[user.__name__]
 
 
+def delete_password_resets(request: Request, age_in_days: int):
+    """Delete password resets that are older than `age_in_days`."""
+    resets = find_service(request.root, 'principals', 'resets')
+    expired = [u for u in resets.values() if is_older_then(u, age_in_days)]
+    for reset in expired:
+        logger.info('deleting reset {0}.format(reset)'.format(reset))
+        del resets[reset.__name__]
+
+
 def includeme(config):
     """Add resource types to registry."""
     add_resource_type_to_registry(principals_meta, config)

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -24,7 +24,7 @@ from adhocracy_core.resources.base import Base
 from adhocracy_core.resources.badge import add_badge_assignments_service
 from adhocracy_core.resources.badge import add_badges_service
 from adhocracy_core.sheets.metadata import IMetadata
-from adhocracy_core.sheets.metadata import is_older_then
+from adhocracy_core.sheets.metadata import is_older_than
 from adhocracy_core.utils import get_sheet
 from adhocracy_core.utils import get_sheet_field
 import adhocracy_core.sheets.metadata
@@ -375,7 +375,7 @@ def delete_not_activated_users(request: Request, age_in_days: int):
                                                    IRolesUserLocator)
     users = userlocator.get_users()
     not_activated = (u for u in users if not u.active)
-    expired = [u for u in not_activated if is_older_then(u, age_in_days)]
+    expired = [u for u in not_activated if is_older_than(u, age_in_days)]
     for user in expired:
         msg = 'deleting user {0}: name {1} email {2}'.format(user,
                                                              user.email,
@@ -387,7 +387,7 @@ def delete_not_activated_users(request: Request, age_in_days: int):
 def delete_password_resets(request: Request, age_in_days: int):
     """Delete password resets that are older than `age_in_days`."""
     resets = find_service(request.root, 'principals', 'resets')
-    expired = [u for u in resets.values() if is_older_then(u, age_in_days)]
+    expired = [u for u in resets.values() if is_older_than(u, age_in_days)]
     for reset in expired:
         print('deleting reset {0}'.format(reset))
         del resets[reset.__name__]

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -20,9 +20,9 @@ def integration(integration):
 
 @fixture
 def mock_is_older(monkeypatch):
-    from adhocracy_core.sheets.metadata import is_older_then
+    from adhocracy_core.sheets.metadata import is_older_than
     from . import principal
-    mock = Mock(spec=is_older_then)
+    mock = Mock(spec=is_older_than)
     monkeypatch.setattr(principal, 'is_older_then', mock)
     return mock
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -62,7 +62,6 @@ class TestPrincipalsService:
     @mark.usefixtures('integration')
     def test_register_services(self, meta, registry, pool):
         from substanced.util import find_service
-        from . import principal
         registry.content.create(meta.iresource.__identifier__, parent=pool)
         assert find_service(pool, 'principals', 'users')
         assert find_service(pool, 'principals', 'groups')
@@ -77,7 +76,6 @@ class TestUsers:
         return users_meta
 
     def test_meta(self, meta):
-        from adhocracy_core import sheets
         from . import badge
         from . import principal
         assert meta.iresource is principal.IUsersService
@@ -99,7 +97,6 @@ class TestUser:
         return user_meta
 
     def test_meta(self, meta):
-        from . import badge
         from . import principal
         import adhocracy_core.sheets
         assert meta.iresource is principal.IUser
@@ -528,45 +525,34 @@ class TestDeleteNotActiveUsers:
         assert 'user' in users
 
 
-    def mock_is_older(self, monkeypatch):
-        from adhocracy_core.sheets.metadata import is_older_then
+class TestDeletePasswordResets:
+
+    @fixture
+    def reset(self):
+        reset = testing.DummyResource()
+        return reset
+
+    @fixture
+    def resets(self, reset, monkeypatch):
         from . import principal
-        mock = Mock(spec=is_older_then)
-        monkeypatch.setattr(principal, 'is_older_then', mock)
+        mock = testing.DummyResource()
+        mock['reset'] = reset
+        monkeypatch.setattr(principal, 'find_service', lambda x, y, z: mock)
         return mock
 
-    @fixture
-    def user(self):
-        user = testing.DummyResource(active=False, email='', name='')
-        return user
-
-    @fixture
-    def users(self, context, user):
-        context['user'] = user
-        return context
-
     def call_fut(self, *args):
-        from .principal import delete_not_activated_users
-        return delete_not_activated_users(*args)
+        from .principal import delete_password_resets
+        return delete_password_resets(*args)
 
-    def test_delete_not_active_users_older_then_days(
-            self, users, user, request_, mock_is_older, mock_user_locator):
+    def test_delete_resets_older_then_days(
+            self, resets, reset, request_, mock_is_older):
         mock_is_older.return_value = True
-        mock_user_locator.get_users.return_value = [user]
         self.call_fut(request_, 7)
-        mock_is_older.assert_called_with(user, 7)
-        assert 'user' not in users
+        mock_is_older.assert_called_with(reset, 7)
+        assert 'reset' not in resets
 
-    def test_ignore_not_active_user_younger_then_days(
-            self, users, user, request_, mock_is_older, mock_user_locator):
+    def test_ignore_resets_younger_then_days(
+            self, resets, reset, request_, mock_is_older):
         mock_is_older.return_value = False
-        mock_user_locator.get_users.return_value = [user]
         self.call_fut(request_, 7)
-        assert 'user' in users
-
-    def test_ignore_active_user(
-            self, users, user, request_, mock_user_locator):
-        user.active = True
-        mock_user_locator.get_users.return_value = [user]
-        self.call_fut(request_, 7)
-        assert 'user' in users
+        assert 'reset' in resets

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -23,7 +23,7 @@ def mock_is_older(monkeypatch):
     from adhocracy_core.sheets.metadata import is_older_than
     from . import principal
     mock = Mock(spec=is_older_than)
-    monkeypatch.setattr(principal, 'is_older_then', mock)
+    monkeypatch.setattr(principal, 'is_older_than', mock)
     return mock
 
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1416,8 +1416,8 @@ class TestValidateActivationPathUnitTest:
         from datetime import datetime
         from datetime import timezone
         mock_user_locator.get_user_by_activation_path.return_value = user
-        self.call_fut(context, _request)
         user.creation_date = datetime(year=2010, month=1, day=1, tzinfo=timezone.utc)
+        self.call_fut(context, _request)
         self.call_fut(context, _request)
         assert 'Unknown or expired activation path' == _request.errors[0].description
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1387,14 +1387,8 @@ class TestValidateActivationPathUnitTest:
         return request_
 
     @fixture
-    def user_with_metadata(self, config):
-        from adhocracy_core.sheets.metadata import IMetadata
-        config.include('adhocracy_core.content')
-        config.include('adhocracy_core.catalog')
-        config.include('adhocracy_core.changelog')
-        config.include('adhocracy_core.events')
-        config.include('adhocracy_core.sheets.metadata')
-        user = testing.DummyResource(__provides__=IMetadata)
+    def user(self):
+        user = testing.DummyResource()
         user.activate = Mock()
         return user
 
@@ -1402,32 +1396,28 @@ class TestValidateActivationPathUnitTest:
         from adhocracy_core.rest.views import validate_activation_path
         return validate_activation_path(context, _request)
 
-    def test_valid(self, _request, user_with_metadata, context,
+    def test_valid(self, _request, user, context,
                    mock_user_locator):
-        mock_user_locator.get_user_by_activation_path.return_value = \
-            user_with_metadata
+        from datetime import datetime
+        from datetime import timezone
+        mock_user_locator.get_user_by_activation_path.return_value = user
+        user.creation_date = datetime.now(timezone.utc)
         self.call_fut(context, _request)
-        assert _request.validated['user'] == user_with_metadata
-        assert user_with_metadata.activate.called
+        assert _request.validated['user'] == user
+        assert user.activate.called
 
     def test_not_found(self, _request, context, mock_user_locator):
         mock_user_locator.get_user_by_activation_path.return_value = None
         self.call_fut(context, _request)
         assert 'Unknown or expired activation path' == _request.errors[0].description
 
-    def test_found_but_expired(self, _request, user_with_metadata, context,
+    def test_found_but_expired(self, _request, user, context,
                                mock_user_locator):
         from datetime import datetime
         from datetime import timezone
-        from adhocracy_core.sheets.metadata import IMetadata
-        from adhocracy_core.utils import get_sheet
-        mock_user_locator.get_user_by_activation_path.return_value = \
-            user_with_metadata
-        metadata = get_sheet(user_with_metadata, IMetadata)
-        appstruct = metadata.get()
-        appstruct['creation_date'] = datetime(
-            year=2010, month=1, day=1, tzinfo=timezone.utc)
-        metadata.set(appstruct, omit_readonly=False)
+        mock_user_locator.get_user_by_activation_path.return_value = user
+        self.call_fut(context, _request)
+        user.creation_date = datetime(year=2010, month=1, day=1, tzinfo=timezone.utc)
         self.call_fut(context, _request)
         assert 'Unknown or expired activation path' == _request.errors[0].description
 

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -1,8 +1,6 @@
 """GET/POST/PUT requests processing."""
 from collections import defaultdict
 from copy import deepcopy
-from datetime import datetime
-from datetime import timezone
 from logging import getLogger
 
 from colander import Invalid
@@ -34,7 +32,6 @@ from adhocracy_core.resources.asset import IAsset
 from adhocracy_core.resources.asset import IAssetDownload
 from adhocracy_core.resources.asset import IAssetsService
 from adhocracy_core.resources.asset import validate_and_complete_asset
-from adhocracy_core.resources.principal import IUser
 from adhocracy_core.resources.principal import IUsersService
 from adhocracy_core.resources.principal import IPasswordReset
 from adhocracy_core.resources.badge import IBadgeAssignmentsService
@@ -62,6 +59,7 @@ from adhocracy_core.sheets.asset import retrieve_asset_file
 from adhocracy_core.sheets.badge import get_assignable_badges
 from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.metadata import IMetadata
+from adhocracy_core.sheets.metadata import is_older_then
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.sheets.principal import IPasswordAuthentication
 from adhocracy_core.sheets.pool import IPool as IPoolSheet
@@ -1091,24 +1089,16 @@ def validate_activation_path(context, request: Request):
     locator = request.registry.getMultiAdapter((context, request),
                                                IUserLocator)
     user = locator.get_user_by_activation_path(path)
-    registry = request.registry
-    if user is None or _activation_time_window_has_expired(user, registry):
-        error = error_entry('body', 'path',
-                            'Unknown or expired activation path')
+    error = error_entry('body', 'path', 'Unknown or expired activation path')
+    if user is None:
         request.errors.append(error)
+    elif is_older_then(user, days=7):
+        request.errors.append(error)
+        user.activation_path = None
     else:
         user.activate()
+        user.activation_path = None
         request.validated['user'] = user
-    if user is not None:
-        user.activation_path = None  # activation path can only be used once
-
-
-def _activation_time_window_has_expired(user: IUser, registry) -> bool:
-    """Check that user account was created less than 7 days ago."""
-    metadata = get_sheet(user, IMetadata, registry=registry)
-    creation_date = metadata.get()['creation_date']
-    timedelta = datetime.now(timezone.utc) - creation_date
-    return timedelta.days >= 7
 
 
 @view_defaults(

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -1092,7 +1092,7 @@ def validate_activation_path(context, request: Request):
     error = error_entry('body', 'path', 'Unknown or expired activation path')
     if user is None:
         request.errors.append(error)
-    elif is_older_than(user, days=7):
+    elif is_older_than(user, days=8):
         request.errors.append(error)
         user.activation_path = None
     else:

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -59,7 +59,7 @@ from adhocracy_core.sheets.asset import retrieve_asset_file
 from adhocracy_core.sheets.badge import get_assignable_badges
 from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.metadata import IMetadata
-from adhocracy_core.sheets.metadata import is_older_then
+from adhocracy_core.sheets.metadata import is_older_than
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.sheets.principal import IPasswordAuthentication
 from adhocracy_core.sheets.pool import IPool as IPoolSheet
@@ -1092,7 +1092,7 @@ def validate_activation_path(context, request: Request):
     error = error_entry('body', 'path', 'Unknown or expired activation path')
     if user is None:
         request.errors.append(error)
-    elif is_older_then(user, days=7):
+    elif is_older_than(user, days=7):
         request.errors.append(error)
         user.activation_path = None
     else:

--- a/src/adhocracy_core/adhocracy_core/scripts/delete_stale_login_data.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/delete_stale_login_data.py
@@ -1,0 +1,66 @@
+"""Delete stale login data.
+
+This is registered as console script 'delete_stale_login_data' in setup.py.
+"""
+import transaction
+import argparse
+import inspect
+import logging
+
+from pyramid.interfaces import IAuthenticationPolicy
+from pyramid.paster import bootstrap
+from pyramid.request import Request
+
+from adhocracy_core.authentication import get_tokenmanager
+from adhocracy_core.resources.principal import delete_password_resets
+from adhocracy_core.resources.principal import delete_not_activated_users
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_stale_login_data():  # pragma: no cover
+    """Remove expired login tokens, not active users, and old password resets.
+
+    usage::
+
+        bin/remove_stale_login_data etc/development.ini  --resets_max_age 10
+        --not_active_users_max_age 10
+    """
+    docstring = inspect.getdoc(delete_stale_login_data)
+    parser = argparse.ArgumentParser(description=docstring)
+    parser.add_argument('ini_file',
+                        help='path to the adhocracy backend ini file')
+    parser.add_argument('-r',
+                        '--resets_max_age',
+                        help='Max age in days for unused password resets',
+                        default=30,
+                        type=int)
+    parser.add_argument('-u',
+                        '--not_active_users_max_age',
+                        help='Max age in days for not activated users',
+                        default=60,
+                        type=int)
+    args = parser.parse_args()
+    env = bootstrap(args.ini_file)
+    _delete_stale_login_data(env['root'],
+                             env['request'],
+                             args.resets_max_age,
+                             args.not_active_users_max_age,
+                             )
+    transaction.commit()
+    env['closer']()
+
+
+def _delete_stale_login_data(root,
+                             request: Request,
+                             not_active_users_max_age: int,
+                             resets_max_age: int,
+                             ):
+    request.root = root
+    delete_not_activated_users(request, not_active_users_max_age)
+    delete_password_resets(request, resets_max_age)
+    auth = request.registry.queryUtility(IAuthenticationPolicy)
+    token_manger = get_tokenmanager(request)
+    if token_manger:  # pragma: no branch
+        token_manger.delete_expired_tokens(auth.timeout)

--- a/src/adhocracy_core/adhocracy_core/scripts/test_delete_stale_login_data.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_delete_stale_login_data.py
@@ -1,0 +1,63 @@
+from pyramid import testing
+from unittest.mock import Mock
+from pytest import fixture
+
+
+class TestDeleteStaleLoginData:
+
+    def call_fut(self, *args):
+        from .delete_stale_login_data import _delete_stale_login_data
+        return _delete_stale_login_data(*args)
+
+    @fixture
+    def mock_delete_resets(self, monkeypatch):
+        from adhocracy_core.resources.principal import delete_password_resets
+        from . import delete_stale_login_data
+        mock = Mock(spec=delete_password_resets)
+        monkeypatch.setattr(delete_stale_login_data, 'delete_password_resets',
+                            mock)
+        return mock
+
+    @fixture
+    def mock_delete_users(self, monkeypatch):
+        from adhocracy_core.resources.principal import delete_not_activated_users
+        from . import delete_stale_login_data
+        mock = Mock(spec=delete_not_activated_users)
+        monkeypatch.setattr(delete_stale_login_data, 'delete_not_activated_users',
+                            mock)
+        return mock
+
+    @fixture
+    def mock_token_manger(self, monkeypatch):
+        from adhocracy_core.authentication import TokenMangerAnnotationStorage
+        from . import delete_stale_login_data
+        mock = Mock(spec=TokenMangerAnnotationStorage)
+        monkeypatch.setattr(delete_stale_login_data, 'get_tokenmanager',
+                            lambda x: mock)
+        return mock
+
+    @fixture
+    def mock_auth_policy(self, registry):
+        from adhocracy_core.authentication import TokenHeaderAuthenticationPolicy
+        mock = Mock(spec=TokenHeaderAuthenticationPolicy)
+        mock.timeout = 0
+        registry.queryUtility = lambda x: mock
+        return mock
+
+    def test_delete_stale_users(
+            self, context, request_, mock_delete_users, mock_delete_resets):
+        self.call_fut(context, request_, 30, 10)
+        assert request_.root == context
+        mock_delete_users.assert_called_with(request_, 30)
+
+    def test_delete_stale_resets(
+            self, context, request_, mock_delete_resets, mock_delete_users):
+        self.call_fut(context, request_, 30, 10)
+        mock_delete_resets.assert_called_with(request_, 10)
+
+    def test_delete_tokens(
+            self, context, request_, mock_auth_policy, mock_token_manger,
+            mock_delete_users, mock_delete_resets):
+        mock_auth_policy.timeout = 10000
+        self.call_fut(context, request_, 30, 10)
+        mock_token_manger.delete_expired_tokens.assert_called_with(10000)

--- a/src/adhocracy_core/adhocracy_core/sheets/metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/metadata.py
@@ -127,7 +127,7 @@ def view_blocked_by_metadata(resource: IResource, registry: Registry,
 def is_older_than(resource: IMetadata, days: int) -> bool:
     """Check if the creation date of `context` is older than `days`."""
     timedelta = now() - resource.creation_date
-    return timedelta.days >= days
+    return timedelta.days > days
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/sheets/metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/metadata.py
@@ -124,7 +124,7 @@ def view_blocked_by_metadata(resource: IResource, registry: Registry,
     return result
 
 
-def is_older_then(resource: IMetadata, days: int) -> bool:
+def is_older_than(resource: IMetadata, days: int) -> bool:
     """Check if the creation date of `context` is older than `days`."""
     timedelta = now() - resource.creation_date
     return timedelta.days >= days

--- a/src/adhocracy_core/adhocracy_core/sheets/metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/metadata.py
@@ -15,6 +15,7 @@ from adhocracy_core.schema import Boolean
 from adhocracy_core.schema import DateTime
 from adhocracy_core.schema import Reference
 from adhocracy_core.utils import get_sheet
+from adhocracy_core.utils import now
 
 
 logger = getLogger(__name__)
@@ -121,6 +122,12 @@ def view_blocked_by_metadata(resource: IResource, registry: Registry,
     result['modification_date'] = appstruct['modification_date']
     result['modified_by'] = appstruct['modified_by']
     return result
+
+
+def is_older_then(resource: IMetadata, days: int) -> bool:
+    """Check if the creation date of `context` is older than `days`."""
+    timedelta = now() - resource.creation_date
+    return timedelta.days >= days
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
@@ -118,3 +118,31 @@ class TestVisibility:
         result = self.call_fut(resource, registry, 'hidden')
         assert result['modified_by'] == user
         assert result['modification_date'] == now
+
+
+class TestIsOlderThen:
+
+    def call_fut(self, *args):
+        from .metadata import is_older_then
+        return is_older_then(*args)
+
+    @fixture
+    def now(self):
+        from pytz import UTC
+        from datetime import datetime
+        now = datetime.utcnow().replace(tzinfo=UTC)
+        return now
+
+    def test_creation_date_older_then_days(self, context, now):
+        from datetime import timedelta
+        context.creation_date = now - timedelta(days=8)
+        assert self.call_fut(context, 7) is True
+
+    def test_creation_date_equal_to_days(self, context, now):
+        from datetime import timedelta
+        context.creation_date = now - timedelta(days=7)
+        assert self.call_fut(context, 7) is True
+
+    def test_creation_date_younger_then_days(self, context, now):
+        context.creation_date = now
+        assert self.call_fut(context, 7) is False

--- a/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
@@ -123,8 +123,8 @@ class TestVisibility:
 class TestIsOlderThen:
 
     def call_fut(self, *args):
-        from .metadata import is_older_then
-        return is_older_then(*args)
+        from .metadata import is_older_than
+        return is_older_than(*args)
 
     @fixture
     def now(self):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
@@ -141,7 +141,7 @@ class TestIsOlderThen:
     def test_creation_date_equal_to_days(self, context, now):
         from datetime import timedelta
         context.creation_date = now - timedelta(days=7)
-        assert self.call_fut(context, 7) is True
+        assert self.call_fut(context, 7) is False
 
     def test_creation_date_younger_then_days(self, context, now):
         context.creation_date = now

--- a/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_metadata.py
@@ -6,12 +6,8 @@ from unittest.mock import Mock
 
 
 @fixture
-def mock_metadata_sheet(context, mock_sheet, registry_with_content):
-    from adhocracy_core.testing import register_sheet
-    from .metadata import IMetadata
-    mock_sheet.meta = mock_sheet.meta._replace(isheet=IMetadata)
-    register_sheet(context, mock_sheet, registry_with_content)
-    return mock_sheet
+def registry(registry_with_content):
+    return registry_with_content
 
 
 class TestIMetadataSchema:
@@ -88,30 +84,14 @@ class TestMetadataSheet:
         assert inst.meta.readable is True
         assert inst.meta.sheet_class is AttributeResourceSheet
 
-
-
-@fixture
-def integration(config):
-    config.include('adhocracy_core.content')
-    config.include('adhocracy_core.catalog')
-    config.include('adhocracy_core.events')
-    config.include('adhocracy_core.changelog')
-    config.include('adhocracy_core.sheets.metadata')
-
-
-@mark.usefixtures('integration')
-def test_includeme_register_metadata_sheet(config):
-    from adhocracy_core.sheets.metadata import IMetadata
-    from adhocracy_core.utils import get_sheet
-    context = testing.DummyResource(__provides__=IMetadata)
-    assert get_sheet(context, IMetadata)
+    @mark.usefixtures('integration')
+    def test_includeme_register_metadata_sheet(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
 
 
 class TestVisibility:
-
-    @fixture
-    def registry(self, registry_with_content):
-        return registry_with_content
 
     def call_fut(self, *args):
         from adhocracy_core.sheets.metadata import view_blocked_by_metadata

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -94,6 +94,8 @@ setup(name='adhocracy_core',
           adhocracy_core.scripts.assign_badges:assign_badges
       set_workflow_state =\
           adhocracy_core.scripts.set_workflow_state:set_workflow_state
+      delete_stale_login_data =\
+          adhocracy_core.scripts.delete_stale_login_data:delete_stale_login_data
       [pyramid.scaffold]
       adhocracy=adhocracy_core.scaffolds:AdhocracyExtensionTemplate
       """,


### PR DESCRIPTION
Internal API Extensions:

- add  function resource "is_older_than"
- add method delete_expired_tokens to authentication  token manager
- add method get_users to interate all users resources to UserAndRoles Finder
- add funtion 'delete_password_resets' to remove not used reset resources.
- add function 'delete_not_activated_users' to remove not activated users.
- add script 'delete_stale_login_data'