### PR TITLE
avoid calling jasmine.execute() twice

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/test.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/test.html
@@ -14,6 +14,18 @@
 
     <script type="text/javascript" src="js/AdhocracySDK.js"></script>
 
+    <script>
+        // only execute jasmine once both require and blanket are ready
+        var originalJasmineExecute = jasmine.getEnv().execute;
+        var jasmineExecuteCalls = 0;
+        jasmine.getEnv().execute = function() {
+            if (jasmineExecuteCalls > 0) {
+                originalJasmineExecute();
+            }
+            jasmineExecuteCalls += 1;
+        };
+    </script>
+
     <script
         src="lib/blanket/dist/qunit/blanket.js"
         data-cover-adapter="lib/blanket/src/adapters/jasmine-2.x-blanket.js"


### PR DESCRIPTION
blanket already calls `jasmine.execute()` event if require.js is not done loading the testdata. This is a potential cause for #1278.