### PR TITLE
Use correct search manager keyword for FCM

### DIFF
--- a/src/adhocracy_pcompass/adhocracy_pcompass/resources/subscriber.py
+++ b/src/adhocracy_pcompass/adhocracy_pcompass/resources/subscriber.py
@@ -26,7 +26,7 @@ def notify_policycompass(event):
 
     resource_name = get_sheet_field(external_resource, IName, 'name')
     match = re.match(
-        '(?P<type>visualization|event|dataset|metric|model|indicator)'
+        '(?P<type>visualization|event|dataset|metric|fuzzymap|indicator)'
         '_(?P<id>[0-9]+)',
         resource_name)
 


### PR DESCRIPTION
We use `fuzzymap` throughout the code, not `model`.