### PR TITLE
Revert "Skip header validation if authentication is done by Thentos"

### DIFF
--- a/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
@@ -46,7 +46,6 @@ class TestBatchView:
     @fixture
     def request_(self, request_, changelog, mock_invoke_subrequest):
         request_.registry.changelog = changelog
-        request_.registry.settings = {}
         request_.invoke_subrequest = mock_invoke_subrequest
         request_.method = 'POST'
         return request_

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -276,13 +276,6 @@ class TestValidateRequest:
             self.call_fut(context, request_)
         assert request_.validated == {}
 
-    def test_invalid_user_headers_but_check_disabled(self, context, request_):
-        request_.registry.settings['adhocracy.validate_user_token'] = False
-        request_.headers['X-User-Path'] = 2
-        request_.headers['X-User-Token'] = 3
-        self.call_fut(context, request_)
-        assert request_.validated == {}
-
 
 class TestValidatePOSTRootVersions:
 

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -16,7 +16,6 @@ from pyramid.request import Request
 from pyramid.view import view_config
 from pyramid.view import view_defaults
 from pyramid.security import remember
-from pyramid.settings import asbool
 from pyramid.traversal import resource_path
 from zope.interface.interfaces import IInterface
 from zope.interface import Interface
@@ -192,9 +191,6 @@ def validate_user_headers(request: Request):
     If the request has a 'X-User-Path' and/or 'X-User-Token' header, we
     ensure that the session takes belongs to the user and is not expired.
     """
-    settings = request.registry.settings
-    if not asbool(settings.get('adhocracy.validate_user_token', True)):
-        return
     headers = request.headers
     if 'X-User-Path' in headers or 'X-User-Token' in headers:
         if get_user(request) is None:


### PR DESCRIPTION
Reverts liqd/adhocracy3.mercator#1778

As @ChristianSi pointed out, that PR was just masking another problem (#1798) and would actually break things at a later point. Sorry for that.