### PR TITLE
 reduce logging noise backend

### DIFF
--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -90,7 +90,6 @@ def includeme(config):
     """Setup basic adhocracy."""
     settings = config.registry.settings
     config.include('pyramid_zodbconn')
-    config.include('pyramid_exclog')
     config.include('pyramid_mako')
     config.hook_zca()  # global adapter lookup (used by adhocracy_core.utils)
     authz_policy = RoleACLAuthorizationPolicy()

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -576,17 +576,17 @@ def _add_node(schema: SchemaNode, node: SchemaNode, name: str):
     schema.add(node)
 
 
-@dispatch(object, str, str)  # flake8: noqa
+@dispatch((FieldIndex, KeywordIndex), str, str)  # flake8: noqa
 def create_arbitrary_filter_node(index, example_value, query):
     return SingleLine()
 
 
-@dispatch(object, int, (int, str))  # flake8: noqa
+@dispatch((FieldIndex, KeywordIndex), int, (int, str))  # flake8: noqa
 def create_arbitrary_filter_node(index, example_value, query):
     return Integer()
 
 
-@dispatch(object, bool, (bool, str))  # flake8: noqa
+@dispatch((FieldIndex, KeywordIndex), bool, (bool, str))  # flake8: noqa
 def create_arbitrary_filter_node(index, example_value, query):
     return Boolean()
 
@@ -599,7 +599,7 @@ def create_arbitrary_filter_node(index, example_value, query):
         return FieldComparableBoolean()
 
 
-@dispatch(object, datetime, str)  # flake8: noqa
+@dispatch((FieldIndex, KeywordIndex), datetime, str)  # flake8: noqa
 def create_arbitrary_filter_node(index, example_value, query):
     return DateTime()
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
@@ -3,8 +3,8 @@ import json
 from pyramid.request import Request
 from pytest import fixture
 from pytest import raises
+from pytest import mark
 from unittest.mock import Mock
-from testfixtures import LogCapture
 
 
 class DummySubresponse:
@@ -34,6 +34,7 @@ class TestBatchItemResponse:
         assert inst.to_dict() == {'code': 200, 'body': {}}
 
 
+@mark.usefixtures('log')
 class TestBatchView:
 
     @fixture
@@ -223,8 +224,7 @@ class TestBatchView:
         mock_invoke_subrequest.side_effect = RuntimeError('Bad luck')
         inst = self.make_one(context, request_)
         with raises(JSONHTTPClientError) as err:
-            with LogCapture() as log:
-                inst.post()
+            inst.post()
         assert err.value.status_code == 500
 
     def _make_batch_response(self, code=200, title='Ok', path=None,

--- a/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
@@ -5,6 +5,7 @@ import colander
 
 
 
+@mark.usefixtures('log')
 class TestJSONHTTPException:
 
     @fixture
@@ -106,6 +107,7 @@ class TestJSONHTTPException:
         assert "{'X-User-Token': '<hidden>'}" in str(log)
 
 
+@mark.usefixtures('log')
 class TestHandleErrorX0XException:
 
     def call_fut(self, error, request):
@@ -119,6 +121,7 @@ class TestHandleErrorX0XException:
         assert error is result_error
 
 
+@mark.usefixtures('log')
 class TestHandleError40X_exception:
 
     @fixture
@@ -175,6 +178,7 @@ class TestHandleError40X_exception:
         assert '400' in resp.json['errors'][0]['description']
 
 
+@mark.usefixtures('log')
 class TestHandleError400ColanderInvalid:
 
     def make_one(self, error, request):
@@ -203,6 +207,7 @@ class TestHandleError400ColanderInvalid:
         assert json.loads(inst.body.decode()) == wanted
 
 
+@mark.usefixtures('log')
 class TestHandleError400URLDecodeError:
 
     def make_one(self, error, request):
@@ -228,6 +233,7 @@ class TestHandleError400URLDecodeError:
             assert json.loads(inst.body.decode()) == wanted
 
 
+@mark.usefixtures('log')
 class TestHandleError500Exception:
 
     def make_one(self, error, request_):
@@ -248,6 +254,7 @@ class TestHandleError500Exception:
         assert message['errors'][0]['name'] == ''
 
 
+@mark.usefixtures('log')
 class TestHandleAutoUpdateNoForkAllowed400Exception:
 
     def make_one(self, error, request_):
@@ -280,6 +287,7 @@ class TestHandleAutoUpdateNoForkAllowed400Exception:
         assert inst.json == wanted
 
 
+@mark.usefixtures('log')
 class TestHandleError410:
 
     @fixture
@@ -321,6 +329,7 @@ class TestHandleError410:
         assert inst.json_body['modified_by'].endswith('user/')
 
 
+@mark.usefixtures('log')
 class TestHandleError400:
 
     @fixture

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -34,6 +34,13 @@ def registry(registry_with_content):
 
 
 @fixture
+def request_(request_, registry, changelog):
+    request_.registry = registry
+    request_.registry.changelog= changelog
+    return request_
+
+
+@fixture
 def mock_authpolicy(registry):
     from pyramid.interfaces import IAuthenticationPolicy
     from adhocracy_core.authentication import TokenHeaderAuthenticationPolicy
@@ -53,6 +60,7 @@ def mock_password_sheet(registry, sheet_meta):
 
 
 class TestValidateRequest:
+
 
     def call_fut(self, context, request_, **kw):
         from adhocracy_core.rest.views import validate_request_data
@@ -308,11 +316,6 @@ class TestValidatePOSTRootVersions:
 
 class TestRESTView:
 
-    @fixture
-    def request_(self, request_, changelog):
-        request_.registry.changelog = changelog
-        return request_
-
     def make_one(self, context, request):
         from adhocracy_core.rest.views import RESTView
         return RESTView(context, request)
@@ -367,11 +370,6 @@ class TestRESTView:
 
 
 class TestResourceRESTView:
-
-    @fixture
-    def request_(self, request_, mock_content_registry):
-        request_.registry.content = mock_content_registry
-        return request_
 
     def make_one(self, context, request_):
         from adhocracy_core.rest.views import ResourceRESTView
@@ -531,35 +529,28 @@ class TestResourceRESTView:
 
 class TestSimpleRESTView:
 
-    @fixture
-    def request(self, request_, registry_with_changelog,
-                mock_content_registry):
-        request_.registry = registry_with_changelog
-        request_.registry.content = mock_content_registry
-        return request_
-
     def make_one(self, context, request):
         from adhocracy_core.rest.views import SimpleRESTView
         return SimpleRESTView(context, request)
 
-    def test_create_valid(self, context, request):
+    def test_create_valid(self, context, request_):
         from adhocracy_core.rest.views import ResourceRESTView
         from adhocracy_core.rest.schemas import PUTResourceRequestSchema
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         assert issubclass(inst.__class__, ResourceRESTView)
         assert inst.validation_PUT == (PUTResourceRequestSchema, [])
         assert 'options' in dir(inst)
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)
 
