### PR TITLE
Extend import_user script to generate password

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scripts/test_import_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_import_users.py
@@ -54,6 +54,28 @@ class TestImportUsers:
         groups = locator.get_groups(bob_user_id)
         assert groups == [default_group]
 
+    def test_create_gen_default_password(self, context, registry, log):
+        from pyramid.traversal import resource_path
+        self._tempfd, filename = mkstemp()
+        with open(filename, 'w') as f:
+            f.write(json.dumps([
+                {'name': 'Alice',
+                 'email': 'alice@example.org',
+                 'roles': ['contributor'],
+                 'groups': ['gods']},
+            ]))
+        locator = self._get_user_locator(context, registry)
+
+        self.call_fut(context, registry, filename)
+
+        god_group = context['principals']['groups']['gods']
+        alice = locator.get_user_by_login('Alice')
+        assert alice.active
+        alice = locator.get_user_by_login('Alice')
+        alice_user_id = resource_path(alice)
+        groups = locator.get_groups(alice_user_id)
+        assert groups == [god_group]
+
     def test_create_email_not_lower_case(self, context, registry, log):
         self._tempfd, filename = mkstemp()
         with open(filename, 'w') as f:


### PR DESCRIPTION
Allow to not specify initial-password field in import_users script.