### PR TITLE
2015 10 cc disabled textareas

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -30,6 +30,21 @@ it is also dirty or the form has been submitted.
 
 /*doc
 ---
+title: textareas
+name: input.textarea
+category: Inputs
+---
+
+Textareas behave exactly like text inputs however they are resizeable when enabled in modern browsers.
+
+```html_example
+<textarea></textarea>
+<textarea disabled="disabled" placeholder="disabled"></textarea>
+```
+*/
+
+/*doc
+---
 title: textinput
 name: textinput
 parent: input
@@ -141,6 +156,11 @@ textarea {
 
 textarea {
     resize: vertical;
+
+    &.ng-disabled,
+    &:disabled {
+        resize: none;
+    }
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -53,7 +53,6 @@ They should all look and behave similarily.
     <option>This one</option>
     <option>The other one</option>
 </select>
-<textarea placeholder="textarea"></textarea>
 ```
 */
 
@@ -64,7 +63,8 @@ name: textinput.textarea
 parent: textinput
 ---
 
-Textareas behave exactly like text inputs however they are resizeable when enabled in modern browsers.
+Textareas behave exactly like text inputs however they are resizeable when
+enabled in modern browsers.
 
 ```html_example
 <textarea></textarea>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -30,21 +30,6 @@ it is also dirty or the form has been submitted.
 
 /*doc
 ---
-title: textareas
-name: input.textarea
-category: Inputs
----
-
-Textareas behave exactly like text inputs however they are resizeable when enabled in modern browsers.
-
-```html_example
-<textarea></textarea>
-<textarea disabled="disabled" placeholder="disabled"></textarea>
-```
-*/
-
-/*doc
----
 title: textinput
 name: textinput
 parent: input
@@ -69,6 +54,21 @@ They should all look and behave similarily.
     <option>The other one</option>
 </select>
 <textarea placeholder="textarea"></textarea>
+```
+*/
+
+/*doc
+---
+title: Textareas
+name: textinput.textarea
+parent: textinput
+---
+
+Textareas behave exactly like text inputs however they are resizeable when enabled in modern browsers.
+
+```html_example
+<textarea></textarea>
+<textarea disabled="disabled" placeholder="disabled"></textarea>
 ```
 */
 


### PR DESCRIPTION
as requested by #1750. Stops textareas from resizing when disabled. They still look the same however, to discuss with designers as this is an input-wide concern.