-    def test_put_valid_no_sheets(self, request, context, mock_sheet):
-        request.registry.content.get_sheets_edit.return_value = [mock_sheet]
-        request.validated = {"content_type": "X", "data": {}}
+    def test_put_valid_no_sheets(self, request_, context, mock_sheet):
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
+        request_.validated = {"content_type": "X", "data": {}}
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.put()
 
-        wanted = {'path': request.application_url + '/',
+        wanted = {'path': request_.application_url + '/',
                   'content_type': IResource.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                           'created': [],
@@ -567,16 +558,16 @@ class TestSimpleRESTView:
                           'removed': []}}
         assert wanted == response
 
-    def test_put_valid_with_sheets(self, request, context, mock_sheet):
-        request.registry.content.get_sheets_edit.return_value = [mock_sheet]
+    def test_put_valid_with_sheets(self, request_, context, mock_sheet):
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
         data = {'content_type': 'X',
                 'data': {ISheet.__identifier__: {'x': 'y'}}}
-        request.validated = data
+        request_.validated = data
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.put()
 
-        wanted = {'path': request.application_url + '/',
+        wanted = {'path': request_.application_url + '/',
                   'content_type': IResource.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -588,48 +579,41 @@ class TestSimpleRESTView:
 
 class TestPoolRESTView:
 
-    @fixture
-    def request(self, request_, registry_with_changelog,
-                mock_content_registry):
-        request_.registry = registry_with_changelog
-        request_.registry.content = mock_content_registry
-        return request_
-
-    def make_one(self, context, request):
+    def make_one(self, context, request_):
         from adhocracy_core.rest.views import PoolRESTView
-        return PoolRESTView(context, request)
+        return PoolRESTView(context, request_)
 
-    def test_create(self, request, context):
+    def test_create(self, request_, context):
         from adhocracy_core.rest.views import SimpleRESTView
         from adhocracy_core.rest.schemas import POSTResourceRequestSchema
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         assert issubclass(inst.__class__, SimpleRESTView)
         assert inst.validation_POST == (POSTResourceRequestSchema, [])
         assert 'options' in dir(inst)
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)
 
-    def test_get_valid_no_sheets(self, request, context):
+    def test_get_valid_no_sheets(self, request_, context):
         from adhocracy_core.rest.schemas import GETResourceResponseSchema
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.get()
 
         wanted = GETResourceResponseSchema().serialize()
-        wanted['path'] = request.application_url + '/'
+        wanted['path'] = request_.application_url + '/'
         wanted['data'] = {}
         wanted['content_type'] = IResource.__identifier__
         assert wanted == response
 
-    def test_get_valid_pool_sheet_with_query_params(self, request, context,
+    def test_get_valid_pool_sheet_with_query_params(self, request_, context,
                                                     mock_sheet):
         from adhocracy_core.sheets.pool import IPool
         mock_sheet.meta = mock_sheet.meta._replace(isheet=IPool)
         mock_sheet.get_cstruct.return_value = {}
-        request.registry.content.get_sheets_read.return_value = [mock_sheet]
-        request.validated['param1'] = 1
+        request_.registry.content.get_sheets_read.return_value = [mock_sheet]
+        request_.validated['param1'] = 1
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.get()
 
         assert response['data'] == {IPool.__identifier__: {}}
@@ -638,17 +622,17 @@ class TestPoolRESTView:
                                                        'root': context,
                                                        }}
 
-    def test_post_valid(self, request, context):
-        request.root = context
+    def test_post_valid(self, request_, context):
+        request_.root = context
         child = testing.DummyResource(__provides__=IResourceX)
         child.__parent__ = context
         child.__name__ = 'child'
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IResourceX, 'data': {}}
-        inst = self.make_one(context, request)
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IResourceX, 'data': {}}
+        inst = self.make_one(context, request_)
         response = inst.post()
 
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IResourceX.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -656,12 +640,12 @@ class TestPoolRESTView:
                                         'removed': []}}
         assert wanted == response
 
-    def test_put_valid_no_sheets(self, request, context, mock_sheet):
-        request.registry.content.get_sheets_edit.return_value = [mock_sheet]
-        request.validated = {"content_type": "X", "data": {}}
-        inst = self.make_one(context, request)
+    def test_put_valid_no_sheets(self, request_, context, mock_sheet):
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
+        request_.validated = {"content_type": "X", "data": {}}
+        inst = self.make_one(context, request_)
         response = inst.put()
