### PR TITLE
removed white space from comment detail

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/CommentDetail.html
@@ -61,9 +61,7 @@
                 <a href="" class="button form-footer-button" data-ng-click="cancel()" data-ng-if="!hideCancel">{{ "TR__CANCEL" | translate }}</a>
             </footer>
         </form>
-        <div class="comment-content" data-ng-switch-default="">
-            {{data.content}}
-        </div>
+        <div class="comment-content" data-ng-switch-default="">{{data.content}}</div>
     </div>
 
     <div class="comment-children-create-form" data-ng-if="show.createForm">


### PR DESCRIPTION
Fixes #1630

I've opted for simply removing the white-space in the HTML - it's something we need to keep an eye on but as this css is not used that much, I don't forsee a situation where it wouldn't be clear what the solution is.

In other scenarios (where it's just applied to <p> tags) these would naturally not have a line-break i the HTML - I say we leave this solution for now as it's the simplest.