### PR TITLE
use catalog search  to get  user

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
@@ -53,6 +53,7 @@ class AdhocracyCatalogIndexes:
     reference = Reference()
     user_name = catalog.Field()
     private_user_email = catalog.Field()
+    private_user_activation_path = catalog.Field()
 
 
 def index_creator(resource, default) -> str:
@@ -185,6 +186,14 @@ def index_user_email(resource, default) -> str:
     return name
 
 
+def index_user_activation_path(resource, default) -> str:
+    """Return value for the private_user_activationpath index."""
+    path = getattr(resource, 'activation_path', None)
+    if path is None:
+        return default
+    return path
+
+
 def includeme(config):
     """Register adhocracy catalog factory."""
     config.add_catalog_factory('adhocracy', AdhocracyCatalogIndexes)
@@ -249,5 +258,10 @@ def includeme(config):
     config.add_indexview(index_user_email,
                          catalog_name='adhocracy',
                          index_name='private_user_email',
+                         context=IUserExtended,
+                         )
+    config.add_indexview(index_user_activation_path,
+                         catalog_name='adhocracy',
+                         index_name='private_user_activation_path',
                          context=IUserBasic,
                          )

--- a/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
@@ -19,6 +19,7 @@ from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.badge import IBadgeable
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
+from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.utils import get_sheet_field
 from adhocracy_core.utils import find_graph
 
@@ -49,6 +50,7 @@ class AdhocracyCatalogIndexes:
     item_creation_date = catalog.Field()
     workflow_state = catalog.Field()
     reference = Reference()
+    user_name = catalog.Field()
 
 
 def index_creator(resource, default) -> str:
@@ -169,6 +171,12 @@ def index_workflow_state_of_item(resource, default) -> [str]:
         return state
 
 
+def index_user_name(resource, default) -> str:
+    """Return value for the user_name index."""
+    name = get_sheet_field(resource, IUserBasic, 'name')
+    return name
+
+
 def includeme(config):
     """Register adhocracy catalog factory."""
     config.add_catalog_factory('adhocracy', AdhocracyCatalogIndexes)
@@ -224,4 +232,9 @@ def includeme(config):
                          catalog_name='adhocracy',
                          index_name='workflow_state',
                          context=IVersionable,
+                         )
+    config.add_indexview(index_user_name,
+                         catalog_name='adhocracy',
+                         index_name='user_name',
+                         context=IUserBasic,
                          )

--- a/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/adhocracy.py
@@ -20,6 +20,7 @@ from adhocracy_core.sheets.badge import IBadgeable
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.sheets.principal import IUserBasic
+from adhocracy_core.sheets.principal import IUserExtended
 from adhocracy_core.utils import get_sheet_field
 from adhocracy_core.utils import find_graph
 
@@ -51,6 +52,7 @@ class AdhocracyCatalogIndexes:
     workflow_state = catalog.Field()
     reference = Reference()
     user_name = catalog.Field()
+    private_user_email = catalog.Field()
 
 
 def index_creator(resource, default) -> str:
@@ -177,6 +179,12 @@ def index_user_name(resource, default) -> str:
     return name
 
 
+def index_user_email(resource, default) -> str:
+    """Return value for the private_user_email index."""
+    name = get_sheet_field(resource, IUserExtended, 'email')
+    return name
+
+
 def includeme(config):
     """Register adhocracy catalog factory."""
     config.add_catalog_factory('adhocracy', AdhocracyCatalogIndexes)
@@ -236,5 +244,10 @@ def includeme(config):
     config.add_indexview(index_user_name,
                          catalog_name='adhocracy',
                          index_name='user_name',
+                         context=IUserBasic,
+                         )
+    config.add_indexview(index_user_email,
+                         catalog_name='adhocracy',
+                         index_name='private_user_email',
                          context=IUserBasic,
                          )

--- a/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
@@ -48,6 +48,12 @@ def reindex_user_email(event):
     catalogs.reindex_index(event.object, 'private_user_email')
 
 
+def reindex_user_activation_path(event):
+    """Reindex indexes `private_user_activation_path`."""
+    catalogs = find_service(event.object, 'catalogs')
+    catalogs.reindex_index(event.object, 'private_user_activation_path')
+
+
 def reindex_badge(event):
     """Reindex badge index if a backreference is modified/created."""
     # TODO we cannot listen to the backreference modified event of the