-        wanted = {'path': request.application_url + '/',
+        wanted = {'path': request_.application_url + '/',
                   'content_type': IResource.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -672,70 +656,57 @@ class TestPoolRESTView:
 
 class TestUsersRESTView:
 
-    @fixture
-    def request(self, request_, registry_with_changelog,
-                mock_content_registry):
-        request_.registry = registry_with_changelog
-        request_.registry.content = mock_content_registry
-        return request_
-
-    def make_one(self, context, request):
+    def make_one(self, context, request_):
         from adhocracy_core.rest.views import UsersRESTView
-        return UsersRESTView(context, request)
+        return UsersRESTView(context, request_)
 
-    def test_create(self, request, context):
+    def test_create(self, request_, context):
         from adhocracy_core.rest.views import PoolRESTView
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         assert issubclass(inst.__class__, PoolRESTView)
         assert 'options' in dir(inst)
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)
 
-    def test_post_valid(self, request, context):
-        request.root = context
+    def test_post_valid(self, request_, context):
+        request_.root = context
         # Little cheat to prevent the POST validator from kicking in --
         # we're working with already-validated data here
-        request.method = 'OPTIONS'
+        request_.method = 'OPTIONS'
         child = testing.DummyResource(__provides__=IResourceX,
                                       __parent__=context,
                                       __name__='child')
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IResourceX,
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IResourceX,
                              'data': {}}
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.post()
 
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IResourceX.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
                                         'modified': [],
                                         'removed': []}}
-        request.registry.content.create.assert_called_with(IResourceX.__identifier__, context,
+        request_.registry.content.create.assert_called_with(IResourceX.__identifier__, context,
                                        creator=None,
                                        appstructs={},
-                                       request=request,
+                                       request=request_,
                                        )
         assert wanted == response
 
 
 class TestItemRESTView:
 
-    @fixture
-    def request(self, request_, mock_content_registry, changelog):
-        request_.registry.content = mock_content_registry
-        request_.registry.changelog = changelog
-        return request_
-
-    def make_one(self, context, request):
+    def make_one(self, context, request_):
         from adhocracy_core.rest.views import ItemRESTView
-        return ItemRESTView(context, request)
+        return ItemRESTView(context, request_)
 
-    def test_create(self, request, context):
+    def test_create(self, request_, context):
         from adhocracy_core.rest.views import validate_post_root_versions
         from adhocracy_core.rest.views import SimpleRESTView
         from adhocracy_core.rest.schemas import POSTItemRequestSchema
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         assert issubclass(inst.__class__, SimpleRESTView)
         assert inst.validation_POST == (POSTItemRequestSchema,
                                         [validate_post_root_versions])
@@ -743,130 +714,131 @@ class TestItemRESTView:
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)
 
-    def test_get_item_with_first_version(self, request, context):
+    def test_get_item_with_first_version(self, request_, context):
         from zope.interface import directlyProvides
         from adhocracy_core.interfaces import IItem
         from adhocracy_core.interfaces import IItemVersion
         directlyProvides(context, IItem)
         context['first'] = testing.DummyResource(__provides__=IItemVersion)
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
 
-        wanted = {'path': request.application_url + '/',  'data': {},
+        wanted = {'path': request_.application_url + '/',  'data': {},
                   'content_type': IItem.__identifier__,
-                  'first_version_path': request.application_url + '/first/'}
+                  'first_version_path': request_.application_url + '/first/'}
         assert inst.get() == wanted
 
-    def test_get_item_without_first_version(self, request, context):
+    def test_get_item_without_first_version(self, request_, context):
         from adhocracy_core.interfaces import IItem
         context = testing.DummyResource(__provides__=IItem)
         context['non_first'] = testing.DummyResource()
 
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
 
-        wanted = {'path': request.application_url + '/',  'data': {},
+        wanted = {'path': request_.application_url + '/',  'data': {},
                   'content_type': IItem.__identifier__,
                   'first_version_path': None}
         assert inst.get() == wanted
 
-    def test_post_valid(self, request, context):
+    def test_post_valid(self, request_, context):
         from adhocracy_core.utils import set_batchmode
-        set_batchmode(request)
-        request.root = context
+        set_batchmode(request_)
+        request_.root = context
         # Little cheat to prevent the POST validator from kicking in --
         # we're working with already-validated data here
-        request.method = 'OPTIONS'
+        request_.method = 'OPTIONS'
         child = testing.DummyResource(__provides__=IResourceX,
                                       __parent__=context,
                                       __name__='child')
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IResourceX,
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IResourceX,
                              'data': {}}
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.post()
 
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IResourceX.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
                                         'modified': [],
                                         'removed': []}}
-        request.registry.content.create.assert_called_with(IResourceX.__identifier__, context,
+        request_.registry.content.create.assert_called_with(IResourceX.__identifier__, context,
                                        creator=None,
                                        appstructs={},
                                        root_versions=[],
-                                       request=request,
+                                       request=request_,
                                        is_batchmode=True)
         assert wanted == response
 
-    def test_post_valid_item(self, request, context):
+    def test_post_valid_item(self, request_, context):
         from adhocracy_core.interfaces import IItem
         from adhocracy_core.interfaces import IItemVersion
-        request.root = context
+        request_.root = context
         child = testing.DummyResource(__provides__=IItem,
                                       __parent__=context,
                                       __name__='child')
         first = testing.DummyResource(__provides__=IItemVersion)
         child['first'] = first
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IItemVersion,
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IItemVersion,
                              'data': {}}
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.post()
 
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IItem.__identifier__,
-                  'first_version_path': request.application_url + '/child/first/',
+                  'first_version_path': request_.application_url + '/child/first/',
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
                                         'modified': [],
                                         'removed': []}}
         assert wanted == response
 
