### PR TITLE
rm unused dependency

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Module.ts
@@ -8,7 +8,6 @@ import * as AdhMappingModule from "../Mapping/Module";
 import * as AdhMarkdownModule from "../Markdown/Module";
 import * as AdhPreliminaryNamesModule from "../PreliminaryNames/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
-import * as AdhResourceWidgetsModule from "../ResourceWidgets/Module";
 import * as AdhStickyModule from "../Sticky/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
@@ -33,7 +32,6 @@ export var register = (angular) => {
             AdhMarkdownModule.moduleName,
             AdhPreliminaryNamesModule.moduleName,
             AdhResourceAreaModule.moduleName,
-            AdhResourceWidgetsModule.moduleName,
             AdhStickyModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])


### PR DESCRIPTION
ResourceWidget is not actually used in Document, so no reason to add it as dependency.