### PR TITLE
2015 10 mh fix build on mac against master

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -236,7 +236,6 @@ input = inline:
     #!/bin/bash
     if type brew > /dev/null 2>&1; then
         (brew list | grep --quiet coreutils) || echo "!!! Mac needs to manually installed gnu coreutils via $ brew install coreutils"
-        # MANPATH="$(brew --prefix)/opt/coreutils/libexec/gnuman:$MANPATH"
         PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
     fi
     

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -235,6 +235,7 @@ static_directories =
 input = inline:
     #!/bin/bash
     if type brew > /dev/null 2>&1; then
+        # REFACT consider to replace coreutil-isms with posix calls
         (brew list | grep --quiet coreutils) || echo "!!! Mac needs to manually installed gnu coreutils via $ brew install coreutils"
         PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
     fi

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -234,6 +234,12 @@ static_directories =
     ${adhocracy:frontend.core.static_dir}
 input = inline:
     #!/bin/bash
+    if type brew > /dev/null 2>&1; then
+        (brew list | grep --quiet coreutils) || echo "!!! Mac needs to manually installed gnu coreutils via $ brew install coreutils"
+        # MANPATH="$(brew --prefix)/opt/coreutils/libexec/gnuman:$MANPATH"
+        PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
+    fi
+    
     mkdir -p ${adhocracy:frontend.static_dir}
     find ${adhocracy:frontend.static_dir} -type l -exec rm {} +
     for dir in ${:static_directories} ; do


### PR DESCRIPTION
Fix build for mac.
    
The problem is that this script uses gnu coreutil specific switches - so coreutils needs to be installed on the mac and prepended to the path for this script. Also added an error message to make it easier to debug why things went wrong.