### PR TITLE
user activity overview

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
@@ -1,9 +1,9 @@
 <table class="user-activity-overview">
   <tbody>
     <tr>
-      <td class="comments">{{ commentCount }} Beiträge</td>
-      <td class="proposals">{{ proposalCount }} Eigene Vorschläge</td>
-      <td class="ratings">{{ rateCount }} Anhänger</td>
+      <td class="comments" data-ng-if="commentCount">{{ commentCount }} Beiträge</td>
+      <td class="proposals" data-ng-if="proposalCount">{{ proposalCount }} Eigene Vorschläge</td>
+      <td class="ratings" data-ng-if="rateCount">{{ rateCount }} Anhänger</td>
     </tr>
   </tbody>
 </table>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
@@ -1,0 +1,9 @@
+<table class="user-activity-overview">
+  <tbody>
+    <tr>
+      <td class="comments">{{ commentCount }} Beiträge</td>
+      <td class="proposals">{{ proposalCount }} Eigene Vorschläge</td>
+      <td class="ratings">{{ rateCount }} Anhänger</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
@@ -1,9 +1,7 @@
-<table class="user-activity-overview">
-  <tbody>
-    <tr>
-      <td class="comments" data-ng-if="commentCount">{{ commentCount }} Beiträge</td>
-      <td class="proposals" data-ng-if="proposalCount">{{ proposalCount }} Eigene Vorschläge</td>
-      <td class="ratings" data-ng-if="rateCount">{{ rateCount }} Anhänger</td>
-    </tr>
-  </tbody>
-</table>
+<div class="user-activity-overview">
+  <div class="wrapper">
+    <div class="comments" data-ng-if="commentCount">{{ commentCount }} Beiträge</div>
+    <div class="proposals" data-ng-if="proposalCount">{{ proposalCount }} Eigene Vorschläge</div>
+    <div class="ratings" data-ng-if="rateCount">{{ rateCount }} Anhänger</div>
+  </div>
+</div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserActivityOverview.html
@@ -1,7 +1,7 @@
 <div class="user-activity-overview">
   <div class="wrapper">
-    <div class="comments" data-ng-if="commentCount">{{ commentCount }} Beiträge</div>
-    <div class="proposals" data-ng-if="proposalCount">{{ proposalCount }} Eigene Vorschläge</div>
-    <div class="ratings" data-ng-if="rateCount">{{ rateCount }} Anhänger</div>
+    <div class="comments" data-ng-if="commentCount">{{ commentCount }} {{ "TR__COMMENTS" | translate}}</div>
+    <div class="proposals" data-ng-if="proposalCount">{{ proposalCount }} {{ "TR__PROPOSALS" | translate }}</div>
+    <div class="ratings" data-ng-if="rateCount">{{ rateCount }} {{ "TR__RATES" | translate}}</div>
   </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -616,14 +616,16 @@ export var adhUserActivityOverviewDirective = (
             };
             params[SIMetadata.nick + ":creator"] = scope.path;
 
-            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RICommentVersion.content_type }, params))
-                .then((pool) => { scope.commentCount = pool.data[SIPool.nick].count; });
+            var requestCountInto = (contentType, scopeTarget, shouldRequest) => {
+                if (shouldRequest === "true") {
+                    adhHttp.get(adhConfig.rest_url, _.assign({ content_type: contentType.content_type }, params))
+                        .then((pool) => { scope[scopeTarget] = pool.data[SIPool.nick].count; });
+                }
+            };
 
-            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RIProposalVersion.content_type }, params))
-                .then((pool) => { scope.proposalCount = pool.data[SIPool.nick].count; });
-
-            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RIRateVersion.content_type }, params))
-                .then((pool) => { scope.rateCount = pool.data[SIPool.nick].count; });
+            requestCountInto(RICommentVersion, "commentCount", attrs.showComments);
+            requestCountInto(RIProposalVersion, "proposalCount", attrs.showProposals);
+            requestCountInto(RIRateVersion, "rateCount", attrs.showRatings);
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -9,8 +9,13 @@ import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhCredentials from "./Credentials";
 import * as AdhUser from "./User";
 