@@ -124,5 +130,8 @@ def includeme(config):
     config.add_subscriber(reindex_user_email,
                           IResourceSheetModified,
                           event_isheet=IUserExtended)
+    config.add_subscriber(reindex_user_activation_path,
+                          IResourceSheetModified,
+                          event_isheet=IUserBasic)
     # add subscriber to updated allowed index
     config.scan('substanced.objectmap.subscribers')

--- a/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
@@ -17,6 +17,7 @@ from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.rate import IRateable
 from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.badge import IBadgeable
+from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.utils import list_resource_with_descendants
 from adhocracy_core.utils import get_sheet_field
@@ -32,6 +33,12 @@ def reindex_rates(event):
     """Reindex the rates index if a rate backreference is modified."""
     catalogs = find_service(event.object, 'catalogs')
     catalogs.reindex_index(event.object, 'rates')
+
+
+def reindex_user_basic(event):
+    """Reindex indexes for :class:`adhcoracy_core.sheets.IUserBasic` sheet."""
+    catalogs = find_service(event.object, 'catalogs')
+    catalogs.reindex_index(event.object, 'user_name')
 
 
 def reindex_badge(event):
@@ -104,5 +111,8 @@ def includeme(config):
     config.add_subscriber(reindex_workflow_state,
                           IResourceSheetModified,
                           event_isheet=IWorkflowAssignment)
+    config.add_subscriber(reindex_user_basic,
+                          IResourceSheetModified,
+                          event_isheet=IUserBasic)
     # add subscriber to updated allowed index
     config.scan('substanced.objectmap.subscribers')

--- a/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
@@ -18,6 +18,7 @@ from adhocracy_core.sheets.rate import IRateable
 from adhocracy_core.sheets.badge import IBadgeAssignment
 from adhocracy_core.sheets.badge import IBadgeable
 from adhocracy_core.sheets.principal import IUserBasic
+from adhocracy_core.sheets.principal import IUserExtended
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.utils import list_resource_with_descendants
 from adhocracy_core.utils import get_sheet_field
@@ -35,10 +36,16 @@ def reindex_rates(event):
     catalogs.reindex_index(event.object, 'rates')
 
 
-def reindex_user_basic(event):
-    """Reindex indexes for :class:`adhcoracy_core.sheets.IUserBasic` sheet."""
+def reindex_user_name(event):
+    """Reindex indexes `user_name`."""
     catalogs = find_service(event.object, 'catalogs')
     catalogs.reindex_index(event.object, 'user_name')
+
+
+def reindex_user_email(event):
+    """Reindex indexes `private_user_email`."""
+    catalogs = find_service(event.object, 'catalogs')
+    catalogs.reindex_index(event.object, 'private_user_email')
 
 
 def reindex_badge(event):
@@ -111,8 +118,11 @@ def includeme(config):
     config.add_subscriber(reindex_workflow_state,
                           IResourceSheetModified,
                           event_isheet=IWorkflowAssignment)
-    config.add_subscriber(reindex_user_basic,
+    config.add_subscriber(reindex_user_name,
                           IResourceSheetModified,
                           event_isheet=IUserBasic)
+    config.add_subscriber(reindex_user_email,
+                          IResourceSheetModified,
+                          event_isheet=IUserExtended)
     # add subscriber to updated allowed index
     config.scan('substanced.objectmap.subscribers')

--- a/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
@@ -34,6 +34,7 @@ def test_create_adhocracy_catalog(pool_graph, registry):
     assert 'title' in catalogs['adhocracy']
     assert 'workflow_state' in catalogs['adhocracy']
     assert 'user_name' in catalogs['adhocracy']
+    assert 'private_user_email' in catalogs['adhocracy']
 
 
 class TestIndexMetadata:
@@ -416,5 +417,28 @@ class TestIndexUserName:
         assert registry.adapters.lookup((IUserBasic,), IIndexView,
                                         name='adhocracy|user_name')
 
+
+
+class TestIndexUserEmail:
+
+    @fixture
+    def registry(self, registry_with_content):
+        return registry_with_content
+
+    def call_fut(self, *args):
+        from .adhocracy import index_user_email
+        return index_user_email(*args)
+
+    def test_return_user_name(self, registry, context, mock_sheet):
+        registry.content.get_sheet.return_value = mock_sheet
+        mock_sheet.get.return_value = {'email': 'test@test.de'}
+        assert self.call_fut(context, 'default') == 'test@test.de'
+
+    @mark.usefixtures('integration')
+    def test_register(self, registry):
+        from adhocracy_core.sheets.principal import IUserExtended
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((IUserExtended,), IIndexView,
+                                        name='adhocracy|private_user_email')
 
 

--- a/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
@@ -394,7 +394,7 @@ class TestIndexWorkflowStateOfItem:
                                         name='adhocracy|workflow_state')
 
 