-    def test_post_valid_itemversion(self, request, context):
+    def test_post_valid_itemversion(self, request_, context):
         from adhocracy_core.interfaces import IItemVersion
-        request.root = context
+        request_.root = context
         child = testing.DummyResource(__provides__=IItemVersion,
                                       __parent__=context,
                                       __name__='child')
         root = testing.DummyResource(__provides__=IItemVersion)
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IItemVersion,
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IItemVersion,
                              'data': {},
                              'root_versions': [root]}
-        inst = self.make_one(context, request)
+        inst = self.make_one(context, request_)
         response = inst.post()
 
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IItemVersion.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
                                         'modified': [],
                                         'removed': []}}
-        assert request.registry.content.create.call_args[1]['root_versions'] == [root]
+        assert request_.registry.content.create.call_args[1]['root_versions'] == [root]
         assert wanted == response
 
     def test_post_valid_itemversion_batchmode_last_version_in_transaction_exists(
-            self, request, context, mock_sheet):
+            self, request_, context, mock_sheet):
         from copy import deepcopy
         from adhocracy_core.interfaces import IItemVersion
         context['last_new_version'] = testing.DummyResource(__provides__=
                                                             IItemVersion)
-        request.root = context
-        request.validated = {'content_type': IItemVersion,
+        request_.root = context
+        request_.validated = {'content_type': IItemVersion,
                              'data': {ISheet.__identifier__: {'x':'y'}},
                              'root_versions': [],
                              '_last_new_version_in_transaction':\
                                  context['last_new_version']}
         versions_sheet = deepcopy(mock_sheet)
         versions_sheet.get.return_value = {'follows': []}
-        request.registry.content.get_sheet.return_value = versions_sheet
-        request.registry.content.get_sheets_create.return_value = [mock_sheet]
-        inst = self.make_one(context, request)
+        request_.registry.content.get_sheet.return_value = versions_sheet
+        request_.registry.content.get_sheets_create.return_value = [mock_sheet]
+        inst = self.make_one(context, request_)
         response = inst.post()
+
         mock_sheet.set.assert_called_with({'x':'y'},
-                                          request=request)
-        wanted = {'path': request.application_url + '/last_new_version/',
+                                          request=request_)
+        wanted = {'path': request_.application_url + '/last_new_version/',
                   'content_type': IItemVersion.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -874,12 +846,12 @@ class TestItemRESTView:
                                         'removed': []}}
         assert wanted == response
 
-    def test_put_valid_no_sheets(self, request, context, mock_sheet):
-        request.registry.content.get_sheets_edit.return_value = [mock_sheet]
-        request.validated = {"content_type": "X", "data": {}}
-        inst = self.make_one(context, request)
+    def test_put_valid_no_sheets(self, request_, context, mock_sheet):
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
+        request_.validated = {"content_type": "X", "data": {}}
+        inst = self.make_one(context, request_)
         response = inst.put()
