### PR TITLE
Fix CrossWindowMessaging uninitialized login state

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -147,12 +147,19 @@ export class Service implements IService {
 
     private setup(data: IMessageData) : void {
         var _self : Service = this;
+        var lastLoggedIn : boolean;
 
         if (_self.embedderOrigin === "*") {
             _self.embedderOrigin = data.embedderOrigin;
 
             if (typeof _self.adhUser !== "undefined") {
-                _self.$rootScope.$watch(() => typeof _self.adhUser.data !== "undefined", (loggedIn) => _self.sendLoginState(loggedIn));
+                _self.adhUser.ready.then(() =>
+                    _self.$rootScope.$watch(() => typeof _self.adhUser.data !== "undefined", (loggedIn) => {
+                        if (loggedIn !== lastLoggedIn) {
+                            lastLoggedIn = loggedIn;
+                            _self.sendLoginState(loggedIn);
+                        }
+                    }));
             }
 
             _self.$rootScope.$watch(() => _self.$location.absUrl(), (absUrl : string) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
+import * as q from "q";
+
 import * as AdhConfig from "../Config/Config";
 import * as AdhCrossWindowMessaging from "./CrossWindowMessaging";
 
@@ -16,7 +18,8 @@ export var register = () => {
             locationMock = jasmine.createSpyObj("locationMock", ["absUrl"]);
             windowMock = jasmine.createSpyObj("windowMock", ["addEventListener"]);
             rootScopeMock = jasmine.createSpyObj("rootScopeMock", ["$watch"]);
-            adhCredentialsMock = jasmine.createSpyObj("adhCredentialsMock", ["loggedIn"]);
+            adhCredentialsMock = jasmine.createSpyObj("adhCredentialsMock", ["loggedIn", "ready"]);
+            adhCredentialsMock.ready.and.returnValue(q.when());
         });
 
         describe("Service", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Module.ts
@@ -14,5 +14,5 @@ export var register = (angular) => {
             AdhCredentialsModule.moduleName,
             AdhHttpModule.moduleName
         ])
-        .service("adhUser", ["adhHttp", "adhCredentials", "$rootScope", AdhUser.Service]);
+        .service("adhUser", ["adhHttp", "adhCredentials", "$q", "$rootScope", AdhUser.Service]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -77,7 +77,7 @@ export var register = () => {
                     adhConfigMock, adhCacheMock, adhTrackingMock, modernizrMock, angularMock,
                     <any>q, httpMock, timeoutMock, rootScopeMock, windowMock);
 
-                adhUser = new AdhUser.Service(adhHttpMock, adhCredentials, rootScopeMock);
+                adhUser = new AdhUser.Service(adhHttpMock, adhCredentials, <any>q, rootScopeMock);
             });
 
             it("registers a handler on 'storage' DOM events", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -248,7 +248,7 @@ export var registerDirective = (
             };
 
             scope.cancel = scope.goBack = () => {
-                 adhTopLevelState.goToCameFrom("/");
+                adhTopLevelState.goToCameFrom("/");
             };
 
 


### PR DESCRIPTION
As long as Adhocracy hasn't properly initialized the user login state, we shall not send any login state through CWM.

This is fixed with this PR by introducing a `adhUser.ready` promise in addition to the already existing `adhCredentials.ready` promise.