-class TestUserName:
+class TestIndexUserName:
 
     @fixture
     def registry(self, registry_with_content):
@@ -408,3 +408,13 @@ class TestUserName:
         registry.content.get_sheet.return_value = mock_sheet
         mock_sheet.get.return_value = {'name': 'user_name'}
         assert self.call_fut(context, 'default') == 'user_name'
+
+    @mark.usefixtures('integration')
+    def test_register(self, registry):
+        from adhocracy_core.sheets.principal import IUserBasic
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((IUserBasic,), IIndexView,
+                                        name='adhocracy|user_name')
+
+
+

--- a/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
@@ -35,6 +35,7 @@ def test_create_adhocracy_catalog(pool_graph, registry):
     assert 'workflow_state' in catalogs['adhocracy']
     assert 'user_name' in catalogs['adhocracy']
     assert 'private_user_email' in catalogs['adhocracy']
+    assert 'private_user_activation_path' in catalogs['adhocracy']
 
 
 class TestIndexMetadata:
@@ -442,3 +443,23 @@ class TestIndexUserEmail:
                                         name='adhocracy|private_user_email')
 
 
+class TestIndexUserActivationPath:
+
+    def call_fut(self, *args):
+        from .adhocracy import index_user_activation_path
+        return index_user_activation_path(*args)
+
+    def test_return_user_activation_path(self, context):
+        context.activation_path = '/path'
+        assert self.call_fut(context, 'default') == '/path'
+
+    def test_return_default_if_activation_path_is_none(self, context):
+        context.activation_path = None
+        assert self.call_fut(context, 'default') == 'default'
+
+    @mark.usefixtures('integration')
+    def test_register(self, registry):
+        from adhocracy_core.sheets.principal import IUserBasic
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((IUserBasic,), IIndexView,
+                                        name='adhocracy|private_user_activation_path')

--- a/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_adhocracy.py
@@ -33,6 +33,7 @@ def test_create_adhocracy_catalog(pool_graph, registry):
     assert 'badge' in catalogs['adhocracy']
     assert 'title' in catalogs['adhocracy']
     assert 'workflow_state' in catalogs['adhocracy']
+    assert 'user_name' in catalogs['adhocracy']
 
 
 class TestIndexMetadata:
@@ -392,3 +393,18 @@ class TestIndexWorkflowStateOfItem:
         assert registry.adapters.lookup((IVersionable,), IIndexView,
                                         name='adhocracy|workflow_state')
 
+
+class TestUserName:
+
+    @fixture
+    def registry(self, registry_with_content):
+        return registry_with_content
+
+    def call_fut(self, *args):
+        from .adhocracy import index_user_name
+        return index_user_name(*args)
+
+    def test_return_user_name(self, registry, context, mock_sheet):
+        registry.content.get_sheet.return_value = mock_sheet
+        mock_sheet.get.return_value = {'name': 'user_name'}
+        assert self.call_fut(context, 'default') == 'user_name'

--- a/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
@@ -39,10 +39,16 @@ def test_reindex_rate_index(event, catalog):
     catalog.reindex_index.assert_called_with(event.object, 'rates')
 
 
-def test_reindex_user_basic(event, catalog):
-    from .subscriber import reindex_user_basic
-    reindex_user_basic(event)
+def test_reindex_user_name(event, catalog):
+    from .subscriber import reindex_user_name
+    reindex_user_name(event)
     catalog.reindex_index.assert_called_with(event.object, 'user_name')
+
+
+def test_reindex_user_email(event, catalog):
+    from .subscriber import reindex_user_email
+    reindex_user_email(event)
+    catalog.reindex_index.assert_called_with(event.object, 'private_user_email')
 
 
 def test_reindex_badge_index(event, catalog, mock_sheet, registry_with_content):
