### PR TITLE
Update frontend dependencies

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/JasmineHelpers.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/JasmineHelpers.ts
@@ -3,7 +3,7 @@
 
 import * as _ from "lodash";
 
-export var customMatchers = {
+export var customMatchers : jasmine.CustomMatcherFactories = {
     toSetEqual: function(util, customEqualityTesters) {
 
         return {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -6,6 +6,8 @@ import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import * as ResourcesBase from "../ResourcesBase";
+
 import RICommentVersion from "../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RIDocument from "../../Resources_/adhocracy_core/resources/document/IDocument";
 import RIDocumentVersion from "../../Resources_/adhocracy_core/resources/document/IDocumentVersion";
@@ -322,7 +324,7 @@ export var postEdit = (
     }
 
     var commit = () => {
-        return adhHttp.deepPost(<any[]>_.flatten([documentVersion, paragraphItems, paragraphVersions]))
+        return adhHttp.deepPost(_.flatten<ResourcesBase.Resource>([documentVersion, paragraphItems, paragraphVersions]))
             .then((result) => result[0]);
     };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -164,7 +164,7 @@ export class Service<Content extends ResourcesBase.Resource> {
 
         return this.adhCache.memoize(path, "OPTIONS",
             () => this.adhCredentials.ready.then(
-                () => this.$http({method: "OPTIONS", url: path, headers: headers})
+                () => this.$http({method: "OPTIONS", url: path, headers: <any>headers})
             )
         ).then((response) => {
             if (typeof config.importOptions === "undefined" || config.importOptions) {
@@ -184,7 +184,7 @@ export class Service<Content extends ResourcesBase.Resource> {
 
         return this.adhCredentials.ready.then(() => this.$http.get(path, {
             params : params,
-            headers : headers
+            headers : <any>headers
         }));
     }
 
@@ -228,7 +228,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         this.adhCache.invalidate(path);
 
         return this.adhCredentials.ready.then(() => this.$http.put(path, obj, {
-            headers: headers
+            headers: <any>headers
         }));
     }
 
@@ -283,12 +283,12 @@ export class Service<Content extends ResourcesBase.Resource> {
                     method: "POST",
                     url: path,
                     data: obj,
-                    headers: _.assign({"Content-Type": undefined}, headers),
+                    headers: <any>_.assign({"Content-Type": undefined}, headers),
                     transformRequest: undefined
                 });
             } else {
                 return _self.$http.post(path, obj, {
-                    headers: headers
+                    headers: <any>headers
                 });
             }
         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -62,8 +62,7 @@ export interface IFacet {
     items : IFacetItem[];
 }
 
-export type IPredicateItem = string | ((string) => string);
-export type IPredicate = IPredicateItem | IPredicateItem[];
+export type IPredicate = string | {[key : string]: string}
 
 export interface ListingScope<Container> extends angular.IScope {
     path : string;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -317,7 +317,7 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
                                 return $q.all([updateMyRate(), updateAggregatedRates()]);
                             })
                             .then(() => undefined);
-                    }).finally<void>(() => {
+                    }).finally(() => {
                         scope.isCast = true;
                         lock = false;
                     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -238,7 +238,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
 
         return this.$q.all(_.map(paths, (path) => {
             return this.adhHttp.get(this.adhConfig.rest_url + path);
-        })).then((resources) => {
+        })).then((resources : ResourcesBase.Resource[]) => {
             for (var i = 0; i < resources.length; i++) {
                 if (resources[i].isInstanceOf(RIProcess.content_type)) {
                     return resources[i];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -268,7 +268,7 @@ export class Service {
 
                     this.blockTemplate = false;
                 })
-                .finally<void>(() => {
+                .finally(() => {
                     this.lock = false;
                 });
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/require-config.js.mako
@@ -19,7 +19,7 @@ require.config({
         Adhocracy: "./Adhocracy",
         adhTemplates: "./templates",
 % endif
-        text: "../lib/requirejs-text/text",
+        text: "../lib/text/text",
         jquery: "../lib/jquery/dist/jquery",
 % if minify:
         angular: "../lib/angular/angular.min",

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
@@ -5,8 +5,9 @@ var fs = require("fs");
 var _ = require("lodash");
 var shared = require("./shared");
 
-/*describe("user registration", function() {
-    xit("can register - broken due to issue #583 (duplicate tpc_begin)", function() {
+describe("user registration", function() {
+    it("can register", function() {
+        UserPages.logout();
         UserPages.register("u1", "u1@example.com", "password1");
         UserPages.logout();
         UserPages.login("u1", "password1");
@@ -14,11 +15,12 @@ var shared = require("./shared");
     });
 
     it("cannot register with wrong password repeat", function() {
+        UserPages.logout();
         var page = new UserPages.RegisterPage().get();
         page.fill("u2", "u2@example.com", "password2", "password3");
         expect(page.submitButton.isEnabled()).toBe(false);
     });
-});*/
+});
 
 describe("user login", function() {
     it("can login with username", function() {
@@ -51,14 +53,14 @@ describe("user login", function() {
         expect(element(by.css(".form-error")).getText()).toContain("Short");
     });
 
-    /*it("login is persistent", function() {
+    it("login is persistent", function() {
         UserPages.login(UserPages.participantName, UserPages.participantPassword);
         expect(UserPages.isLoggedIn()).toBe(true);
         browser.refresh();
         browser.waitForAngular();
         expect(UserPages.isLoggedIn()).toBe(true);
         UserPages.logout();
-    });*/
+    });
 });
 
 describe("user password reset", function() {

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
@@ -79,6 +79,7 @@ describe("user password reset", function() {
     it("error displayed if the email is not associated to an user", function() {
         var page = new UserPages.ResetPasswordCreatePage().get();
         page.fill("abc@xy.de");
+        browser.wait(browser.isElementPresent(element(by.css(".form-error"))), 1000)
         expect(element(by.css(".form-error")).getText()).toContain("No user");
     });
 
@@ -105,7 +106,7 @@ describe("user password reset", function() {
 
         browser.driver.wait(function() {
             return resetUrl != "";
-        }).then(function() {
+        }, 1000).then(function() {
             var resetPage = new UserPages.ResetPasswordPage().get(resetUrl);
             resetPage.fill('new password');
 

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -204,7 +204,7 @@ packages =
     lodash#3.10.1
     requirejs#2.1.20
     requirejs-text#2.0.14
-    DefinitelyTyped#7ca8add069411b3bde47fad7208706801cde8656
+    DefinitelyTyped#54f064352a3615443f7bff4198078db15e28247b
     jasmine#2.3.4
     blanket#1.1.7
     q#1.4.1

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -144,15 +144,15 @@ input = inline:
         "version": "0.0.1",
         "devDependencies": {
             "typescript": "1.6.2",
-            "tslint": "2.4.0",
-            "bower": "1.4.1",
-            "jasmine-node": "2.0.0",
-            "protractor": "1.8.0",
-            "sync-exec": "0.4.0",
+            "tslint": "2.5.0",
+            "bower": "1.5.3",
+            "jasmine-node": "2.0.0-beta4",
+            "protractor": "2.2.0",
+            "sync-exec": "0.6.2",
             "q": "1.4.1",
-            "lodash": "3.10.0",
+            "lodash": "3.10.1",
             "node-fs": "0.1.7",
-            "underscore.string": "3.1.1",
+            "underscore.string": "3.2.2",
             "grunt": "0.4.5",
             "grunt-cli": "0.1.13",
             "grunt-angular-templates": "0.5.7",
@@ -189,30 +189,30 @@ update-command = ${:command}
 [bower]
 recipe = bowerrecipe
 packages =
-    jquery#1.11.2
-    angular#1.4.3
-    angular-animate#1.4.3
-    angular-aria#1.4.3
-    angular-messages#1.4.3
+    jquery#2.1.4
+    angular#1.4.6
+    angular-animate#1.4.6
+    angular-aria#1.4.6
+    angular-messages#1.4.6
     angular-cache#4.3.2
     angular-elastic#2.5.0
-    angular-scroll#0.7.1
-    angular-translate#2.7.2
-    angular-translate-loader-static-files#2.7.2
+    angular-scroll#0.7.2
+    angular-translate#2.8.0
+    angular-translate-loader-static-files#2.8.0
     markdown-it#4.4.0
-    leaflet#0.7.3
-    lodash#3.10.0
+    leaflet#0.7.5
+    lodash#3.10.1
     requirejs#2.1.20
     requirejs-text#2.0.14
     DefinitelyTyped#7ca8add069411b3bde47fad7208706801cde8656
     jasmine#2.3.4
     blanket#1.1.7
     q#1.4.1
-    moment#2.10.3
+    moment#2.10.6
     relatively-sticky#2.0.0
     ng-flow#2.6.1
     nidico/socialshareprivacy#protocol-relative-urls
-    webshim#1.15.8
+    webshim#1.15.10
     lato#0.3.0
     webfont-opensans#0.0.2
 
@@ -377,12 +377,11 @@ update-command = ${grunt:command}
 [rubygems]
 recipe = rubygemsrecipe
 gems =
-    sass==3.4.16
+    sass==3.4.18
     compass==1.0.3
     hologram==1.4.0
-    scss-lint==0.37.0
+    scss-lint==0.38.0
     susy==2.2.5
-    travis==1.7.5
 
 [frontend.current.link]
 recipe = plone.recipe.command

--- a/src/meinberlin/meinberlin/static/js/Packages/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Proposal/Proposal.ts
@@ -123,7 +123,7 @@ var bindPath = (
                     adhRate.fetchAggregatedRates(rateableSheet.post_pool, resource.path),
                     getPolygon(),
                     adhGetBadges(resource)
-                ]).then((args) => {
+                ]).then((args : any[]) => {
                     var commentCount = args[0];
                     var rates = args[1];
                     var polygon = args[2];


### PR DESCRIPTION
this updates many frontend dependencies, e.g.:

-   [angular](https://github.com/angular/angular.js/blob/master/CHANGELOG.md)
-   jquery (drops [support for IE8](https://jquery.com/browser-support/))
-   [protractor](https://github.com/angular/protractor/blob/master/CHANGELOG.md) (major version jump to 2.0.2)
-   jasmine-node (fixes #1665)
-   [sass](http://sass-lang.com/documentation/file.SASS_CHANGELOG.html)
-   [tslint](https://github.com/palantir/tslint/blob/master/CHANGELOG.md)

The travis gem was removed because it is only really used to initially setup a travis setup.

I did not find any major changes in the changelogs.

While making the protractor tests work with the new version I also re-enabled some tests that were disabled due to #583. @nidico could you please check whether that is fixed now?