### PR TITLE
Parse URLs instead of doing string slicing that breaks in the presence of small variations in the URL

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -1,6 +1,7 @@
 """Authentication with support for token http headers."""
 import hashlib
 from datetime import datetime
+import urllib
 
 from colander import Invalid
 from persistent.dict import PersistentDict
@@ -124,12 +125,7 @@ def _get_raw_x_user_headers(request: Request) -> tuple:
     # well with the pyramid authentication system. We don't have the
     # a context or root object to resolve the resource path when processing
     # the unauthenticated_userid and effective_principals methods.
-    app_url_length = len(request.application_url)
-    user_path = None
-    if user_url.startswith('/'):
-        user_path = user_url
-    elif len(user_url) >= app_url_length:
-        user_path = user_url[app_url_length:][:-1]
+    user_path = urllib.parse.urlparse(user_url).path.rstrip('/') or None
     token = request.headers.get('X-User-Token', None)
     return user_path, token
 

--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -6,6 +6,7 @@ import decimal
 import io
 import os
 import re
+import urllib
 
 from pyramid.path import DottedNameResolver
 from pyramid.traversal import find_resource
@@ -474,8 +475,7 @@ class ResourceObject(colander.SchemaType):
             application_url_len = len(request.application_url)
             if application_url_len > len(str(value)):
                 raise KeyError
-            # Fixme: This does not work with :term:`virtual hosting`
-            path = value[application_url_len:]
+            path = urllib.parse.urlparse(value).path
             return find_resource(request.root, path)
 
 

--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -475,6 +475,7 @@ class ResourceObject(colander.SchemaType):
             application_url_len = len(request.application_url)
             if application_url_len > len(str(value)):
                 raise KeyError
+            # Fixme: This does not work with :term:`virtual hosting`
             path = urllib.parse.urlparse(value).path
             return find_resource(request.root, path)
 


### PR DESCRIPTION
Fixes #1797 
With this patch, A3 seems to work when using virtual hosting. I hope I didn't miss any problems with this. Tests still pass. I might add a regression test once I figure out how.