@@ -179,6 +185,7 @@ def test_register_subscriber(registry):
     assert subscriber.reindex_badge.__name__ in handlers
     assert subscriber.reindex_item_badge.__name__ in handlers
     assert subscriber.reindex_workflow_state.__name__ in handlers
-    assert subscriber.reindex_user_basic.__name__ in handlers
+    assert subscriber.reindex_user_name.__name__ in handlers
+    assert subscriber.reindex_user_email.__name__ in handlers
 
 

--- a/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
@@ -39,6 +39,12 @@ def test_reindex_rate_index(event, catalog):
     catalog.reindex_index.assert_called_with(event.object, 'rates')
 
 
+def test_reindex_user_basic(event, catalog):
+    from .subscriber import reindex_user_basic
+    reindex_user_basic(event)
+    catalog.reindex_index.assert_called_with(event.object, 'user_name')
+
+
 def test_reindex_badge_index(event, catalog, mock_sheet, registry_with_content):
     from .subscriber import reindex_badge
     badgeable = testing.DummyResource()
@@ -173,5 +179,6 @@ def test_register_subscriber(registry):
     assert subscriber.reindex_badge.__name__ in handlers
     assert subscriber.reindex_item_badge.__name__ in handlers
     assert subscriber.reindex_workflow_state.__name__ in handlers
+    assert subscriber.reindex_user_basic.__name__ in handlers
 
 

--- a/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
@@ -51,6 +51,13 @@ def test_reindex_user_email(event, catalog):
     catalog.reindex_index.assert_called_with(event.object, 'private_user_email')
 
 
+def test_reindex_user_activation_path(event, catalog):
+    from .subscriber import reindex_user_activation_path
+    reindex_user_activation_path(event)
+    catalog.reindex_index.assert_called_with(event.object,
+                                             'private_user_activation_path')
+
+
 def test_reindex_badge_index(event, catalog, mock_sheet, registry_with_content):
     from .subscriber import reindex_badge
     badgeable = testing.DummyResource()

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -314,10 +314,15 @@ class UserLocatorAdapter(object):
 
     def get_user_by_activation_path(self, activation_path: str) -> IUser:
         """Find user per activation path or return None."""
-        users = self.get_users()
-        for user in users:
-            if user.activation_path == activation_path:  # pragma: no branch
-                return user
+        catalogs = find_service(self.context, 'catalogs')
+        query = search_query._replace(indexes={'private_user_activation_path':
+                                               activation_path},
+                                      resolve=True)
+        users = catalogs.search(query).elements
+        if len(users) == 1:
+            return users[0]
+        else:
+            return None
 
     def get_groupids(self, userid: str) -> list:
         """Get :term:`groupid`s for term:`userid` or return None."""

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -15,6 +15,7 @@ from adhocracy_core.interfaces import IPool
 from adhocracy_core.interfaces import IServicePool
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IRolesUserLocator
+from adhocracy_core.interfaces import search_query
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources import resource_meta
 from adhocracy_core.resources.pool import Pool
@@ -273,11 +274,14 @@ class UserLocatorAdapter(object):
 
     def get_user_by_login(self, login: str) -> IUser:
         """Find user per `login` name or return None."""
-        # TODO use catalog for all get_user_by_ methods
-        users = self.get_users()
-        for user in users:
-            if user.name == login:
-                return user
+        catalogs = find_service(self.context, 'catalogs')
+        query = search_query._replace(indexes={'user_name': login},
+                                      resolve=True)
+        users = catalogs.search(query).elements
+        if len(users) == 1:
+            return users[0]
+        else:
+            return None
 
     def get_users(self) -> [IUser]:
         """Return all users."""

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -303,10 +303,14 @@ class UserLocatorAdapter(object):
 
     def get_user_by_email(self, email: str) -> IUser:
         """Find user per email or return None."""
-        users = self.get_users()
-        for user in users:
-            if user.email == email:
-                return user
+        catalogs = find_service(self.context, 'catalogs')
+        query = search_query._replace(indexes={'private_user_email': email},
+                                      resolve=True)
+        users = catalogs.search(query).elements
+        if len(users) == 1:
+            return users[0]
+        else:
+            return None
 
     def get_user_by_activation_path(self, activation_path: str) -> IUser:
         """Find user per activation path or return None."""

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -383,16 +383,17 @@ class TestUserLocatorAdapter:
             resolve=True,
         )
 
