### PR TITLE
pin all python dependencies (fixes #1494)

### DIFF
--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -271,6 +271,7 @@ args = 0.1.0
 buildout.requirements = 0.2.2
 collective.recipe.genshi = 1.0
 lingua = 3.10
+multipledispatch = 0.4.8
 pathtools = 0.1.2
 polib = 1.0.7
 polytester = 1.2.0

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -263,3 +263,15 @@ zope.event = 4.0.3
 
 # Required by: repoze.sphinx.autointerface==0.7.1
 zope.interface = 4.1.2
+
+# unsorted
+Genshi = 0.7
+argh = 0.26.1
+args = 0.1.0
+buildout.requirements = 0.2.2
+collective.recipe.genshi = 1.0
+lingua = 3.10
+pathtools = 0.1.2
+polib = 1.0.7
+polytester = 1.2.0
+testfixtures = 4.1.2


### PR DESCRIPTION
My buildout didn't build because of a newer version of testfixtures (4.3.0). So I fixed #1494.

*Note*: buildout still reports that it automatically picks `collective.recipe.template = 1.12`, but `collective.recipe.template = 1.11` is specified in versions.cfg.