### PR TITLE
Add search and hash to camefrom in toplevel state

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -427,8 +427,7 @@ export class Service {
             "/activate"
         ];
 
-        // FIXME: DefinitelyTyped
-        if (!(<any>_).includes(denylist, url)) {
+        if (!_.includes(denylist, url)) {
             this.cameFrom = url;
             return true;
         } else {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -414,24 +414,9 @@ export class Service {
 
     private cameFrom : string;
 
-    public setCameFrom(path? : string) : boolean {
-        if (typeof path === "undefined") {
-            path = this.$location.path();
-
-            var search = this.$location.search();
-            if (Object.keys(search).length > 0) {
-                path += "?";
-                for (var key in search) {
-                    if (me.hasOwnProperty(key)) {
-                        path += "&" + key + "=" + search[key];
-                    }
-                }
-            }
-
-            var hash = this.$location.hash();
-            if (hash !== "") {
-                path += "#" + hash;
-            }
+    public setCameFrom(url? : string) : boolean {
+        if (typeof url === "undefined") {
+            url = this.$location.url();
         }
 
         var denylist = [
@@ -443,8 +428,8 @@ export class Service {
         ];
 
         // FIXME: DefinitelyTyped
-        if (!(<any>_).includes(denylist, path)) {
-            this.cameFrom = path;
+        if (!(<any>_).includes(denylist, url)) {
+            this.cameFrom = url;
             return true;
         } else {
             return false;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -422,14 +422,14 @@ export class Service {
             if (Object.keys(search).length > 0) {
                 path += "?";
                 for (var key in search) {
-                    if (me.hasOwnProperty(prop)) {
+                    if (me.hasOwnProperty(key)) {
                         path += "&" + key + "=" + search[key];
                     }
                 }
             }
 
             var hash = this.$location.hash();
-            if (hash === "") {
+            if (hash !== "") {
                 path += "#" + hash;
             }
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -417,6 +417,21 @@ export class Service {
     public setCameFrom(path? : string) : boolean {
         if (typeof path === "undefined") {
             path = this.$location.path();
+
+            var search = this.$location.search();
+            if (Object.keys(search).length > 0) {
+                path += "?";
+                for (var key in search) {
+                    if (me.hasOwnProperty(prop)) {
+                        path += "&" + key + "=" + search[key];
+                    }
+                }
+            }
+
+            var hash = this.$location.hash();
+            if (hash === "") {
+                path += "#" + hash;
+            }
         }
 
         var denylist = [


### PR DESCRIPTION
The bug that I am trying to fix can be reproduced using this [embed link]( https://embed-meinberlin-stage.liqd.net/embed/meinberlin-stadtforum-proposal-create?pool-path=https:%2F%2Fembed-meinberlin-stage.liqd.net%2Fapi%2Fstadtentwicklung%2Fstadtforum%2F) from mein berlin stage.

If the user klicks (while not being logged in) on the any of the rate widgets (or are the called directives?) she will be redirected to the login page. After logging in the user will be redirected to the embed widget without the query parameters.

After poking around a bit I would say this is an issue for all embed widgets based wrapping directly a  directives (like the discussion in policycompass). Embed widgets that are based on context or plain are not affected, since they don't use the query parameters of a request.

I am now also copying the hash of the url, that wasn't needed for my issue but seems to me a sane thing to do.

**Disclaimer:** I know that is a change on a pretty important component, hence I want to stress that I have barely a clue what I am doing when it comes to the frontend. I setup a `burgerhaushalt` instance and that seems still to work after the change. I didn't yet think about url escaping when building the came from. 