-    def test_get_user_by_activation_path_user_not_exists(self, inst, mock_catalogs):
+    def test_get_user_by_activation_path_user_not_exists(self, inst,
+                                                         mock_catalogs):
         assert inst.get_user_by_activation_path('/activate/no_such_link') is None
         assert mock_catalogs.search.called
 
-    def test_get_user_by_userid_user_exists(self, context, request_, inst):
+    def test_get_user_by_userid_user_exists(self, context, inst):
         user = testing.DummyResource()
         context['principals']['users']['User1'] = user
         assert inst.get_user_by_userid('/principals/users/User1') is user
 
-    def test_get_user_by_userid_user_not_exists(self, context, request_, inst):
+    def test_get_user_by_userid_user_not_exists(self, inst):
         assert inst.get_user_by_userid('/principals/users/User1') is None
 
     def test_get_groupids_user_exists(self, context, mock_sheet, request_, inst):
@@ -406,10 +407,10 @@ class TestUserLocatorAdapter:
         context['principals']['users']['User1'] = user
         assert inst.get_groupids('/principals/users/User1') == ['group:group1']
 
-    def test_get_groupids_user_not_exists(self, context, request_, inst):
+    def test_get_groupids_user_not_exists(self, inst):
         assert inst.get_groupids('/principals/users/User1') is None
 
-    def test_get_role_and_group_role_ids_user_exists(self, context, request_, inst):
+    def test_get_role_and_group_role_ids_user_exists(self, context, inst):
         inst.get_user_by_userid = Mock()
         inst.get_user_by_userid.return_value = context
         inst.get_roleids = Mock()
@@ -419,7 +420,7 @@ class TestUserLocatorAdapter:
         assert inst.get_role_and_group_roleids('/principals/users/User1') ==\
                ['role:admin', 'role:reader']
 
-    def test_get_role_and_group_roleids_user_not_exists(self, context, request_, inst):
+    def test_get_role_and_group_roleids_user_not_exists(self, inst):
         assert inst.get_role_and_group_roleids('/principals/users/User1') is None
 
     def test_get_group_roleids_user_exists(self, inst, context, mock_sheet, request_,
@@ -435,7 +436,7 @@ class TestUserLocatorAdapter:
         context['principals']['users']['User1'] = user
         assert inst.get_group_roleids('/principals/users/User1') == ['role:role1']
 
-    def test_get_group_roleids_user_not_exists(self, context, request_, inst):
+    def test_get_group_roleids_user_not_exists(self, inst):
         assert inst.get_group_roleids('/principals/users/User1') is None
 
     def test_get_roleids_user_exists(self, context, mock_sheet, request_, inst):
@@ -445,7 +446,7 @@ class TestUserLocatorAdapter:
         context['principals']['users']['User1'] = user
         assert inst.get_roleids('/principals/users/User1') == ['role:role1']
 
-    def test_get_roleids_user_not_exists(self, context, request_, inst):
+    def test_get_roleids_user_not_exists(self, inst):
         assert inst.get_roleids('/principals/users/User1') is None
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -312,6 +312,13 @@ class TestPasswordReset:
 class TestUserLocatorAdapter:
 
     @fixture
+    def mock_catalogs(self, monkeypatch, mock_catalogs) -> Mock:
+        from . import principal
+        monkeypatch.setattr(principal, 'find_service',
+                            lambda x, y: mock_catalogs)
+        return mock_catalogs
+
+    @fixture
     def context(self, pool, service):
         from copy import deepcopy
         pool['principals'] = service
@@ -319,15 +326,15 @@ class TestUserLocatorAdapter:
         return pool
 
     @fixture
-    def request(self, context, registry_with_content):
+    def request_(self, context, registry_with_content):
         request = testing.DummyRequest(context=context)
         request.registry = registry_with_content
         return request
 
     @fixture
-    def inst(self, context, request):
+    def inst(self, context, request_):
         from .principal import UserLocatorAdapter
-        return UserLocatorAdapter(context, request)
+        return UserLocatorAdapter(context, request_)
 
     def test_create(self, inst):
         from adhocracy_core.interfaces import IRolesUserLocator
@@ -335,32 +342,34 @@ class TestUserLocatorAdapter:
         assert IRolesUserLocator.providedBy(inst)
         assert verifyObject(IRolesUserLocator, inst)
 
-    def test_get_user_by_email_user_exists(self, context, request, inst):
+    def test_get_user_by_email_user_exists(self, context, request_, inst):
         from .principal import IUser
         user = testing.DummyResource(email='test@test.de', __provides__=IUser)
         context['principals']['users']['User1'] = user
         assert inst.get_user_by_email('test@test.de') is user
 
-    def test_get_user_by_email_user_not_exists(self, context, request, inst):
+    def test_get_user_by_email_user_not_exists(self, context, request_, inst):
         from .principal import IUser
         user = testing.DummyResource(email='', __provides__=IUser)
         context['principals']['users']['User1'] = user
         assert inst.get_user_by_email('wrong@test.de') is None
 
-    def test_get_user_by_login_user_exists(self, context, request, inst):
-        from .principal import IUser
-        user = testing.DummyResource(name='login name', __provides__=IUser)
-        context['principals']['users']['User1'] = user
-        other = testing.DummyResource()
-        context['principals']['users']['other'] = other
+    def test_get_user_by_login_user_exists(self, inst, mock_catalogs,
+                                           search_result, query):
+        user = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user])
         assert inst.get_user_by_login('login name') is user
