### PR TITLE
Fix: version.py only adds annotated tags

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/version.py
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_core/version.py
+++ b/src/adhocracy_core/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/version.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_frontend/version.py
+++ b/src/adhocracy_frontend/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_kit/version.py
+++ b/src/adhocracy_kit/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_meinberlin/version.py
+++ b/src/adhocracy_meinberlin/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_mercator/version.py
+++ b/src/adhocracy_mercator/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_pcompass/version.py
+++ b/src/adhocracy_pcompass/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_s1/version.py
+++ b/src/adhocracy_s1/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/adhocracy_spd/version.py
+++ b/src/adhocracy_spd/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/euth/version.py
+++ b/src/euth/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/meinberlin/version.py
+++ b/src/meinberlin/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/mercator/version.py
+++ b/src/mercator/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/pcompass/version.py
+++ b/src/pcompass/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/s1/version.py
+++ b/src/s1/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/src/spd/version.py
+++ b/src/spd/version.py
@@ -37,7 +37,7 @@ from subprocess import Popen, PIPE
 def call_git_describe(abbrev=4):
     """Call git describe to get the current version number."""
     try:
-        p = Popen(['git', 'describe', '--abbrev=%d' % abbrev],
+        p = Popen(['git', 'describe', '--tags', '--abbrev=%d' % abbrev],
                   stdout=PIPE, stderr=PIPE)
         p.stderr.close()
         line = p.stdout.readlines()[0]


### PR DESCRIPTION
Its confusing that you have to add an annotated tag in order to make a new release version.
This pull request changes version.py to also work with non annonated tags.