### PR TITLE
Add UI for creating bplan processes

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Module.ts
@@ -1,12 +1,16 @@
+import * as AdhMeinberlinBplanProcessModule from "./Process/Module";
 import * as AdhMeinberlinBplanProposalModule from "./Proposal/Module";
 
 export var moduleName = "adhMeinberlinBplan";
 
+
 export var register = (angular) => {
+    AdhMeinberlinBplanProcessModule.register(angular);
     AdhMeinberlinBplanProposalModule.register(angular);
 
     angular
         .module(moduleName, [
+            AdhMeinberlinBplanProcessModule.moduleName,
             AdhMeinberlinBplanProposalModule.moduleName
         ]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
@@ -90,12 +90,12 @@
 &lt;/script&gt;
 &lt;div
     class=&quot;adhocracy_marker&quot;
-    data-widget=&quot;buergerhaushalt&quot;
-    data-initial-url=&quot;{{resultUrl}}&quot;
+    data-widget=&quot;mein-berlin-bplaene-proposal-embed&quot;
+    data-path=&quot;{{resultUrl}}&quot;
     data-locale=&quot;de&quot;
-    data-autoresize=&quot;false&quot;
+    data-autoresize=&quot;true&quot;
     data-autourl=&quot;false&quot;
-    style=&quot;height: 650px&quot;&gt;
-&lt;/div&gt;
-    </pre>
+    data-noheader=&quot;true&quot;
+    data-nocenter=&quot;true&quot;&gt;
+&lt;/div&gt;</pre>
 </form>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
@@ -1,0 +1,75 @@
+<form
+    name="processForm"
+    novalidate="novalidate"
+    data-ng-submit="submit()">
+
+    <div class="proposal-form-upper">
+        <div class="form-error" data-ng-repeat="error in errors track by $index">
+            <p>{{ error | adhFormatError | translate }}</p>
+        </div>
+
+        <label>
+            <span class="label-text">{{ "TR__TITLE" | translate }}</span>
+            <input
+                type="text"
+                data-ng-model="data.title"
+                name="title"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(processForm, processForm.title, 'required')">
+                {{ "TR__ERROR_REQUIRED_TITLE" | translate }}
+            </span>
+        </label>
+
+        <label>
+            <span class="label-text">{{ "TR__MEINBERLIN_BPLAN_KIND" | translate }}</span>
+            <select data-ng-model="data.kind" name="kind">
+                <option>öffentliche Auslegung</option>
+                <option>frühzeitige Öffentlichkeitsbeteiligung</option>
+            </select>
+        </label>
+
+        <label>
+            <span class="label-text">{{ "TR__OFFICE_WORKER" | translate }}</span>
+            <input
+                type="url"
+                data-ng-model="data.officeWorker"
+                name="officeWorker"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(processForm, processForm.officeWorker, 'required')">
+                {{ "TR__ERROR_REQUIRED_OFFICE_WORKER" | translate }}
+            </span>
+        </label>
+
+        <label>
+            <span class="label-text">{{ "TR__DATE_START" | translate }}</span>
+            <input
+                type="date"
+                data-ng-model="data.startDate"
+                name="startDate"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(processForm, processForm.startDate, 'required')">
+                {{ "TR__ERROR_REQUIRED_DATE" | translate }}
+            </span>
+        </label>
+
+        <label>
+            <span class="label-text">{{ "TR__DATE_END" | translate }}</span>
+            <input
+                type="date"
+                data-ng-model="data.endDate"
+                name="endDate"
+                required="required" />
+            <span class="input-error" data-ng-show="showError(processForm, processForm.endDate, 'required')">
+                {{ "TR__ERROR_REQUIRED_DATE" | translate }}
+            </span>
+        </label>
+    </div>
+
+    <footer class="form-footer">
+        <input
+            type="submit"
+            name="submit"
+            value="{{ 'TR__PUBLISH' | translate }}"
+            class="button-cta form-footer-button-cta" />
+    </footer>
+</form>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
@@ -43,24 +43,32 @@
         <label>
             <span class="label-text">{{ "TR__DATE_START" | translate }}</span>
             <input
-                type="date"
+                type="text"
                 data-ng-model="data.startDate"
                 name="startDate"
+                data-ng-pattern="/([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|(1|2)[0-9]|0[1-9])$/"
                 required="required" />
             <span class="input-error" data-ng-show="showError(processForm, processForm.startDate, 'required')">
                 {{ "TR__ERROR_REQUIRED_DATE" | translate }}
+            </span>
+            <span class="input-error" data-ng-if="showError(processForm, processForm.startDate, 'pattern')">
+                {{ "TR__ERROR_INVALID_DATE" | translate }}
             </span>
         </label>
 
         <label>
             <span class="label-text">{{ "TR__DATE_END" | translate }}</span>
             <input
-                type="date"
+                type="text"
                 data-ng-model="data.endDate"
                 name="endDate"
+                data-ng-pattern="/([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|(1|2)[0-9]|0[1-9])$/"
                 required="required" />
             <span class="input-error" data-ng-show="showError(processForm, processForm.endDate, 'required')">
                 {{ "TR__ERROR_REQUIRED_DATE" | translate }}
+            </span>
+            <span class="input-error" data-ng-if="showError(processForm, processForm.endDate, 'pattern')">
+                {{ "TR__ERROR_INVALID_DATE" | translate }}
             </span>
         </label>
     </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Create.html
@@ -80,4 +80,22 @@
             value="{{ 'TR__PUBLISH' | translate }}"
             class="button-cta form-footer-button-cta" />
     </footer>
+
+    <pre class="embed-snippet" data-ng-if="resultUrl">
+&lt;script type=&quot;text/javascript&quot; src=&quot;{{origin}}/AdhocracySDK.js&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+    adhocracy.init('{{origin}}', function(adhocracy) {
+        adhocracy.embed('.adhocracy_marker');
+    });
+&lt;/script&gt;
+&lt;div
+    class=&quot;adhocracy_marker&quot;
+    data-widget=&quot;buergerhaushalt&quot;
+    data-initial-url=&quot;{{resultUrl}}&quot;
+    data-locale=&quot;de&quot;
+    data-autoresize=&quot;false&quot;
+    data-autourl=&quot;false&quot;
+    style=&quot;height: 650px&quot;&gt;
+&lt;/div&gt;
+    </pre>
 </form>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
@@ -23,5 +23,5 @@ export var register = (angular) => {
                 .registerDirective("meinberlin-bplan-process-create");
         }])
         .directive("adhMeinberlinBplanProcessCreate", [
-            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", Process.createDirective]);
+            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", "$window", Process.createDirective]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
@@ -1,0 +1,27 @@
+import * as AdhHttpModule from "../../../Http/Module";
+import * as AdhPreliminaryNamesModule from "../../../PreliminaryNames/Module";
+import * as AdhEmbedModule from "../../../Embed/Module";
+import * as AdhAngularHelpers from "../../../AngularHelpers/Module";
+
+import * as AdhEmbed from "../../../Embed/Embed";
+
+import * as Process from "./Process";
+
+
+export var moduleName = "adhMeinBerlinBplanProcess";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhAngularHelpers.moduleName,
+            AdhEmbedModule.moduleName,
+            AdhHttpModule.moduleName,
+            AdhPreliminaryNamesModule.moduleName
+        ])
+        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
+            adhEmbedProvider
+                .registerDirective("meinberlin-bplan-process-create");
+        }])
+        .directive("adhMeinberlinBplanProcessCreate", [
+            "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", Process.createDirective]);
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
@@ -1,0 +1,83 @@
+/// <reference path="../../../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
+
+import * as AdhConfig from "../../../Config/Config";
+import * as AdhHttp from "../../../Http/Http";
+import * as AdhPreliminaryNames from "../../../PreliminaryNames/PreliminaryNames";
+
+import * as SITitle from "../../../../Resources_/adhocracy_core/sheets/title/ITitle";
+import * as SIName from "../../../../Resources_/adhocracy_core/sheets/name/IName";
+import * as SIProcessSettings from "../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IProcessSettings";
+import RIProcess from "../../../../Resources_/adhocracy_meinberlin/resources/bplan/IProcess";
+
+var pkgLocation = "/Meinberlin/Bplan/Process";
+
+
+export interface IScope {
+    poolPath : string;
+    errors : any[];
+    data : {
+        title : string;
+        officeWorker : string;
+        startDate : string;
+        endDate : string;
+        kind : string;
+    };
+    showError : any;
+    submit() : angular.IPromise<any>;
+}
+
+
+var postCreate = (
+    adhHttp : AdhHttp.Service<any>,
+    adhPreliminaryNames : AdhPreliminaryNames.Service
+) => (
+    scope : IScope,
+    poolPath : string
+) => {
+    var process = new RIProcess({preliminaryNames: adhPreliminaryNames});
+    process.parent = poolPath;
+
+    process.data[SIName.nick] = new SIName.Sheet({
+        name: scope.data.title
+    });
+    process.data[SITitle.nick] = new SITitle.Sheet({
+        title: "Bebauungsplan " + scope.data.title
+    });
+    process.data[SIProcessSettings.nick] = new SIProcessSettings.Sheet({
+        office_worker: scope.data.officeWorker,
+        participation_start_date: scope.data.startDate,
+        participation_end_date: scope.data.endDate,
+        participation_kind: scope.data.kind,
+        plan_number: scope.data.title
+    });
+
+    return adhHttp.deepPost([process]);
+};
+
+
+export var createDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>,
+    adhPreliminaryNames : AdhPreliminaryNames.Service,
+    adhShowError,
+    adhSubmitIfValid
+) => {
+    return {
+        restrict: "E",
+        scope: {
+            poolPath: "@"
+        },
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
+        link: (scope, element) => {
+            scope.errors = [];
+            scope.data = {};
+            scope.showError = adhShowError;
+
+            scope.submit = () => {
+                return adhSubmitIfValid(scope, element, scope.processForm, () => {
+                    return postCreate(adhHttp, adhPreliminaryNames)(scope, scope.poolPath);
+                });
+            };
+        }
+    };
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
@@ -60,7 +60,8 @@ export var createDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhShowError,
-    adhSubmitIfValid
+    adhSubmitIfValid,
+    $window : angular.IWindowService
 ) => {
     return {
         restrict: "E",
@@ -72,10 +73,13 @@ export var createDirective = (
             scope.errors = [];
             scope.data = {};
             scope.showError = adhShowError;
+            scope.origin = $window.location.origin;
 
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.processForm, () => {
-                    return postCreate(adhHttp, adhPreliminaryNames)(scope, scope.poolPath);
+                    return postCreate(adhHttp, adhPreliminaryNames)(scope, scope.poolPath).then((responses) => {
+                        scope.resultUrl = responses[0].path;
+                    });
                 });
             };
         }


### PR DESCRIPTION
-   office workers need to be entered by full URL
-   on success, an embed snippet is shown. This makes it very useful in a specific usecase but not useable in some others.
-   I did end up not using `date` inputs because only chrome seems to support them and the polyfill is kinda broken. This was an issue before, can't find the issue right now.