### PR TITLE
Prevent creating empty first versions within batch request (save 10% database size)

### DIFF
--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -81,7 +81,7 @@ def add_changelog_followed(event):
         return
     _add_changelog(event.registry, event.object, key='followed_by',
                    value=event.new_version)
-    item = find_interface(event.object, IItem)
+    item = find_interface(event.new_version, IItem)
     _add_changelog(event.registry, item, key='last_version',
                    value=event.new_version)
 

--- a/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
@@ -36,6 +36,15 @@ def test_add_changelog_created_with_parent(event, pool, changelog):
     assert changelog['parent'].modified is True
 
 
+def test_add_changelog_followed_with_item_parent(event, item, changelog):
+    from .subscriber import add_changelog_followed
+    new_version = testing.DummyResource()
+    item['version_0'] = new_version
+    event.new_version = new_version
+    add_changelog_followed(event)
+    assert changelog['/'].last_version == new_version
+
+
 def test_add_changelog_followed_with_has_no_follows(event, changelog):
     from .subscriber import add_changelog_followed
     event.new_version = None
@@ -48,6 +57,7 @@ def test_add_changelog_followed_with_has_follows(event, changelog):
     event.new_version = testing.DummyResource()
     add_changelog_followed(event)
     assert changelog['/'].followed_by is event.new_version
+
 
 
 class TestAddChangelogModified:

--- a/src/adhocracy_core/adhocracy_core/resources/itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/itemversion.py
@@ -46,6 +46,9 @@ def notify_new_itemversion_created(context, registry, options):
                                                         registry,
                                                         creator,
                                                         is_batchmode)
+    if follows == []:
+        _notify_itemversion_has_new_version(None, new_version, registry,
+                                            creator)
 
 
 def _notify_itemversion_has_new_version(old_version, new_version, registry,

--- a/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
@@ -61,18 +61,19 @@ class TestItemVersion:
         version_0 = self.make_one(config, context)
         assert IItemVersion.providedBy(version_0)
 
-    def test_create_new_version(self, config, context):
+    def test_create_first_and_send_version_added_event(self, config, context):
         events = create_event_listener(config, IItemVersionNewVersionAdded)
-        creator = self.make_one(config, context)
-
         version_0 = self.make_one(config, context)
-        version_1 = self.make_one(config, context,
-                                   follows=[version_0], creator=creator)
+        assert events[0].object == None
+        assert events[0].new_version == version_0
 
-        assert len(events) == 1
+    def test_create_followoing_and_send_version_added_event(self, config,
+                                                            context):
+        version_0 = self.make_one(config, context)
+        events = create_event_listener(config, IItemVersionNewVersionAdded)
+        version_1 = self.make_one(config, context, follows=[version_0])
         assert events[0].object == version_0
         assert events[0].new_version == version_1
-        assert events[0].creator == creator
 
     def test_create_new_version_with_referencing_resources(self, config,
                                                            context):

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -848,6 +848,7 @@ class TestItemRESTView:
 
     def test_post_valid_itemversion_batchmode_last_version_in_transaction_exists(
             self, request, context, mock_sheet):
+        from copy import deepcopy
         from adhocracy_core.interfaces import IItemVersion
         context['last_new_version'] = testing.DummyResource(__provides__=
                                                             IItemVersion)
@@ -857,6 +858,9 @@ class TestItemRESTView:
                              'root_versions': [],
                              '_last_new_version_in_transaction':\
                                  context['last_new_version']}
+        versions_sheet = deepcopy(mock_sheet)
+        versions_sheet.get.return_value = {'follows': []}
+        request.registry.content.get_sheet.return_value = versions_sheet
         request.registry.content.get_sheets_create.return_value = [mock_sheet]
         inst = self.make_one(context, request)
         response = inst.post()

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -626,7 +626,7 @@ class ItemRESTView(PoolRESTView):
         root_versions = validated.get('root_versions', [])
         last_new_version = validated.get('_last_new_version_in_transaction',
                                          None)
