### PR TITLE
send runtime statistics to statsd server

### DIFF
--- a/docs/architecture/backend_structure.rst
+++ b/docs/architecture/backend_structure.rst
@@ -150,6 +150,7 @@ Modules API and separation of responsibility
     adhocracy_core.events
     adhocracy_core.schema
     adhocracy_core.exceptions
+    adhocracy_core.stats
 
 .. rubric:: Other stuff
 

--- a/etc/development.ini.in
+++ b/etc/development.ini.in
@@ -27,6 +27,13 @@ substanced.initial_email = admin@example.com
 substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
 substanced.autosync_catalogs = true
 substanced.autoevolve = false
+
+# send runtime statistics to statsd
+#substanced.statsd.enabled = true
+#substanced.statsd.host = localhost
+#substanced.statsd.port = 8125
+#substanced.statsd.prefix = a3
+
 adhocracy.ws_url = ws://localhost:6561
 # Set to false to use the SMTP server instead
 adhocracy.use_mail_queue = true
@@ -59,6 +66,7 @@ adhocracy.frontend_url = http://localhost:6551/static/embed.html#!
 adhocracy_core.caching.http.mode = without_proxy_cache
 # backend behind varnish
 #adhocracy_core.caching.http.mode = with_proxy_cache
+
 
 mail.queue_path = %(here)s/../var/mail
 # Configure the following fields for sending mails via SMTP

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -115,6 +115,7 @@ def includeme(config):
     config.include('.workflows')
     config.include('.websockets')
     config.include('.rest')
+    config.include('.stats')
     if settings.get('adhocracy.add_test_users', False):
         from adhocracy_core.testing import add_create_test_users_subscriber
         add_create_test_users_subscriber(config)

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -6,6 +6,7 @@ from pyramid.traversal import find_resource
 from pyramid.request import Request
 from pyramid.i18n import TranslationStringFactory
 from substanced.util import find_service
+from substanced.stats import statsd_incr
 from zope.interface import Attribute
 from zope.interface import Interface
 from zope.interface import implementer
@@ -125,6 +126,7 @@ class User(Pool):
         sheet = get_sheet(self, IMetadata)
         appstruct = sheet.get()
         appstruct['hidden'] = not active
+        statsd_incr('useractivated', 1)
         sheet.set(appstruct)
 
 
@@ -227,6 +229,7 @@ class PasswordReset(Base):
         if not user.active:  # pragma: no cover
             user.activate()
         del self.__parent__[self.__name__]
+        statsd_incr('pwordresetreseted', 1)
 
 
 passwordreset_meta = resource_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -386,7 +386,7 @@ class TestResourceRESTView:
         from adhocracy_core.rest.views import RESTView
         inst = self.make_one(context, request_)
         assert isinstance(inst, RESTView)
-        assert inst.registry is request_.registry.content
+        assert inst.content is request_.registry.content
 
     def test_create_method_get_and_resource_blocked(self, request_, context):
         from pyramid.httpexceptions import HTTPGone

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -25,6 +25,12 @@ substanced.uploads_tempdir = %(here)s/../var/uploads_tmp
 substanced.autosync_catalogs = true
 substanced.autoevolve = true
 
+# send runtime statistics to statsd
+#substanced.statsd.enabled = true
+#substanced.statsd.host = localhost
+#substanced.statsd.port = 8125
+#substanced.statsd.prefix = a3
+
 # The websocket url to notify about resource modifications
 adhocracy.ws_url = ws://localhost:6561
 # The login name for the initial user

--- a/src/adhocracy_core/adhocracy_core/stats/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/stats/__init__.py
@@ -1,0 +1,6 @@
+"""Send runtime statistics to `statsd <http://statsd.readthedocs.org>`."""
+
+
+def includeme(config):
+    """Add statsd client."""
+    config.include('substanced.stats')

--- a/src/adhocracy_core/adhocracy_core/stats/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/stats/__init__.py
@@ -4,3 +4,4 @@
 def includeme(config):
     """Add statsd client."""
     config.include('substanced.stats')
+    config.include('.subscriber')

--- a/src/adhocracy_core/adhocracy_core/stats/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/stats/subscriber.py
@@ -1,0 +1,53 @@
+"""Send counter runtime statistics to statsd server."""
+from functools import partial
+from pyramid.events import ApplicationCreated
+from pyramid.events import NewRequest
+from pyramid.threadlocal import get_current_registry
+from substanced.stats import statsd_incr
+from adhocracy_core.resources.principal import IPasswordReset
+from adhocracy_core.resources.principal import IUser
+from adhocracy_core.interfaces import IResourceCreatedAndAdded
+
+
+def incr_event_metric(name: str, rate: float, event: object):
+    """Increment statsd metric `name`.
+
+    :param `name`: the metric name send to the stats server
+    :param `rate`: sample rate (>=0 and <= 1) to reduce the number of values
+    :param `event`: object with optional `registry` attribute to retrieve the
+                    pyramid registry.
+
+    """
+    registry = getattr(event, 'registry', None)
+    if registry is None:
+        registry = get_current_registry()
+    statsd_incr(name, value=1, rate=rate, registry=registry)
+
+incr_started = partial(incr_event_metric, 'started', 1)
+incr_resource_created = partial(incr_event_metric, 'resourcecreated', .05)
+incr_pwordreset_created = partial(incr_event_metric, 'pwordresetcreated', 1)
+incr_user_created = partial(incr_event_metric, 'usercreated', 1)
+
+
+def incr_requests(event):
+    """Increment statsd metrics to count requests."""
+    method = event.request.method.lower()
+    path = event.request.path
+    name = 'requests' + method
+    if path == '/batch':
+        name += 'batch'
+    incr_event_metric(name, .1, event)
+
+
+def includeme(config):
+    """Include subscriber to send runtime statistics."""
+    config.add_subscriber(incr_started, ApplicationCreated)
+    config.add_subscriber(incr_requests, NewRequest)
+    config.add_subscriber(incr_resource_created,
+                          IResourceCreatedAndAdded)
+    config.add_subscriber(incr_pwordreset_created,
+                          IResourceCreatedAndAdded,
+                          object_iface=IPasswordReset)
+    config.add_subscriber(incr_user_created,
+                          IResourceCreatedAndAdded,
+                          object_iface=IUser)

