### PR TITLE
Add current links earlier (trivial)

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -7,6 +7,7 @@ parts +=
     protractor
     merge_static_directories
     do_merge_static_directories
+    frontend.current.link
     bower
     AdhocracySpec.ts
     meta_api
@@ -16,7 +17,6 @@ parts +=
     grunt
     javascript.umd
     rubygems
-    frontend.current.link
     stylesheets
     hologram
     styleguide


### PR DESCRIPTION
This makes sure the links are also there if tsc fails.