-        wanted = {'path': request.application_url + '/',
+        wanted = {'path': request_.application_url + '/',
                   'content_type': IResource.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -889,13 +861,6 @@ class TestItemRESTView:
 
 
 class TestBadgeAssignmentsRESTView:
-
-    @fixture
-    def request_(self, request_, registry_with_changelog,
-                 mock_content_registry):
-        request_.registry = registry_with_changelog
-        request_.registry.content = mock_content_registry
-        return request_
 
     @fixture
     def assignment_sheet(self, mock_sheet):
@@ -978,96 +943,91 @@ class TestBadgeAssignmentsRESTView:
 
 class TestMetaApiView:
 
-    @fixture
-    def request(self, request_,  mock_content_registry):
-        request_.registry.content = mock_content_registry
-        return request_
-
-    def make_one(self, request, context):
+    def make_one(self, request_, context):
         from adhocracy_core.rest.views import MetaApiView
-        return MetaApiView(context, request)
+        return MetaApiView(context, request_)
 
-    def test_get_empty(self, request, context):
-        inst = self.make_one(request, context)
+    def test_get_empty(self, request_, context):
+        inst = self.make_one(request_, context)
         response = inst.get()
         assert response['resources'] == {}
         assert response['sheets'] == {}
         assert response['workflows'] == {}
 
-    def test_get_resources(self, request, context, resource_meta):
-        request.registry.content.resources_meta[IResource] = resource_meta
-        inst = self.make_one(request, context)
+    def test_get_resources(self, request_, context, resource_meta):
+        request_.registry.content.resources_meta[IResource] = resource_meta
+        inst = self.make_one(request_, context)
         resp = inst.get()
         assert IResource.__identifier__ in resp['resources']
         assert resp['resources'][IResource.__identifier__]['sheets'] == []
         assert resp['resources'][IResource.__identifier__]['super_types'] == []
 
-    def test_get_resources_with_super_types(self, request, context, resource_meta):
+    def test_get_resources_with_super_types(self, request_, context, resource_meta):
         class IResourceBX(IResourceX):
             pass
         resource_meta._replace(iresource=IResourceBX)
-        request.registry.content.resources_meta[IResourceBX] = resource_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.resources_meta[IResourceBX] = resource_meta
+        inst = self.make_one(request_, context)
         resp = inst.get()
         assert resp['resources'][IResourceBX.__identifier__]['super_types'] ==\
             [IResourceX.__identifier__]
 
-    def test_get_resources_with_sheets_meta(self, request, context, resource_meta):
+    def test_get_resources_with_sheets_meta(self, request_, context, resource_meta):
         resource_meta = resource_meta._replace(basic_sheets=(ISheet,),
                                                extended_sheets=(ISheetB,))
-        request.registry.content.resources_meta[IResource] = resource_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.resources_meta[IResource] = resource_meta
+        inst = self.make_one(request_, context)
 
         resp = inst.get()['resources']
 
         wanted_sheets = [ISheet.__identifier__, ISheetB.__identifier__]
         assert wanted_sheets == resp[IResource.__identifier__]['sheets']
 
-    def test_get_resources_with_element_types_metadata(self, request, context, resource_meta):
+    def test_get_resources_with_element_types_metadata(self, request_, context, resource_meta):
         resource_meta = resource_meta._replace(element_types=[IResource,
                                                               IResourceX])
-        request.registry.content.resources_meta[IResource] = resource_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.resources_meta[IResource] = resource_meta
+        inst = self.make_one(request_, context)
 
         resp = inst.get()['resources']
 
         wanted = [IResource.__identifier__, IResourceX.__identifier__]
         assert wanted == resp[IResource.__identifier__]['element_types']
 
-    def test_get_resources_with_item_type_metadata(self, request, context, resource_meta):
+    def test_get_resources_with_item_type_metadata(self, request_, context, resource_meta):
         resource_meta = resource_meta._replace(item_type=IResourceX)
-        request.registry.content.resources_meta[IResource] = resource_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.resources_meta[IResource] = resource_meta
+        inst = self.make_one(request_, context)
 
         resp = inst.get()['resources']
 
         wanted = IResourceX.__identifier__
         assert wanted == resp[IResource.__identifier__]['item_type']
 
-    def test_get_sheets(self, request, context, sheet_meta):
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+    def test_get_sheets(self, request_, context, sheet_meta):
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
         response = inst.get()
         assert ISheet.__identifier__ in response['sheets']
         assert 'fields' in response['sheets'][ISheet.__identifier__]
         assert response['sheets'][ISheet.__identifier__]['fields'] == []
         assert response['sheets'][ISheet.__identifier__]['super_types'] == []
 
-    def test_get_sheets_with_super_types(self, request, context, sheet_meta):
+    def test_get_sheets_with_super_types(self, request_, context, sheet_meta):
         class ISheetBX(ISheetB):
             pass
         sheet_meta = sheet_meta._replace(isheet=ISheetBX)
-        request.registry.content.sheets_meta[ISheetBX] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheetBX] = sheet_meta
+        inst = self.make_one(request_, context)
         response = inst.get()['sheets'][ISheetBX.__identifier__]
         assert response['super_types'] == [ISheetB.__identifier__]
 
-    def test_get_sheets_with_field(self, request, context, sheet_meta):
+    def test_get_sheets_with_field(self, request_, context, sheet_meta):
         class SchemaF(colander.MappingSchema):
             test = colander.SchemaNode(colander.Int())
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         response = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1080,12 +1040,12 @@ class TestMetaApiView:
         assert field_metadata['name'] == 'test'
         assert 'valuetype' in field_metadata
 
-    def test_get_sheet_with_readonly_field(self, request, context, sheet_meta):
+    def test_get_sheet_with_readonly_field(self, request_, context, sheet_meta):
         class SchemaF(colander.MappingSchema):
             test = colander.SchemaNode(colander.Int(), readonly=True)
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         response = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1094,12 +1054,12 @@ class TestMetaApiView:
         assert field_metadata['creatable'] is False
         assert field_metadata['create_mandatory'] is False
 
-    def test_get_sheets_with_field_colander_noniteratable(self, request, context, sheet_meta):
+    def test_get_sheets_with_field_colander_noniteratable(self, request_, context, sheet_meta):
         class SchemaF(colander.MappingSchema):
             test = colander.SchemaNode(colander.Int())
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         response = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1107,13 +1067,13 @@ class TestMetaApiView:
         assert 'containertype' not in field_metadata
         assert field_metadata['valuetype'] == 'Integer'
 
-    def test_get_sheets_with_field_adhocracy_noniteratable(self, request, context, sheet_meta):
+    def test_get_sheets_with_field_adhocracy_noniteratable(self, request_, context, sheet_meta):
         from adhocracy_core.schema import Name
         class SchemaF(colander.MappingSchema):
             test = colander.SchemaNode(Name())
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         response = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1121,14 +1081,14 @@ class TestMetaApiView:
         assert 'containertype' not in field_metadata
         assert field_metadata['valuetype'] == 'adhocracy_core.schema.Name'
 
-    def test_get_sheets_with_field_adhocracy_referencelist(self, request, context, sheet_meta):
+    def test_get_sheets_with_field_adhocracy_referencelist(self, request_, context, sheet_meta):
         from adhocracy_core.interfaces import SheetToSheet
         from adhocracy_core.schema import UniqueReferences
         class SchemaF(colander.MappingSchema):
             test = UniqueReferences(reftype=SheetToSheet)
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         sheet_metadata = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1137,7 +1097,7 @@ class TestMetaApiView:
         assert field_metadata['valuetype'] == 'adhocracy_core.schema.AbsolutePath'
         assert field_metadata['targetsheet'] == ISheet.__identifier__
 
-    def test_get_sheets_with_field_adhocracy_back_referencelist(self, request, context, sheet_meta):
+    def test_get_sheets_with_field_adhocracy_back_referencelist(self, request_, context, sheet_meta):
         from adhocracy_core.interfaces import SheetToSheet
         from adhocracy_core.schema import UniqueReferences
         class BSheetToSheet(SheetToSheet):
@@ -1146,8 +1106,8 @@ class TestMetaApiView:
         class SchemaF(colander.MappingSchema):
             test = UniqueReferences(reftype=BSheetToSheet, backref=True)
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
 
         sheet_metadata = inst.get()['sheets'][ISheet.__identifier__]
 
@@ -1155,25 +1115,25 @@ class TestMetaApiView:
         assert field_metadata['targetsheet'] == ISheetB.__identifier__
 
     def test_get_sheets_with_field_non_generic_or_container(
-            self, request, context, sheet_meta):
+            self, request_, context, sheet_meta):
         from adhocracy_core.schema import Identifier
         class SchemaF(colander.MappingSchema):
             id = Identifier()
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
         sheet_metadata = inst.get()['sheets'][ISheet.__identifier__]
         field_metadata = sheet_metadata['fields'][0]
         assert field_metadata['valuetype'] == 'adhocracy_core.schema.Identifier'
 
