### PR TITLE
Validate password field in login (fixes #1747)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
@@ -23,9 +23,14 @@
                 type="password"
                 name="password"
                 required="required"
+                data-ng-minlength="6"
+                data-ng-maxlength="100"
                 data-ng-model="credentials.password" />
             <span class="input-error" data-ng-show="showError(loginForm, loginForm.password, 'required')">
                 {{ "TR__ERROR_REQUIRED_PASSWORD" | translate }}
+            </span>
+            <span class="input-error" data-ng-show="showError(loginForm, loginForm.password, 'minlength')">
+                {{ "TR__ERROR_TOO_SHORT_PASSWORD" | translate }}
             </span>
         </label>
 


### PR DESCRIPTION
It'd be nicer to not let the backend expose the minimum length on login,
but this would be more work now, and like that it's at least consistent
throughout the frontend.