+import RICommentVersion from "../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
+import RIProposalVersion from "../../Resources_/adhocracy_core/resources/proposal/IProposalVersion";
+import RIRateVersion from "../../Resources_/adhocracy_core/resources/rate/IRateVersion";
 import RIUser from "../../Resources_/adhocracy_core/resources/principal/IUser";
 import RIUsersService from "../../Resources_/adhocracy_core/resources/principal/IUsersService";
+import * as SIMetadata from "../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
+import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SIUserBasic from "../../Resources_/adhocracy_core/sheets/principal/IUserBasic";
 
 var pkgLocation = "/User";
@@ -590,6 +595,38 @@ export var adhUserManagementHeaderDirective = (
     };
 };
 
+
+export var adhUserActivityOverviewDirective = (
+    adhConfig: AdhConfig.IService,
+    adhHttp: AdhHttp.Service<any>
+) => {
+    return {
+        restrict: "E",
+        scope: {
+            path: "@"
+        },
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/UserActivityOverview.html",
+        link: (scope, element, attrs) => {
+            // TODO attrs should determine which request to make
+            var params = {
+                depth: "all",
+                tag: "LAST",
+                count: true,
+                elements: false
+            };
+            params[SIMetadata.nick + ":creator"] = scope.path;
+
+            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RICommentVersion.content_type }, params))
+                .then((pool) => { scope.commentCount = pool.data[SIPool.nick].count; });
+
+            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RIProposalVersion.content_type }, params))
+                .then((pool) => { scope.proposalCount = pool.data[SIPool.nick].count; });
+
+            adhHttp.get(adhConfig.rest_url, _.assign({ content_type: RIRateVersion.content_type }, params))
+                .then((pool) => { scope.rateCount = pool.data[SIPool.nick].count; });
+        }
+    };
+};
 
 export var registerRoutes = (
     context : string = ""

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -595,7 +595,17 @@ export var adhUserManagementHeaderDirective = (
     };
 };
 
