### PR TITLE
show fake comment form for not logged-in users in stadtforum

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Detail.html
@@ -8,6 +8,13 @@
         <i class="icon-speechbubble"></i> {{ data.commentCount }}
     </span>
 
+    <div class="proposal-comment-form-fake comment-create-form" data-ng-if="!options.loggedIn">
+        <textarea class="comment-create-form-text" disabled="disabled"></textarea>
+        <footer class="form-footer">
+            <a href="" data-ng-click="goToLogin()" class="comment-create-form-button-submit button-cta form-footer-button-cta">{{ "TR__CREATE_COMMENT" | translate }}</a>
+        </footer>
+    </div>
+
     <adh-comment-listing
         data-path="{{path}}"
         data-frontend-order-predicate="frontendOrderPredicate"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -39,6 +39,7 @@ export interface IScope extends angular.IScope {
     resource : any;
     frontendOrderPredicate : any;
     frontendOrderReverse : boolean;
+    goToLogin() : void;
 }
 
 var bindPath = (
@@ -156,6 +157,10 @@ export var detailDirective = (
             bindPath(adhHttp, adhPermissions, adhRate, adhTopLevelState, adhGetBadges, $q)(scope);
             scope.frontendOrderPredicate = (id) => id;
             scope.frontendOrderReverse = true;
+
+            scope.goToLogin = () => {
+                adhTopLevelState.setCameFromAndGo("/login");
+            };
         }
     };
 };


### PR DESCRIPTION
some notes:

-   [ ] translation is missing
-   [ ] the disabled textarea is not visually distinguishable from a non-disabled one
-   [ ] the disabled textarea is resizable
-   This is implemented in stadtforum instead of comment because the permission check is hardcoded (it is not possible to check "what would a 'normal' user be able to do"; see #1347). If the scope is limited to stadtforum, it is reasonable that we can guess the correct permissions.
-   As there is no proper workflow for stadtforum yet (see #1732) there are no permission checks in place. Once we have a proper workflow we might want to show/hide the fake form based on workflow state.