+        assert mock_catalogs.search.call_args[0][0] == query._replace(
+            indexes={'user_name': 'login name'},
+            resolve=True,
+        )
 
-    def test_get_user_by_login_user_not_exists(self, context, request, inst,
-                                               mock_catalogs, search_result):
-        mock_catalogs.search.return_value = search_result
+    def test_get_user_by_login_user_not_exists(self, inst, mock_catalogs):
         assert inst.get_user_by_login('wrong login name') is None
+        assert mock_catalogs.search.called
 
-    def test_get_user_by_activation_path_user_exists(self, context, request, inst):
+    def test_get_user_by_activation_path_user_exists(self, context, request_, inst):
         from .principal import IUser
         user = testing.DummyResource(activation_path='/activate/foo',
                                      __provides__=IUser)
@@ -369,34 +378,34 @@ class TestUserLocatorAdapter:
         context['principals']['users']['other'] = other
         assert inst.get_user_by_activation_path('/activate/foo') is user
         
-    def test_get_user_by_activation_path_user_not_exists(self, context, request, inst):
+    def test_get_user_by_activation_path_user_not_exists(self, context, request_, inst):
         user = testing.DummyResource(activation_path=None)
         context['principals']['users']['User1'] = user
         assert inst.get_user_by_activation_path('/activate/no_such_link') is None
 
-    def test_get_user_by_userid_user_exists(self, context, request, inst):
+    def test_get_user_by_userid_user_exists(self, context, request_, inst):
         user = testing.DummyResource()
         context['principals']['users']['User1'] = user
         assert inst.get_user_by_userid('/principals/users/User1') is user
 
-    def test_get_user_by_userid_user_not_exists(self, context, request, inst):
+    def test_get_user_by_userid_user_not_exists(self, context, request_, inst):
         assert inst.get_user_by_userid('/principals/users/User1') is None
 
-    def test_get_groupids_user_exists(self, context, mock_sheet, request, inst):
+    def test_get_groupids_user_exists(self, context, mock_sheet, request_, inst):
         from adhocracy_core.sheets.principal import IPermissions
         from adhocracy_core.testing import register_sheet
         group = testing.DummyResource(__name__='group1')
         mock_sheet.meta = mock_sheet.meta._replace(isheet=IPermissions)
         mock_sheet.get.return_value = {'groups': [group]}
         user = testing.DummyResource()
-        register_sheet(user, mock_sheet, request.registry)
+        register_sheet(user, mock_sheet, request_.registry)
         context['principals']['users']['User1'] = user
         assert inst.get_groupids('/principals/users/User1') == ['group:group1']
 
-    def test_get_groupids_user_not_exists(self, context, request, inst):
+    def test_get_groupids_user_not_exists(self, context, request_, inst):
         assert inst.get_groupids('/principals/users/User1') is None
 
-    def test_get_role_and_group_role_ids_user_exists(self, context, request, inst):
+    def test_get_role_and_group_role_ids_user_exists(self, context, request_, inst):
         inst.get_user_by_userid = Mock()
         inst.get_user_by_userid.return_value = context
         inst.get_roleids = Mock()
@@ -406,10 +415,10 @@ class TestUserLocatorAdapter:
         assert inst.get_role_and_group_roleids('/principals/users/User1') ==\
                ['role:admin', 'role:reader']
 
