### PR TITLE
Fix silent failing on duplicate users in DB

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -300,8 +300,12 @@ class UserLocatorAdapter(object):
         query = search_query._replace(indexes={index_name: value},
                                       resolve=True)
         users = catalogs.search(query).elements
-        if len(users) == 1:
+        users_count = len(users)
+        if users_count == 1:
             return users[0]
+        elif users_count > 1:
+            raise ValueError('{} users are indexed by `{}` with value `{}`.'
+                             .format(users_count, index_name, value))
 
     def get_groupids(self, userid: str) -> [str]:
         """Get :term:`groupid`s for term:`userid` or return None."""

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -1,12 +1,12 @@
 """Tests for the principal package."""
-import unittest
-from unittest.mock import Mock
-
 from pyramid import testing
 from pytest import fixture
-from pytest import mark
-from pytest import mark
 from pytest import fixture
+from pytest import mark
+from pytest import mark
+from unittest.mock import Mock
+import pytest
+import unittest
 
 
 @fixture
@@ -360,6 +360,15 @@ class TestUserLocatorAdapter:
             indexes={'private_user_email': 'test@test.de'},
             resolve=True,
         )
+
+    def test_get_user_by_email_two_identical_user_exists(self, inst, mock_catalogs,
+                                                         search_result, query):
+        user = testing.DummyResource()
+        user2 = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user, user2])
+        with pytest.raises(ValueError):
+            inst.get_user_by_email('test@test.de')
 
     def test_get_user_by_email_user_not_exists(self, inst, mock_catalogs):
         assert inst.get_user_by_email('wrong@test.de') is None


### PR DESCRIPTION
Raises an error if by mistake duplicate users exists in the DB. This
should prevent some failures if we forgot to reindex the user catalogs
before migration the old databases.