-        if last_new_version is not None:
+        if last_new_version is not None:  # this only happens in batch request
             follows = get_sheet_field(last_new_version,
                                       IVersionable,
                                       'follows',

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -65,8 +65,10 @@ from adhocracy_core.sheets.metadata import IMetadata
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.sheets.principal import IPasswordAuthentication
 from adhocracy_core.sheets.pool import IPool as IPoolSheet
+from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.utils import extract_events_from_changelog_metadata
 from adhocracy_core.utils import get_sheet
+from adhocracy_core.utils import get_sheet_field
 from adhocracy_core.utils import get_user
 from adhocracy_core.utils import is_batchmode
 from adhocracy_core.utils import strip_optional_prefix
@@ -625,13 +627,21 @@ class ItemRESTView(PoolRESTView):
         last_new_version = validated.get('_last_new_version_in_transaction',
                                          None)
         if last_new_version is not None:
+            follows = get_sheet_field(last_new_version,
+                                      IVersionable,
+                                      'follows',
+                                      registry=self.request.registry)
+            is_first_version = follows == []
             sheets = self.registry.get_sheets_create(last_new_version,
                                                      self.request)
             appstructs = self.request.validated.get('data', {})
             for sheet in sheets:
-                name = sheet.meta.isheet.__identifier__
-                if name in appstructs:  # pragma: no branch
-                    sheet.set(appstructs[name],
+                isheet = sheet.meta.isheet
+                is_versions_sheet = IVersionable.isEqualOrExtendedBy(isheet)
+                if is_first_version and is_versions_sheet:
+                    continue
+                if isheet.__identifier__ in appstructs:  # pragma: no branch
+                    sheet.set(appstructs[isheet.__identifier__],
                               request=self.request)
             resource = last_new_version
         else:

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1219,32 +1219,35 @@ omitted::
      'code': 200}
     >>> pprint(batch_resp['responses'][1])
     {'body': {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
-              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/'},
+              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
      'code': 200}
     >>> pprint(batch_resp['responses'][2])
     {'body': {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
               'data': {...},
-              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/'},
+              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
      'code': 200}
      >>> batch_resp['responses'][2]['body']['data']['adhocracy_core.sheets.document.IParagraph']['text']
      'sein blick ist vom vorüberziehn der stäbchen'
 
 
-Now the first, empty paragraph version should contain the newly
-created paragraph version as its only successor ::
+New Versions are only created once within one batch request. That means the second
+subrequest does not create a second version, but updates the existing first version:
 
-    .. >>> v1 = batch_resp[2]['body']['data']['adhocracy_core.sheets.versions.IVersionable']['followed_by']
-    .. >>> v2 = [batch_resp[1]['path']]
-    .. >>> v1 == v2
-    .. True
-    .. >>> print(v1, v2)
-    .. ...
+    >>> v0 = batch_resp['responses'][0]['body']['first_version_path']
+    >>> v0_again = batch_resp['responses'][1]['body']['path']
+    >>> v0 == v0_again
+    True
 
-The LAST tag should point to the version we created within the batch request::
+The follow reference points to None, because the there is only one version:
+
+    >>> batch_resp['responses'][2]['body']['data']['adhocracy_core.sheets.versions.IVersionable']['follows']
+    []
+
+The LAST tag should point to the last version we created within the batch request::
 
     >>> resp_data = testapp.get(rest_url + "/Documents/document_0000000/PARAGRAPH_0000002/LAST").json
     >>> resp_data['data']['adhocracy_core.sheets.tags.ITag']['elements']
-    ['.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/']
+    ['.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/']
 
 All creation and modification dates are equal for one batch request:
 
@@ -1538,7 +1541,7 @@ versions of all documents::
     >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool']['elements'])
     ['http://localhost/Documents/document_0000000/PARAGRAPH_0000000/VERSION_0000001/',
      'http://localhost/Documents/document_0000000/PARAGRAPH_0000001/VERSION_0000001/',
-     'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/']
+     'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/']
 
 Valid query comparables: 'eq', 'noteq', 'any', 'notany'
 
@@ -1583,7 +1586,20 @@ custom filters:
 *<package.sheets.sheet.ISheet:FieldName>* filters: you can add arbitrary custom
 filters that refer to sheet fields with references. The key is the name of
 the isheet plus the field name separated by ':' The value is the wanted
-reference target. ::
+reference target.
+
+First we create more paragraphs versions::
+
+    >>> pvrs0_path = 'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'
+    >>> pvrs = {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
+    ...         'data': {'adhocracy_core.sheets.versions.IVersionable': {
+    ...                  'follows': [pvrs0_path]}},
+    ...          'root_versions': [pvrs0_path]}
+    >>> resp = testapp.post_json('http://localhost/Documents/document_0000000/PARAGRAPH_0000002',
+    ...                           pvrs, headers=god_header)
+    >>> pvrs1_path = resp.json["path"]
+
+Now we can search references::
 
     >>> resp_data = testapp.get('/Documents/document_0000000',
     ...     params={'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
@@ -1600,7 +1616,7 @@ not a reference field, the backend responds with an error::
 
     >>> resp_data = testapp.get('/Documents/document_0000000',
     ...     params={'adhocracy_core.sheets.NoSuchSheet:nowhere':
-    ...             'http://localhost/Documents/document_0000000/kapitel2/VERSION_0000000/'},
+    ...             'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
     ...     status=400).json
     >>> resp_data['errors'][0]['description']
     'No such sheet or field'

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1238,7 +1238,7 @@ subrequest does not create a second version, but updates the existing first vers
     >>> v0 == v0_again
     True
 
-The follow reference points to None, because the there is only one version:
+The follow reference points to None:
 
     >>> batch_resp['responses'][2]['body']['data']['adhocracy_core.sheets.versions.IVersionable']['follows']
     []


### PR DESCRIPTION
depends on  #1647

API EXTENSION:

- Update first version instead of creating a new version within a batch request. This  prevents creating an empty first version for every item we create.

- migration script to delete exsiting first versions without any data.

UPGRADE NOTE:

Long running migration script that delets resources, have a backup by hand. @slomo .