### PR TITLE
workaround #1661

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -11,9 +11,10 @@ parts +=
     AdhocracySpec.ts
     meta_api
     resources
-    javascript
+    javascript.amd
     gruntfile
     grunt
+    javascript.umd
     rubygems
     frontend.current.link
     stylesheets
@@ -267,12 +268,19 @@ command =
 update-command = ${:command}
 jsdir = ${adhocracy:frontend.static_dir}/js
 
-[javascript]
+[javascript.umd]
 recipe = plone.recipe.command
 stop-on-error = True
 command =
     ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m umd -d --sourcemap ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
-update-command = ${javascript:command}
+update-command = ${javascript.umd:command}
+
+[javascript.amd]
+recipe = plone.recipe.command
+stop-on-error = True
+command =
+    ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m amd -d --sourcemap ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
+update-command = ${javascript.amd:command}
 
 [gruntfile]
 recipe = collective.recipe.template


### PR DESCRIPTION
TypeScript UMD and the require.js optimizer do not yet play well with each other. I submitted a fix at https://github.com/jrburke/r.js/pull/857. Until that fix is available, here is a workaround in adhocracy.