-    def test_get_role_and_group_roleids_user_not_exists(self, context, request, inst):
+    def test_get_role_and_group_roleids_user_not_exists(self, context, request_, inst):
         assert inst.get_role_and_group_roleids('/principals/users/User1') is None
 
-    def test_get_group_roleids_user_exists(self, inst, context, mock_sheet, request,
+    def test_get_group_roleids_user_exists(self, inst, context, mock_sheet, request_,
                                           ):
         from adhocracy_core.sheets.principal import IPermissions
         from adhocracy_core.testing import register_sheet
@@ -417,22 +426,22 @@ class TestUserLocatorAdapter:
         user = testing.DummyResource()
         mock_sheet.meta = mock_sheet.meta._replace(isheet=IPermissions)
         mock_sheet.get.return_value = {'groups': [group]}
-        register_sheet(user, mock_sheet, request.registry)
+        register_sheet(user, mock_sheet, request_.registry)
         group.roles = ['role1']
         context['principals']['users']['User1'] = user
         assert inst.get_group_roleids('/principals/users/User1') == ['role:role1']
 
-    def test_get_group_roleids_user_not_exists(self, context, request, inst):
+    def test_get_group_roleids_user_not_exists(self, context, request_, inst):
         assert inst.get_group_roleids('/principals/users/User1') is None
 
-    def test_get_roleids_user_exists(self, context, mock_sheet, request, inst):
+    def test_get_roleids_user_exists(self, context, mock_sheet, request_, inst):
         from adhocracy_core.testing import register_sheet
         user = testing.DummyResource(roles=['role1'])
-        register_sheet(user, mock_sheet, request.registry)
+        register_sheet(user, mock_sheet, request_.registry)
         context['principals']['users']['User1'] = user
         assert inst.get_roleids('/principals/users/User1') == ['role:role1']
 
-    def test_get_roleids_user_not_exists(self, context, request, inst):
+    def test_get_roleids_user_not_exists(self, context, request_, inst):
         assert inst.get_roleids('/principals/users/User1') is None
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -342,17 +342,20 @@ class TestUserLocatorAdapter:
         assert IRolesUserLocator.providedBy(inst)
         assert verifyObject(IRolesUserLocator, inst)
 
-    def test_get_user_by_email_user_exists(self, context, request_, inst):
-        from .principal import IUser
-        user = testing.DummyResource(email='test@test.de', __provides__=IUser)
-        context['principals']['users']['User1'] = user
+    def test_get_user_by_email_user_exists(self, inst, mock_catalogs,
+                                           search_result, query):
+        user = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user])
         assert inst.get_user_by_email('test@test.de') is user
+        assert mock_catalogs.search.call_args[0][0] == query._replace(
+            indexes={'private_user_email': 'test@test.de'},
+            resolve=True,
+        )
 
-    def test_get_user_by_email_user_not_exists(self, context, request_, inst):
-        from .principal import IUser
-        user = testing.DummyResource(email='', __provides__=IUser)
-        context['principals']['users']['User1'] = user
+    def test_get_user_by_email_user_not_exists(self, inst, mock_catalogs):
         assert inst.get_user_by_email('wrong@test.de') is None
+        assert mock_catalogs.search.called
 
     def test_get_user_by_login_user_exists(self, inst, mock_catalogs,
                                            search_result, query):

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -372,19 +372,20 @@ class TestUserLocatorAdapter:
         assert inst.get_user_by_login('wrong login name') is None
         assert mock_catalogs.search.called
 
-    def test_get_user_by_activation_path_user_exists(self, context, request_, inst):
-        from .principal import IUser
-        user = testing.DummyResource(activation_path='/activate/foo',
-                                     __provides__=IUser)
-        context['principals']['users']['User1'] = user
-        other = testing.DummyResource()
-        context['principals']['users']['other'] = other
+    def test_get_user_by_activation_path_user_exists(self, inst, mock_catalogs,
+                                                     search_result, query):
+        user = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user])
         assert inst.get_user_by_activation_path('/activate/foo') is user
-        
-    def test_get_user_by_activation_path_user_not_exists(self, context, request_, inst):
-        user = testing.DummyResource(activation_path=None)
-        context['principals']['users']['User1'] = user
+        assert mock_catalogs.search.call_args[0][0] == query._replace(
+            indexes={'private_user_activation_path': '/activate/foo'},
+            resolve=True,
+        )
+
+    def test_get_user_by_activation_path_user_not_exists(self, inst, mock_catalogs):
         assert inst.get_user_by_activation_path('/activate/no_such_link') is None