--- a/src/adhocracy_core/adhocracy_core/stats/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/stats/test_init.py
@@ -1,0 +1,6 @@
+def test_add_statsd_client_to_registry_if_runtim_statitics_enabled(config):
+    from statsd.client import StatsClient
+    config.registry.settings['substanced.statsd.enabled'] = True
+    config.include('adhocracy_core.stats')
+    client = config.registry['statsd_client']
+    assert isinstance(client, StatsClient)

--- a/src/adhocracy_core/adhocracy_core/stats/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/stats/test_init.py
@@ -1,3 +1,7 @@
+from py.test import mark
+
+
+@mark.usefixtures('integration')
 def test_add_statsd_client_to_registry_if_runtim_statitics_enabled(config):
     from statsd.client import StatsClient
     config.registry.settings['substanced.statsd.enabled'] = True

--- a/src/adhocracy_core/adhocracy_core/stats/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/stats/test_subscriber.py
@@ -1,0 +1,63 @@
+#from unittest.mock import patch
+from mock import patch
+from pytest import mark
+from pytest import fixture
+from pyramid import testing
+
+
+@fixture
+def mock_statsd_incr(mock):
+    return mock.patch('adhocracy_core.stats.subscriber.statsd_incr')
+
+
+@fixture
+def event():
+    return testing.DummyResource()
+
+
+class TestIncrEventMetric:
+
+    def call_fut(self, *args):
+        from .subscriber import incr_event_metric
+        return incr_event_metric(*args)
+
+    def test_increment_metric(self, mock_statsd_incr, event):
+        self.call_fut('metricname', 1.0, event)
+        assert mock_statsd_incr.call_args[0][0] == 'metricname'
+        assert mock_statsd_incr.call_args[1]['value'] == 1
+        assert mock_statsd_incr.call_args[1]['rate'] == 1.0
+
+    def test_add_threadlocal_registry(self, mock_statsd_incr, event, registry):
+        self.call_fut('metricname', 1.0, event)
+        assert mock_statsd_incr.call_args[1]['registry'] == registry
+
+    def test_add_event_registry_if_given(self, mock_statsd_incr, event):
+        event.registry = object()
+        self.call_fut('metricname', 1.0, event)
+        assert mock_statsd_incr.call_args[1]['registry'] == event.registry
+
+
+def test_incr_requests_metrics_http_methods(request_, mock_statsd_incr, event):
+    from .subscriber import incr_requests
+    request_.method = 'POST'
+    event.request = request_
+    incr_requests(event)
+    mock_statsd_incr.assert_called_with('requestspost', value=1, rate=0.1,
+                                        registry=request_.registry)
+
+def test_incr_requests_metric_post_batch(request_, mock_statsd_incr, event):
+    from .subscriber import incr_requests
+    request_.method = 'POST'
+    request_.path = '/batch'
+    event.request = request_
+    incr_requests(event)
+    mock_statsd_incr.assert_called_with('requestspostbatch', value=1, rate=0.1,
+                                        registry=request_.registry)
+
+
+@mark.usefixtures('integration')
+def test_register_subscriber(config, registry):
+    from . import subscriber
+    config.include(subscriber)
+    handlers = [x.handler.__name__ for x in registry.registeredHandlers()]
+    assert subscriber.incr_requests.__name__ in handlers

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -37,6 +37,7 @@ test_requires = [
     'webtest',
     'pytest-pyramid',
     'pytest-timeout',
+    'pytest-mock',
     'coverage',
     'python-coveralls',
     'babel',


### PR DESCRIPTION
New config options:

substanced.statsd.enabled = true
sbstanced.statsd.host = localhost
substanced.statsd.port = 8125
substanced.statsd.prefix = a3

Runtime statistic metrics:

gauge

-  check_password
- catalog.queue_length (for deffered indexing)

counter 

-  zodb.loads (objects loaded from database)
-  zodb.stores (objects stored in database)
- started (application start)
- resourcecreated
- usercreated
- useractivated
- pwordcreated
- pwordreseted
- requestspost
- requestpostbatch
- requestget
- requestoptions
- requestput
- requesthead

timer
- authenticateuser
- authenticategroups (find user groups)
- authorization (check permissions except search with permision filter)
- validate (validate request body or query parameter)
- procoessgetwithoutquery (process get request without query
parameters)
- procoessgetwithquery (process get request with query parameters)
- proceesgetmetaapi
- processoption
- processhead
- processput
- processpost (post a resource (no proposal/rate versions)
- processpostrateversion
- processpostproposalversion
-  folder.get (time to find child resource)
-  folder.add (time ot add child resource)
-  catalog.query (time to search resources in one catalog index)
-  catalog.index_resoure
-  catalog.reindex_resoure
- catalog.unindex_resoure