-
+/**
+ * Usage:
+ *
+ *   <adh-user-activity-overview
+ *       data-show-comments="true"
+ *       data-show-proposals="true"
+ *       data-show-ratings="true"
+ *       data-path="{{userUrl}}"
+ *   >
+ *   </adh-user-activity-overview>
+ */
 export var adhUserActivityOverviewDirective = (
     adhConfig: AdhConfig.IService,
     adhHttp: AdhHttp.Service<any>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -607,6 +607,8 @@ export var adhUserActivityOverviewDirective = (
         },
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserActivityOverview.html",
         link: (scope, element, attrs) => {
+            if (typeof scope.path === "undefined") { return; }
+
             var requestCountInto = (contentType, scopeTarget, shouldRequest) => {
                 // REFACT consider to just check that the tag is set instead of requiring it to be set to true
                 if (shouldRequest !== "true") { return; }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -9,9 +9,9 @@ import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhCredentials from "./Credentials";
 import * as AdhUser from "./User";
 
-import RICommentVersion from "../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
-import RIProposalVersion from "../../Resources_/adhocracy_core/resources/proposal/IProposalVersion";
-import RIRateVersion from "../../Resources_/adhocracy_core/resources/rate/IRateVersion";
+import RIComment from "../../Resources_/adhocracy_core/resources/comment/IComment";
+import RIProposal from "../../Resources_/adhocracy_core/resources/proposal/IProposal";
+import RIRate from "../../Resources_/adhocracy_core/resources/rate/IRate";
 import RIUser from "../../Resources_/adhocracy_core/resources/principal/IUser";
 import RIUsersService from "../../Resources_/adhocracy_core/resources/principal/IUsersService";
 import * as SIMetadata from "../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
@@ -607,25 +607,25 @@ export var adhUserActivityOverviewDirective = (
         },
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserActivityOverview.html",
         link: (scope, element, attrs) => {
-            // TODO attrs should determine which request to make
-            var params = {
-                depth: "all",
-                tag: "LAST",
-                count: true,
-                elements: false
-            };
-            params[SIMetadata.nick + ":creator"] = scope.path;
-
             var requestCountInto = (contentType, scopeTarget, shouldRequest) => {
-                if (shouldRequest === "true") {
-                    adhHttp.get(adhConfig.rest_url, _.assign({ content_type: contentType.content_type }, params))
-                        .then((pool) => { scope[scopeTarget] = pool.data[SIPool.nick].count; });
-                }
+                // REFACT consider to just check that the tag is set instead of requiring it to be set to true
+                if (shouldRequest !== "true") { return; }
+
+                var params = {
+                    depth: "all",
+                    count: true,
+                    elements: false,
+                    content_type: contentType.content_type
+                };
+                params[SIMetadata.nick + ":creator"] = scope.path;
+
+                adhHttp.get(adhConfig.rest_url, params)
+                    .then((pool) => { scope[scopeTarget] = pool.data[SIPool.nick].count; });
             };
 
-            requestCountInto(RICommentVersion, "commentCount", attrs.showComments);
-            requestCountInto(RIProposalVersion, "proposalCount", attrs.showProposals);
-            requestCountInto(RIRateVersion, "rateCount", attrs.showRatings);
+            requestCountInto(RIComment, "commentCount", attrs.showComments);
+            requestCountInto(RIProposal, "proposalCount", attrs.showProposals);
+            requestCountInto(RIRate, "rateCount", attrs.showRatings);
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -108,5 +108,6 @@ export var register = (angular) => {
         .directive("adhUserMessage", ["adhConfig", "adhHttp", AdhUserViews.userMessageDirective])
         .directive("adhUserDetailColumn", ["adhPermissions", "adhConfig", AdhUserViews.userDetailColumnDirective])
         .directive("adhUserListingColumn", ["adhConfig", AdhUserViews.userListingColumnDirective])
-        .directive("adhUserManagementHeader", ["adhConfig", AdhUserViews.adhUserManagementHeaderDirective]);
+        .directive("adhUserManagementHeader", ["adhConfig", AdhUserViews.adhUserManagementHeaderDirective])
+        .directive("adhUserActivityOverview", ["adhConfig", "adhHttp", AdhUserViews.adhUserActivityOverviewDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_profile.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_profile.scss
@@ -57,3 +57,16 @@
         }
     }
 }
+
+.user-activity-overview {
+    width: 100%;
+    border-top: 1px solid LightGray;
+    border-bottom: 1px solid LightGray;
+    
+    // td directives ordered this way to ensure rendering with
+    // less than three items will remove them in the order middle, last, first
+    td { text-align: center; }
+    td:last-child { text-align: right; }
+    td:first-child { text-align: left; }
+    
+}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_profile.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_profile.scss
@@ -59,14 +59,27 @@
 }
 
 .user-activity-overview {
+    @include box-sizing(border-box);
     width: 100%;
-    border-top: 1px solid LightGray;
-    border-bottom: 1px solid LightGray;
-    
-    // td directives ordered this way to ensure rendering with
-    // less than three items will remove them in the order middle, last, first
-    td { text-align: center; }
-    td:last-child { text-align: right; }
-    td:first-child { text-align: left; }
-    
+    padding-left: 12px; // is there a variable for this width? --MH
+    padding-right: 12px;
+
+    .wrapper {
+        display: table;
+        width: 100%;
+
+        border-top: 1px solid $color-structure-normal;
+        border-bottom: 1px solid $color-structure-normal;
+        color: $color-brand-one-normal;
+
+        // directives ordered this way to ensure rendering with
+        // less than three items will remove them in the order: middle, last, first
+        > div { 
+            display: table-cell;
+            text-align: center;
+        }
+        
+        > div:last-child { text-align: right; }
+        > div:first-child { text-align: left; }
+    }
 }


### PR DESCRIPTION
This is foremost for s1 - but as it is general enough to go into core proper it's built in core.

It can be used in the UserDetailColumn.html like this:

```patch
@@ -17,6 +17,12 @@
     <adh-recompile-on-change
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
+        <adh-user-activity-overview
+         data-show-comments="true"
+         data-show-proposals="true"
+         data-show-ratings="true"
+        >
+        </adh-user-activity-overview>
         <adh-user-profile
             data-path="{{userUrl}}">
             <section class="s1-user-profile-proposal-list">
```

Does this work for you or do you require some further changes?

Many thanks,
Martin