+        assert mock_catalogs.search.called
 
     def test_get_user_by_userid_user_exists(self, context, request_, inst):
         user = testing.DummyResource()

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -355,9 +355,9 @@ class TestUserLocatorAdapter:
         context['principals']['users']['other'] = other
         assert inst.get_user_by_login('login name') is user
 
-    def test_get_user_by_login_user_not_exists(self, context, request, inst):
-        user = testing.DummyResource(name='')
-        context['principals']['users']['User1'] = user
+    def test_get_user_by_login_user_not_exists(self, context, request, inst,
+                                               mock_catalogs, search_result):
+        mock_catalogs.search.return_value = search_result
         assert inst.get_user_by_login('wrong login name') is None
 
     def test_get_user_by_activation_path_user_exists(self, context, request, inst):

--- a/src/adhocracy_core/adhocracy_core/resources/test_root.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_root.py
@@ -20,6 +20,7 @@ def integration(integration):
     integration.include('adhocracy_core.changelog')
     integration.include('adhocracy_core.rest')
     integration.include('adhocracy_core.messaging')
+    return integration
 
 
 @mark.usefixtures('integration')

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1342,6 +1342,14 @@ class TestValidateActivationPathUnitTest:
     @fixture
     def user(self):
         user = testing.DummyResource()
+
+    def user_with_metadata(self, config):
+        from adhocracy_core.sheets.metadata import IMetadata
+        config.include('adhocracy_core.content')
+        config.include('adhocracy_core.events')
+        config.include('adhocracy_core.changelog')
+        config.include('adhocracy_core.sheets.metadata')
+        user = testing.DummyResource(__provides__=IMetadata)
         user.activate = Mock()
         return user
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1342,14 +1342,6 @@ class TestValidateActivationPathUnitTest:
     @fixture
     def user(self):
         user = testing.DummyResource()
-
-    def user_with_metadata(self, config):
-        from adhocracy_core.sheets.metadata import IMetadata
-        config.include('adhocracy_core.content')
-        config.include('adhocracy_core.events')
-        config.include('adhocracy_core.changelog')
-        config.include('adhocracy_core.sheets.metadata')
-        user = testing.DummyResource(__provides__=IMetadata)
         user.activate = Mock()
         return user
 

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -21,6 +21,7 @@ from zope.interface.interfaces import IInterface
 from zope.interface import Interface
 
 from adhocracy_core.caching import set_cache_header
+from adhocracy_core.events import ResourceSheetModified
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IItem
 from adhocracy_core.interfaces import IItemVersion
@@ -64,6 +65,7 @@ from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.sheets.principal import IPasswordAuthentication
 from adhocracy_core.sheets.pool import IPool as IPoolSheet
 from adhocracy_core.sheets.versions import IVersionable
+from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.utils import extract_events_from_changelog_metadata
 from adhocracy_core.utils import get_sheet
 from adhocracy_core.utils import get_sheet_field
@@ -1109,6 +1111,9 @@ def validate_activation_path(context, request: Request):
         user.activate()
         user.activation_path = None
         request.validated['user'] = user
+        event = ResourceSheetModified(user, IUserBasic, request.registry, {},
+                                      {}, request)
+        request.registry.notify(event)  # trigger reindex activation_path index
 
 
 @view_defaults(

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1584,6 +1584,9 @@ custom filters:
   sheet.
   Valid query comparable: 'eq', 'noteq', 'lt', 'le', 'gt', 'ge', 'any', 'notany'
 
+* *user_name* the login name of users.
+  Valid query comparable: 'eq', 'noteq', 'lt', 'le', 'gt', 'ge', 'any', 'notany'
+
 *<package.sheets.sheet.ISheet:FieldName>* filters: you can add arbitrary custom
 filters that refer to sheet fields with references. The key is the name of
 the isheet plus the field name separated by ':' The value is the wanted


### PR DESCRIPTION
API EXTENSION:

- add search index 'user_name' (to sort user by login name)

INTERNAL:

- refactor to speed up login/activation of users

MANUAL MIGRATION NEEDED:

Restart adhocracy, then reindex all users (@slomo):

    bin/sd_reindex  -c adhocracy etc/development.ini -p "/principals/users"