-    def test_get_sheets_with_sequence_schema_as_node(self, request, context,
+    def test_get_sheets_with_sequence_schema_as_node(self, request_, context,
                                                      sheet_meta):
         from adhocracy_core.schema import Roles
         class SchemaF(colander.MappingSchema):
             roles = Roles()
         sheet_meta = sheet_meta._replace(schema_class=SchemaF)
-        request.registry.content.sheets_meta[ISheet] = sheet_meta
-        inst = self.make_one(request, context)
+        request_.registry.content.sheets_meta[ISheet] = sheet_meta
+        inst = self.make_one(request_, context)
         sheet_metadata = inst.get()['sheets'][ISheet.__identifier__]
         field_metadata = sheet_metadata['fields'][0]
         assert field_metadata['valuetype'] == 'adhocracy_core.schema.Role'
@@ -1181,9 +1141,9 @@ class TestMetaApiView:
 
     # TODO test for single reference
 
-    def test_get_workflows(self, request, context):
-        inst = self.make_one(request, context)
-        request.registry.content.workflows_meta['sample'] = {'states': {},
+    def test_get_workflows(self, request_, context):
+        inst = self.make_one(request_, context)
+        request_.registry.content.workflows_meta['sample'] = {'states': {},
                                                              'transitions': {}}
         workflows_meta = inst.get()['workflows']
         assert workflows_meta == {'sample': {'initial_state': '',
@@ -1194,137 +1154,127 @@ class TestMetaApiView:
 class TestValidateLoginEmail:
 
     @fixture
-    def request(self, request_, registry):
-        request_.registry = registry
+    def request_(self, request_):
         request_.validated['email'] = 'user@example.org'
         return request_
 
-
-    def call_fut(self, context, request):
+    def call_fut(self, context, request_):
         from adhocracy_core.rest.views import validate_login_email
-        return validate_login_email(context, request)
+        return validate_login_email(context, request_)
 
-    def test_valid(self, request, context, mock_user_locator):
+    def test_valid(self, request_, context, mock_user_locator):
         user = testing.DummyResource()
         mock_user_locator.get_user_by_email.return_value = user
-        self.call_fut(context, request)
-        assert request.validated['user'] == user
+        self.call_fut(context, request_)
+        assert request_.validated['user'] == user
 
-    def test_valid_email_with_capital_letters(self, request, context, mock_user_locator):
-        request.validated['email'] = 'usER@example.org'
+    def test_valid_email_with_capital_letters(self, request_, context, mock_user_locator):
+        request_.validated['email'] = 'usER@example.org'
         user = testing.DummyResource()
         mock_user_locator.get_user_by_email.return_value = user
-        self.call_fut(context, request)
+        self.call_fut(context, request_)
         mock_user_locator.get_user_by_email.assert_called_with('user@example.org')
-        assert request.validated['user'] == user
+        assert request_.validated['user'] == user
 
-    def test_invalid(self, request, context, mock_user_locator):
+    def test_invalid(self, request_, context, mock_user_locator):
         mock_user_locator.get_user_by_email.return_value = None
-        self.call_fut(context, request)
-        assert 'user' not in request.validated
-        assert 'User doesn\'t exist' in request.errors[0].description
+        self.call_fut(context, request_)
+        assert 'user' not in request_.validated
+        assert 'User doesn\'t exist' in request_.errors[0].description
 
 
 class TestValidateLoginNameUnitTest:
 
     @fixture
-    def request(self, request_, registry):
-        request_.registry = registry
+    def request_(self, request_):
         request_.validated['name'] = 'user'
         return request_
 
-    def call_fut(self, context, request):
+    def call_fut(self, context, request_):
         from adhocracy_core.rest.views import validate_login_name
-        return validate_login_name(context, request)
+        return validate_login_name(context, request_)
 
-    def test_invalid(self, request, context, mock_user_locator):
+    def test_invalid(self, request_, context, mock_user_locator):
         mock_user_locator.get_user_by_login.return_value = None
-        self.call_fut(context, request)
-        assert 'User doesn\'t exist' in request.errors[0].description
+        self.call_fut(context, request_)
+        assert 'User doesn\'t exist' in request_.errors[0].description
 
-    def test_valid(self, request, context, mock_user_locator):
+    def test_valid(self, request_, context, mock_user_locator):
         user = testing.DummyResource()
         mock_user_locator.get_user_by_login.return_value = user
-        self.call_fut(context, request)
-        assert request.validated['user'] == user
+        self.call_fut(context, request_)
+        assert request_.validated['user'] == user
 
 
 class TestValidateLoginPasswordUnitTest:
 
     @fixture
-    def request(self, request_, registry):
+    def request_(self, request_):
         from adhocracy_core.sheets.principal import IPasswordAuthentication
-        request_.registry = registry
         user = testing.DummyResource(__provides__=IPasswordAuthentication)
         request_.validated['user'] = user
         request_.validated['password'] = 'lalala'
         return request_
 
-    def call_fut(self, context, request):
+    def call_fut(self, context, request_):
         from adhocracy_core.rest.views import validate_login_password
-        return validate_login_password(context, request)
+        return validate_login_password(context, request_)
 
-    def test_valid(self, request, context, mock_password_sheet):
+    def test_valid(self, request_, context, mock_password_sheet):
         sheet = mock_password_sheet
         sheet.check_plaintext_password.return_value = True
-        self.call_fut(context, request)
-        assert request.errors == []
+        self.call_fut(context, request_)
+        assert request_.errors == []
 
-    def test_invalid(self, request, context, mock_password_sheet):
+    def test_invalid(self, request_, context, mock_password_sheet):
         sheet = mock_password_sheet
         sheet.check_plaintext_password.return_value = False
-        self.call_fut(context, request)
-        assert 'password is wrong' in request.errors[0].description
+        self.call_fut(context, request_)
+        assert 'password is wrong' in request_.errors[0].description
 
-    def test_invalid_with_ValueError(self, request, context, mock_password_sheet):
+    def test_invalid_with_ValueError(self, request_, context, mock_password_sheet):
         sheet = mock_password_sheet
         sheet.check_plaintext_password.side_effect = ValueError
-        self.call_fut(context, request)
-        assert 'password is wrong' in request.errors[0].description
+        self.call_fut(context, request_)
+        assert 'password is wrong' in request_.errors[0].description
 
-    def test_user_is_None(self, request, context):
-        request.validated['user'] = None
-        self.call_fut(context, request)
-        assert request.errors == []
+    def test_user_is_None(self, request_, context):
+        request_.validated['user'] = None
+        self.call_fut(context, request_)
+        assert request_.errors == []
 
 
 class TestValidateAccountActiveUnitTest:
-
-    @fixture
-    def request(self, request_, registry):
-        request_.registry = registry
-        return request_
 
     def call_fut(self, context, request):
         from adhocracy_core.rest.views import validate_account_active
         return validate_account_active(context, request)
 
-    def test_valid(self, request, context):
+    def test_valid(self, request_, context):
         user = testing.DummyResource(active=True)
-        request.validated['user'] = user
-        self.call_fut(context, request)
-        assert not request.errors
+        request_.validated['user'] = user
+        self.call_fut(context, request_)
+        assert not request_.errors
 
-    def test_invalid(self, request, context):
+    def test_invalid(self, request_, context):
         user = testing.DummyResource(active=False)
-        request.validated['user'] = user
-        self.call_fut(context, request)
-        assert 'not yet activated' in request.errors[0].description
+        request_.validated['user'] = user
+        self.call_fut(context, request_)
+        assert 'not yet activated' in request_.errors[0].description
 
-    def test_no_error_added_after_other_errors(self, request, context):
+    def test_no_error_added_after_other_errors(self, request_, context):
         user = testing.DummyResource(active=False)
-        request.validated['user'] = user
-        request.errors.append(('blah', 'blah', 'blah'))
-        assert len(request.errors) == 1
-        self.call_fut(context, request)
-        assert len(request.errors) == 1
+        request_.validated['user'] = user
+        request_.errors.append(('blah', 'blah', 'blah'))
+        assert len(request_.errors) == 1
+        self.call_fut(context, request_)
+        assert len(request_.errors) == 1
 
 
 class TestLoginUserName:
 
     @fixture
-    def request(self, request_, registry):
-        request_.registry = registry
+    def request(self, request_):
         request_.validated['user'] = testing.DummyResource()
         request_.validated['password'] = 'lalala'
         return request_
@@ -1354,8 +1304,7 @@ class TestLoginUserName:
 class TestLoginEmailView:
 
     @fixture
-    def request(self, request_, registry):
-        request_.registry=registry
+    def request(self, request_):
         request_.validated['user'] = testing.DummyResource()
         return request_
 
@@ -1429,8 +1378,7 @@ class TestValidateActivationPathUnitTest:
 class TestActivateAccountView:
 
     @fixture
-    def request(self, request_, registry):
-        request_.registry=registry
+    def request(self, request_):
         request_.validated['user'] = testing.DummyResource()
         return request_
 
@@ -1454,10 +1402,9 @@ class TestActivateAccountView:
 class TestReportAbuseView:
 
     @fixture
-    def request(self, request_, registry):
+    def request(self, request_):
         from adhocracy_core.messaging import Messenger
-        registry.messenger = Mock(spec=Messenger)
-        request_.registry = registry
+        request_.registry.messenger = Mock(spec=Messenger)
         request_.validated['url'] = 'http://localhost/blablah'
         request_.validated['remark'] = 'Too much blah!'
         return request_
@@ -1479,10 +1426,9 @@ class TestReportAbuseView:
 class TestMessageUserView:
 
     @fixture
-    def request(self, request_, registry):
+    def request(self, request_):
         from adhocracy_core.messaging import Messenger
-        registry.messenger = Mock(spec=Messenger)
-        request_.registry = registry
+        request_.registry.messenger = Mock(spec=Messenger)
         request_.validated['recipient'] = testing.DummyResource()
         request_.validated['title'] = 'Important Adhocracy notice'
         request_.validated['text'] = 'Surprisingly enough, all is well.'
@@ -1516,25 +1462,20 @@ class TestMessageUserView:
 
 class TestAssetsServiceRESTView:
 
-    @fixture
-    def request(self, request_, mock_content_registry):
-        request_.registry.content = mock_content_registry
-        return request_
-
     def make_one(self, context, request):
         from adhocracy_core.rest.views import AssetsServiceRESTView
         return AssetsServiceRESTView(context, request)
 
-    def test_post_valid(self, request, context):
-        request.root = context
+    def test_post_valid(self, request_, context):
+        request_.root = context
         child = testing.DummyResource(__provides__=IResourceX)
         child.__parent__ = context
         child.__name__ = 'child'
-        request.registry.content.create.return_value = child
-        request.validated = {'content_type': IResourceX, 'data': {}}
-        inst = self.make_one(context, request)
+        request_.registry.content.create.return_value = child
+        request_.validated = {'content_type': IResourceX, 'data': {}}
+        inst = self.make_one(context, request_)
         response = inst.post()
-        wanted = {'path': request.application_url + '/child/',
+        wanted = {'path': request_.application_url + '/child/',
                   'content_type': IResourceX.__identifier__,
                   'updated_resources': {'changed_descendants': [],
                                         'created': [],
@@ -1544,11 +1485,6 @@ class TestAssetsServiceRESTView:
 
 
 class TestAssetRESTView:
-
-    @fixture
-    def request_(self, request_, mock_content_registry):
-        request_.registry.content = mock_content_registry
-        return request_
 
     def make_one(self, context, request_):
         from adhocracy_core.rest.views import AssetRESTView
@@ -1575,11 +1511,6 @@ class TestAssetRESTView:
 
 
 class TestAssetDownloadRESTView:
-
-    @fixture
-    def request_(self, request_, mock_content_registry):
-        request_.registry.content = mock_content_registry
-        return request_
 
     def make_one(self, context, request_):
         from adhocracy_core.rest.views import AssetDownloadRESTView
@@ -1628,8 +1559,7 @@ class TestCreatePasswordResetView:
         context['resets'] = service
 
     @fixture
-    def request_(self, request_, registry):
-        request_.registry = registry
+    def request_(self, request_):
         request_.validated['user'] = testing.DummyResource()
         return request_
 
@@ -1669,11 +1599,6 @@ class TestCreatePasswordResetView:
 
 
 class TestPasswordResetView:
-
-    @fixture
-    def request_(self, request_, registry):
-        request_.registry = registry
-        return request_
 
     @fixture
     def mock_remember(self, monkeypatch):

--- a/src/adhocracy_core/adhocracy_core/websockets/client.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/client.py
@@ -55,8 +55,8 @@ class Client:
                 self._connect_and_receive_and_log_messages()
             except (WebSocketConnectionClosedException, ConnectionError,
                     OSError) as err:
-                logger.warning('Problem connecting to Websocket server: %s',
-                               exception_to_str(err))
+                logger.info('Problem connecting to Websocket server: %s',
+                            exception_to_str(err))
                 self._is_running = False
                 time.sleep(1)
             except WebSocketException as err:  # pragma: no cover

--- a/src/adhocracy_core/docs/abuse.rst
+++ b/src/adhocracy_core/docs/abuse.rst
@@ -17,6 +17,7 @@ Start Adhocracy testapp::
     >>> app = getfixture('app')
     >>> testapp = TestApp(app)
     >>> rest_url = 'http://localhost'
+    >>> log = getfixture('log')
 
 Reporting bad content
 ---------------------

--- a/src/adhocracy_core/docs/authentication_api.rst
+++ b/src/adhocracy_core/docs/authentication_api.rst
@@ -19,6 +19,7 @@ Start adhocracy app and log in some users::
     >>> participant = getfixture('app_participant')
     >>> moderator = getfixture('app_moderator')
     >>> admin = getfixture('app_admin')
+    >>> log = getfixture('log')
 
 Test that the relevant resources and sheets exist:
 

--- a/src/adhocracy_core/docs/badges.rst
+++ b/src/adhocracy_core/docs/badges.rst
@@ -20,6 +20,7 @@ Start adhocracy app and log in some users::
     >>> participant = getfixture('app_participant')
     >>> initiator = getfixture('app_initiator')
     >>> admin = getfixture('app_admin')
+    >>> log = getfixture('log')
 
 Create participation process structure/content to get started::
 

--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -134,6 +134,7 @@ Start adhocracy app and log in some users::
     >>> participant = getfixture('app_participant')
     >>> moderator = getfixture('app_moderator')
     >>> admin = getfixture('app_admin')
+    >>> log = getfixture('log')
 
 Lets create some content::
 

--- a/src/adhocracy_core/docs/messaging.rst
+++ b/src/adhocracy_core/docs/messaging.rst
@@ -17,6 +17,7 @@ Start Adhocracy testapp ::
     >>> participant = getfixture('app_participant')
     >>> moderator = getfixture('app_moderator')
     >>> admin = getfixture('app_admin')
+    >>> log = getfixture('log')
 
 Message to a User
 -----------------

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -20,6 +20,7 @@ Some imports to work with rest api calls::
 Start Adhocracy testapp::
 
     >>> from webtest import TestApp
+    >>> log = getfixture('log')
     >>> app = getfixture('app')
     >>> testapp = TestApp(app)
     >>> rest_url = 'http://localhost'


### PR DESCRIPTION
- less logging to shell when running backend  tests
- decrease logging level for "Problem connection to Websocket server" error from warning to info
- don't include 'pyramid_exclog' (force logging of all python exceptions), this only makes sense for productive installations.